### PR TITLE
[DRAFT] Add support for noncoherent integrations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,11 @@ FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 GNSSSignals = "52c80523-2a4e-5c38-8979-05588f836870"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 DocStringExtensions = "0.6, 0.7, 0.8, 0.9"
 FFTW = "1.0"
-GNSSSignals = "0.15, 0.16"
+GNSSSignals = "0.15, 0.16, 0.17"
 LoopVectorization = "0.12"
 RecipesBase = "1.0"
 Unitful = "0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.1.1"
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 GNSSSignals = "52c80523-2a4e-5c38-8979-05588f836870"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 GNSSSignals = "52c80523-2a4e-5c38-8979-05588f836870"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"

--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -20,7 +20,9 @@ export acquire,
     CoarseFineAcquisitionPlan,
     noncoherent_integrate,
     noncoherent_integrate_manual_timeshift,
-    noncoherent_integrate_manual_timeshift_dopplers
+    noncoherent_integrate_manual_timeshift_dopplers,
+    noncoherent_integrate!,
+    preallocate_thread_local_buffer
 
 struct AcquisitionResults{S<:AbstractGNSS,T}
     system::S

--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -12,7 +12,9 @@ export acquire,
     acquire!,
     AcquisitionPlan,
     CoarseFineAcquisitionPlan,
-    noncoherent_integrate
+    noncoherent_integrate,
+    noncoherent_integrate_manual_timeshift,
+    noncoherent_integrate_manual_timeshift_dopplers
 
 struct AcquisitionResults{S<:AbstractGNSS,T}
     system::S
@@ -37,4 +39,15 @@ include("plot.jl")
 include("calc_powers.jl")
 include("est_signal_noise_power.jl")
 include("acquire.jl")
+
+function _precompile_()
+    Base.precompile(Tuple{typeof(Core.kwcall),Core.NamedTuple{(:max_doppler, :coarse_step, :fine_step, :prns, :fft_flag), Tuple{Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}}, Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}}, Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}}, Base.UnitRange{Core.Int64}, Core.UInt32}},Type{CoarseFineAcquisitionPlan},GPSL1{Matrix{Int16}},Int64,Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}}})   # time: 0.34097806
+    isdefined(Acquisition, Symbol("#27#28")) && Base.precompile(Tuple{getfield(Acquisition, Symbol("#27#28")),Vector{ComplexF32},Matrix{Float32},Matrix{ComplexF32}})   # time: 0.16505001
+    isdefined(Acquisition, Symbol("#35#37")) && Base.precompile(Tuple{getfield(Acquisition, Symbol("#35#37")),Matrix{Float32},Matrix{ComplexF32},Int64})   # time: 0.10682159
+    isdefined(Acquisition, Symbol("#35#37")) && Base.precompile(Tuple{getfield(Acquisition, Symbol("#35#37")),Any,Any,Any})   # time: 0.040406585
+    Base.precompile(Tuple{typeof(est_signal_noise_power),Matrix{Float32},Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}},Unitful.Quantity{Core.Int64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}},Nothing})   # time: 0.016112743
+    Base.precompile(Tuple{typeof(est_signal_noise_power),Matrix{Float32},Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}},Unitful.Quantity{Core.Int64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}},Float32})   # time: 0.002283945
+end
+
+ 
 end

--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -65,14 +65,29 @@ include("calc_powers.jl")
 include("est_signal_noise_power.jl")
 include("acquire.jl")
 
-function _precompile_()
-    Base.precompile(Tuple{typeof(Core.kwcall),Core.NamedTuple{(:max_doppler, :coarse_step, :fine_step, :prns, :fft_flag), Tuple{Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}}, Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}}, Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}}, Base.UnitRange{Core.Int64}, Core.UInt32}},Type{CoarseFineAcquisitionPlan},GPSL1{Matrix{Int16}},Int64,Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}}})   # time: 0.34097806
-    isdefined(Acquisition, Symbol("#27#28")) && Base.precompile(Tuple{getfield(Acquisition, Symbol("#27#28")),Vector{ComplexF32},Matrix{Float32},Matrix{ComplexF32}})   # time: 0.16505001
-    isdefined(Acquisition, Symbol("#35#37")) && Base.precompile(Tuple{getfield(Acquisition, Symbol("#35#37")),Matrix{Float32},Matrix{ComplexF32},Int64})   # time: 0.10682159
-    isdefined(Acquisition, Symbol("#35#37")) && Base.precompile(Tuple{getfield(Acquisition, Symbol("#35#37")),Any,Any,Any})   # time: 0.040406585
-    Base.precompile(Tuple{typeof(est_signal_noise_power),Matrix{Float32},Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}},Unitful.Quantity{Core.Int64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}},Nothing})   # time: 0.016112743
-    Base.precompile(Tuple{typeof(est_signal_noise_power),Matrix{Float32},Unitful.Quantity{Core.Float64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}},Unitful.Quantity{Core.Int64, 𝐓^-1, Unitful.FreeUnits{(Hz,), 𝐓^-1, nothing}},Float32})   # time: 0.002283945
+
+@setup_workload begin
+    # Putting some things in `@setup_workload` instead of `@compile_workload` can reduce the size of the
+    # precompile file and potentially make loading faster.
+    rate = 2.048e6 
+
+    data_ci8 = rand(Complex{Int8},Int(round(rate*0.01)))
+    data_ci16 = rand(Complex{Int16},Int(round(rate*0.01)))
+    data_cf32 = rand(Complex{Float32},Int(round(rate*0.01)))
+    data_cf64 = rand(Complex{Float64},Int(round(rate*0.01)))
+
+    @compile_workload begin
+        # all calls in this block will be precompiled, regardless of whether
+        # they belong to your package or not (on Julia 1.8 and higher)
+        samplerate = rate*Hz
+        coarse_fine_acquire(GPSL1(),data_ci8[1:2048], samplerate, 1:32; interm_freq=0*Hz, max_doppler=40e3*Hz);
+        coarse_fine_acquire(GPSL1(),data_ci16[1:2048], samplerate, 1:32; interm_freq=0*Hz, max_doppler=40e3*Hz);
+        coarse_fine_acquire(GPSL1(),data_cf32[1:2048], samplerate, 1:32; interm_freq=0*Hz, max_doppler=40e3*Hz);
+        coarse_fine_acquire(GPSL1(),data_cf64[1:2048], samplerate, 1:32; interm_freq=0*Hz, max_doppler=40e3*Hz);
+
+    end
 end
+
 
  
 end

--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -1,9 +1,15 @@
 module Acquisition
 
 using DocStringExtensions,
-    GNSSSignals, RecipesBase, FFTW, Statistics, LinearAlgebra, LoopVectorization, Unitful, FLoops
+    GNSSSignals, RecipesBase, FFTW, Statistics, LinearAlgebra, LoopVectorization, Unitful
 
 import Unitful: s, Hz
+
+using PrecompileTools
+
+using ThreadsX
+
+using PrettyTables
 
 export acquire,
     plot_acquisition_results,

--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -1,7 +1,7 @@
 module Acquisition
 
 using DocStringExtensions,
-    GNSSSignals, RecipesBase, FFTW, Statistics, LinearAlgebra, LoopVectorization, Unitful
+    GNSSSignals, RecipesBase, FFTW, Statistics, LinearAlgebra, LoopVectorization, Unitful, FLoops
 
 import Unitful: s, Hz
 
@@ -11,7 +11,8 @@ export acquire,
     coarse_fine_acquire!,
     acquire!,
     AcquisitionPlan,
-    CoarseFineAcquisitionPlan
+    CoarseFineAcquisitionPlan,
+    noncoherent_integrate
 
 struct AcquisitionResults{S<:AbstractGNSS,T}
     system::S
@@ -22,6 +23,7 @@ struct AcquisitionResults{S<:AbstractGNSS,T}
     CN0::Float64
     noise_power::T
     power_bins::Matrix{T}
+    complex_signal::Matrix{Complex{T}}
     dopplers::StepRangeLen{
         Float64,
         Base.TwicePrecision{Float64},

--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -39,6 +39,25 @@ struct AcquisitionResults{S<:AbstractGNSS,T}
     }
 end
 
+function Base.show(io::IO, ::MIME"text/plain", acq_channels::Vector{Acquisition.AcquisitionResults{T1,T2}}) where {T1,T2}
+    header = ["PRN"; "CN0"; "Carrier doppler (Hz)"; "Code phase (samples)"]
+    data = Matrix{Any}(undef, length(acq_channels),length(header))
+
+    for (idx,acq) in enumerate(acq_channels)
+        data[idx,1] = acq.prn
+        data[idx,2] = acq.CN0
+        data[idx,3] = acq.carrier_doppler
+        data[idx,4] = acq.code_phase
+    end
+    hl_good = Highlighter((data,i,j)->(j==2) &&(data[i,j] > 42),crayon"green")
+    hl_bad = Highlighter((data,i,j)->(j==2) &&(data[i,j] < 42),crayon"red")
+    
+    pretty_table(io,data,header=header,highlighters=(hl_good,hl_bad))
+end
+
+
+
+
 include("plan_acquire.jl")
 include("downconvert.jl")
 include("plot.jl")

--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -24,7 +24,7 @@ export acquire,
     noncoherent_integrate!,
     preallocate_thread_local_buffer
 
-struct AcquisitionResults{S<:AbstractGNSS,T}
+struct AcquisitionResults{S<:AbstractGNSS,T,T2<:StepRangeLen}
     system::S
     prn::Int
     sampling_frequency::typeof(1.0Hz)
@@ -34,14 +34,27 @@ struct AcquisitionResults{S<:AbstractGNSS,T}
     noise_power::T
     power_bins::Matrix{T}
     complex_signal::Matrix{Complex{T}}
-    dopplers::StepRangeLen{
-        Float64,
-        Base.TwicePrecision{Float64},
-        Base.TwicePrecision{Float64},
-    }
+    dopplers::T2
 end
 
-function Base.show(io::IO, ::MIME"text/plain", acq_channels::Vector{Acquisition.AcquisitionResults{T1,T2}}) where {T1,T2}
+function AcquisitionResults(system, prn, sampling_frequency, carrier_doppler, code_phase, CN0, noise_power, power_bins::Matrix{T}, dopplers) where T
+
+    AcquisitionResults(
+        system,
+        prn,
+        uconvert(Hz, sampling_frequency),
+        uconvert(Hz, carrier_doppler),
+        code_phase,
+        CN0, 
+        noise_power,
+        power_bins,
+        similar(power_bins, Complex{T}),
+        dopplers
+    )
+end
+
+
+function Base.show(io::IO, ::MIME"text/plain", acq_channels::Vector{Acquisition.AcquisitionResults{T1,T2,T3}}) where {T1,T2,T3}
     header = ["PRN"; "CN0"; "Carrier doppler (Hz)"; "Code phase (samples)"]
     data = Matrix{Any}(undef, length(acq_channels),length(header))
 

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -100,6 +100,29 @@ function acquire!(
     end
 end
 
+
+function acquire_mt!(
+    acq_plan::AcquisitionPlan,
+    signal,
+    prns::AbstractVector{<:Integer};
+    interm_freq = 0.0Hz,
+    doppler_offset = 0.0Hz,
+    noise_power = nothing,
+)
+    all(map(prn -> prn in acq_plan.avail_prn_channels, prns)) ||
+        throw(ArgumentError("You'll need to plan every PRN"))
+    code_period = get_code_length(acq_plan.system) / get_code_frequency(acq_plan.system)
+
+    signal_baseband_buffer, signal_baseband_freq_domain_buffer = preallocate_thread_local_buffer(acq_plan.signal_length, length(acq_plan.dopplers))
+    #println(prns)
+
+    powers_per_sats = power_over_dopplers_code_mt!(acq_plan,signal,prns,interm_freq,signal_baseband_buffer,signal_baseband_freq_domain_buffer)
+    return powers_per_sats
+end
+
+
+
+
 function acquire!(
     acq_plan::AcquisitionPlan,
     signal,

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -13,22 +13,25 @@ function acquire(
     prns::AbstractVector{<:Integer};
     interm_freq = 0.0Hz,
     max_doppler = 7000Hz,
-    dopplers = -max_doppler:1/3/(length(signal)/sampling_freq):max_doppler,
-    compensate_doppler_code = false
+    dopplers = -max_doppler:1/3/(0.001s):max_doppler,
+    noncoherent_rounds = 1,
+    compensate_doppler_code = :positive,
+    coherent_integration_length_samples=4096
 )
     acq_plan = AcquisitionPlan(
         system,
-        length(signal),
+        coherent_integration_length_samples,
         sampling_freq;
         dopplers,
         prns,
         fft_flag = FFTW.ESTIMATE,
-        compensate_doppler_code = compensate_doppler_code
+        compensate_doppler_code = compensate_doppler_code,
+        noncoherent_rounds= noncoherent_rounds
     )
     acquire!(acq_plan, signal, prns; interm_freq)
 end
 
-function acquire(
+#= function acquire(
     system::AbstractGNSS,
     signal,
     sampling_freq,
@@ -49,10 +52,10 @@ function acquire(
         compensate_doppler_code = compensate_doppler_code
     )
     acquire!(acq_plan, signal, prns,time_shift_amt; interm_freq)
-end
+end =#
 
 
-"""
+#= """
 $(SIGNATURES)
 This acquisition function uses a predefined acquisition plan to accelerate the computing time.
 This will be useful, if you have to calculate the acquisition multiple time in a row.
@@ -98,8 +101,91 @@ function acquire!(
             (acq_plan.dopplers .+ doppler_offset) / 1.0Hz,
         )
     end
-end
+end  =#
 
+"""
+$(SIGNATURES)
+This acquisition function uses a predefined acquisition plan to accelerate the computing time.
+This will be useful, if you have to calculate the acquisition multiple time in a row.
+"""
+function acquire!(
+    acq_plan::AcquisitionPlan,
+    signal,
+    prns::AbstractVector{<:Integer};
+    interm_freq = 0.0Hz,
+    doppler_offset = 0.0Hz,
+    noise_power = nothing,    
+)
+    all(map(prn -> prn in acq_plan.avail_prn_channels, prns)) ||
+        throw(ArgumentError("You'll need to plan every PRN"))
+    code_period = get_code_length(acq_plan.system) / get_code_frequency(acq_plan.system)
+
+
+#=     powers_per_sats, complex_sigs_per_sats =
+        power_over_doppler_and_codes!(acq_plan, signal, prns, interm_freq, doppler_offset) =#
+
+    #Currently we parallelize over doppler taps 
+    #It might be faster if we parallelize over PRNs
+
+    #preallocate noncoherent integration workbuffer
+    # we want a 3d array with dimensions of (1ms signal * doppler taps * prns)
+    plan = acq_plan
+    powers_per_sats = [zeros(Float32,plan.signal_length,length(plan.dopplers)) for _ in eachindex(prns)]
+    intermediate_freq = interm_freq
+    center_frequency = 0.0Hz
+    noncoherent_rounds = plan.noncoherent_rounds
+    compensate_doppler_code = plan.compensate_doppler_code
+    for (noncoherent_power_buffer_idx, prn) in enumerate(prns)
+        noncoherent_power_accumulator_buffer = powers_per_sats[noncoherent_power_buffer_idx]
+        for (chunk,round_idx) in zip(Iterators.partition(signal[1:(noncoherent_rounds*plan.signal_length)],plan.signal_length), 0:noncoherent_rounds-1)
+            acq = acquire_mt!(plan,chunk, [prn]; interm_freq=(intermediate_freq+center_frequency))
+            #power_bin_ncoh3 += acq.power_bins
+              #for each dopplers compensate for code drift
+              #for idx1 in 1:length(plan.dopplers)
+              for (acc,power_doppler,dop) in zip(eachcol(noncoherent_power_accumulator_buffer),eachcol(acq[1]),plan.dopplers)
+                  #CM-ABS algo 3 step 6 eqn 7
+                  doppler1 = ustrip(dop)
+                  if compensate_doppler_code == :negative
+                      Ns = sign(ustrip(doppler1) - ustrip(center_frequency)) * round(round_idx*0.001* ustrip(plan.sampling_freq) * abs(ustrip(doppler1) - ustrip(center_frequency))/ustrip(get_center_frequency(plan.system)), RoundNearest)
+                      acc .= acc .+ circshift(power_doppler,-Ns)
+                  elseif compensate_doppler_code == :positive
+                      Ns = sign(ustrip(doppler1) - ustrip(center_frequency)) * round(round_idx*0.001* ustrip(plan.sampling_freq) * abs(ustrip(doppler1) - ustrip(center_frequency))/ustrip(get_center_frequency(plan.system)), RoundNearest)
+                      acc .= acc .+ circshift(power_doppler,Ns)
+                  else
+                      acc .= acc .+ power_doppler
+                  end
+              end
+        end
+    end
+
+    map(powers_per_sats, prns) do powers, prn
+        signal_power, noise_power, code_index, doppler_index = est_signal_noise_power(
+            powers,
+            acq_plan.sampling_freq,
+            get_code_frequency(acq_plan.system), 
+            noise_power,
+        )
+        CN0 = 10 * log10(signal_power / noise_power / code_period / 1.0Hz)
+        doppler =
+            (doppler_index - 1) * step(acq_plan.dopplers) +
+            first(acq_plan.dopplers) +
+            doppler_offset
+        code_phase =
+            (code_index - 1) /
+            (acq_plan.sampling_freq / get_code_frequency(acq_plan.system))
+        AcquisitionResults(
+            acq_plan.system,
+            prn,
+            acq_plan.sampling_freq,
+            doppler,
+            code_phase,
+            CN0,
+            noise_power,
+            powers,
+            (acq_plan.dopplers .+ doppler_offset) / 1.0Hz,
+        )
+    end 
+end
 
 function acquire_mt!(
     acq_plan::AcquisitionPlan,
@@ -121,9 +207,7 @@ function acquire_mt!(
 end
 
 
-
-
-function acquire!(
+#= function acquire!(
     acq_plan::AcquisitionPlan,
     signal,
     prns::AbstractVector{<:Integer},
@@ -165,62 +249,7 @@ function acquire!(
             (acq_plan.dopplers .+ doppler_offset) / 1.0Hz,
         )
     end
-  end
-
-#= function noncoherent_integrate(fp, prn, noncoherent_rounds; intermediate_freq=0, max_doppler=20000.0, compensate_doppler_code=true, time_shift_amt=0)
-    rate = fp.samplerate
-    samples_1ms = Int(round(rate * 0.001))
-    @floop for (chunk,samplestep) in zip(Iterators.partition(fp[1:(noncoherent_rounds*samples_1ms)],samples_1ms), Iterators.partition(0:noncoherent_rounds-1, 1))
-      time_shift_amt2 = time_shift_amt
-      acq = acquire(GPSL1(),chunk, rate*Hz, [prn],time_shift_amt2; interm_freq=intermediate_freq*Hz, max_doppler=max_doppler*Hz, compensate_doppler_code=compensate_doppler_code)
-      @reduce(power_bin_ncoh3 += acq[1].power_bins)
-      #println(size(acq[1].power_bins))
-    end
-    return power_bin_ncoh3  
-  end
-
-  function noncoherent_integrate(fp::Vector{ComplexF64}, prn, noncoherent_rounds, rate; intermediate_freq=0, max_doppler=20000.0, compensate_doppler_code=true, time_shift_amt=0)
-    samples_1ms = Int(round(rate * 0.001))
-    @floop for (chunk,samplestep) in zip(Iterators.partition(fp[1:(noncoherent_rounds*samples_1ms)],samples_1ms), Iterators.partition(0:noncoherent_rounds-1, 1))
-      time_shift_amt2 = time_shift_amt
-      acq = acquire(GPSL1(),chunk, rate*Hz, [prn],time_shift_amt2; interm_freq=intermediate_freq*Hz, max_doppler=max_doppler*Hz, compensate_doppler_code=compensate_doppler_code)
-      @reduce(power_bin_ncoh3 += acq[1].power_bins)
-      #println(size(acq[1].power_bins))
-    end
-    return power_bin_ncoh3  
-  end
-
-
-function noncoherent_integrate_manual_timeshift_dopplers(fp, prn, noncoherent_rounds, doppler_steps; intermediate_freq=0, compensate_doppler_code=true, time_shift_amt=0)
-    rate = fp.samplerate
-    samples_1ms = Int(round(rate * 0.001))
-    println("trig")
-    @floop for (chunk,samplestep) in zip(Iterators.partition(fp[1:(noncoherent_rounds*samples_1ms)],samples_1ms), Iterators.partition(0:noncoherent_rounds*samples_1ms-1,samples_1ms))
-        acq = acquire(GPSL1(),chunk, rate*Hz, [prn],time_shift_amt; interm_freq=intermediate_freq*Hz, dopplers=doppler_steps, compensate_doppler_code=compensate_doppler_code)
-        @reduce(power_bin_ncoh3 += acq[1].power_bins)
-        #println(size(acq[1].power_bins))
-    end
-    return power_bin_ncoh3 
-end
-
-
-
-function noncoherent_integrate(fp, prn, noncoherent_rounds, doppler_steps; intermediate_freq=0, compensate_doppler_code=true)
-    rate = fp.samplerate
-  
-    samples_1ms = Int(round(rate * 0.001))
-  
-    @floop for (chunk,samplestep) in zip(Iterators.partition(fp[1:(noncoherent_rounds*samples_1ms)],samples_1ms), Iterators.partition(0:noncoherent_rounds-1, 1))
-      #time_shift_amt2_without_doppler = -(3274/rate)*samplestep[1] * rate /1575.42e6
-      time_shift_amt2_without_doppler = -0.001*samplestep[1] * rate /1575.42e6
-      #println(time_shift_amt2_without_doppler *-419.4809160305349 )
-      acq = acquire(GPSL1(),chunk, rate*Hz, [prn],time_shift_amt2_without_doppler; interm_freq=intermediate_freq*Hz, dopplers=doppler_steps, compensate_doppler_code=compensate_doppler_code)
-      @reduce(power_bin_ncoh3 += acq[1].power_bins)
-      #println(size(acq[1].power_bins))
-    end
-    return power_bin_ncoh3  
-  end
- =#
+  end =#
 
 
   function noncoherent_integrate!(fp, prn, noncoherent_rounds, center_frequency, plan::AcquisitionPlan; intermediate_freq=0, compensate_doppler_code=false)
@@ -253,33 +282,6 @@ function noncoherent_integrate(fp, prn, noncoherent_rounds, doppler_steps; inter
     end
     return power_bin_ncoh3  
   end
-
-#=   function noncoherent_integrate!(fp, prn::Vector{Int}, noncoherent_rounds, center_frequency, plan::AcquisitionPlan; intermediate_freq=0, compensate_doppler_code=true)
-    rate = ustrip(plan.sampling_freq)
-  
-    samples_1ms = Int(round(rate * 0.001))
-    power_bin_ncoh3 = zeros(Float32,plan.signal_length,length(plan.dopplers))
-    for (chunk,round_idx) in zip(Iterators.partition(fp[1:(noncoherent_rounds*samples_1ms)],samples_1ms), 0:noncoherent_rounds-1)
-      acq = acquire_mt!(plan,chunk, [prn]; interm_freq=(intermediate_freq+center_frequency)*Hz)
-      #power_bin_ncoh3 += acq.power_bins
-        #for each dopplers compensate for code drift
-        #for idx1 in 1:length(plan.dopplers)
-        for (acc,power_doppler,dop) in zip(eachcol(power_bin_ncoh3),eachcol(acq[1]),plan.dopplers)
-            #CM-ABS algo 3 step 6 eqn 7
-            #doppler1 = ustrip(plan.dopplers[idx1])
-            doppler1 = ustrip(dop)
-            Ns = sign(doppler1 - center_frequency) * round(round_idx*0.001* ustrip(plan.sampling_freq) * abs(doppler1 - center_frequency)/ustrip(get_center_frequency(plan.system)), RoundFromZero)
-            if doppler1 ≈ 0
-                println(Ns)
-            end
-            #println(Ns)
-            #power_bin_ncoh3[:,idx1] = power_bin_ncoh3[:,idx1] .+ circshift(acq.power_bins[:,idx1],Ns)
-            acc .= acc .+ circshift(power_doppler,Ns)
-        end
-
-    end
-    return power_bin_ncoh3  
-  end =#
 
 function acquire!(
     acq_plan::CoarseFineAcquisitionPlan,

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -318,8 +318,9 @@ function acquire(
     interm_freq = 0.0Hz,
     max_doppler = 7000Hz,
     dopplers = -max_doppler:1/3/(length(signal)/sampling_freq):max_doppler,
+    noncoherent_rounds=1
 )
-    only(acquire(system, signal, sampling_freq, [prn]; interm_freq, dopplers))
+    only(acquire(system, signal, sampling_freq, [prn]; interm_freq, dopplers, noncoherent_rounds))
 end
 
 function acquire!(

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -33,78 +33,6 @@ function acquire(
     acquire!(acq_plan, signal, prns; interm_freq)
 end
 
-#= function acquire(
-    system::AbstractGNSS,
-    signal,
-    sampling_freq,
-    prns::AbstractVector{<:Integer},
-    time_shift_amt;
-    interm_freq = 0.0Hz,
-    max_doppler = 7000Hz,
-    dopplers = -max_doppler:1/3/(length(signal)/sampling_freq):max_doppler,
-    compensate_doppler_code = false
-)
-    acq_plan = AcquisitionPlan(
-        system,
-        length(signal),
-        sampling_freq;
-        dopplers,
-        prns,
-        fft_flag = FFTW.ESTIMATE,
-        compensate_doppler_code = compensate_doppler_code
-    )
-    acquire!(acq_plan, signal, prns,time_shift_amt; interm_freq)
-end =#
-
-
-#= """
-$(SIGNATURES)
-This acquisition function uses a predefined acquisition plan to accelerate the computing time.
-This will be useful, if you have to calculate the acquisition multiple time in a row.
-"""
-function acquire!(
-    acq_plan::AcquisitionPlan,
-    signal,
-    prns::AbstractVector{<:Integer};
-    interm_freq = 0.0Hz,
-    doppler_offset = 0.0Hz,
-    noise_power = nothing,
-)
-    all(map(prn -> prn in acq_plan.avail_prn_channels, prns)) ||
-        throw(ArgumentError("You'll need to plan every PRN"))
-    code_period = get_code_length(acq_plan.system) / get_code_frequency(acq_plan.system)
-    powers_per_sats, complex_sigs_per_sats =
-        power_over_doppler_and_codes!(acq_plan, signal, prns, interm_freq, doppler_offset)
-    map(powers_per_sats, complex_sigs_per_sats, prns) do powers, complex_sig, prn
-        signal_power, noise_power, code_index, doppler_index = est_signal_noise_power(
-            powers,
-            acq_plan.sampling_freq,
-            get_code_frequency(acq_plan.system), 
-            noise_power,
-        )
-        CN0 = 10 * log10(signal_power / noise_power / code_period / 1.0Hz)
-        doppler =
-            (doppler_index - 1) * step(acq_plan.dopplers) +
-            first(acq_plan.dopplers) +
-            doppler_offset
-        code_phase =
-            (code_index - 1) /
-            (acq_plan.sampling_freq / get_code_frequency(acq_plan.system))
-        AcquisitionResults(
-            acq_plan.system,
-            prn,
-            acq_plan.sampling_freq,
-            doppler,
-            code_phase,
-            CN0,
-            noise_power,
-            powers,
-            complex_sig,
-            (acq_plan.dopplers .+ doppler_offset) / 1.0Hz,
-        )
-    end
-end  =#
-
 """
 $(SIGNATURES)
 This acquisition function uses a predefined acquisition plan to accelerate the computing time.
@@ -141,9 +69,7 @@ function acquire!(
         noncoherent_power_accumulator_buffer = powers_per_sats[noncoherent_power_buffer_idx]
         for (chunk,round_idx) in zip(Iterators.partition(signal[1:(noncoherent_rounds*plan.signal_length)],plan.signal_length), 0:noncoherent_rounds-1)
             acq = acquire_mt!(plan,chunk, [prn]; interm_freq=(intermediate_freq+center_frequency))
-            #power_bin_ncoh3 += acq.power_bins
               #for each dopplers compensate for code drift
-              #for idx1 in 1:length(plan.dopplers)
               for (acc,power_doppler,dop) in zip(eachcol(noncoherent_power_accumulator_buffer),eachcol(acq[1]),plan.dopplers)
                   #CM-ABS algo 3 step 6 eqn 7
                   doppler1 = ustrip(dop)
@@ -207,83 +133,6 @@ function acquire_mt!(
     powers_per_sats = power_over_dopplers_code_mt!(acq_plan,signal,prns,interm_freq,signal_baseband_buffer,signal_baseband_freq_domain_buffer)
     return powers_per_sats
 end
-
-
-#= function acquire!(
-    acq_plan::AcquisitionPlan,
-    signal,
-    prns::AbstractVector{<:Integer},
-    time_shift_amt;
-    interm_freq = 0.0Hz,
-    doppler_offset = 0.0Hz,
-    noise_power = nothing,
-)
-    all(map(prn -> prn in acq_plan.avail_prn_channels, prns)) ||
-        throw(ArgumentError("You'll need to plan every PRN"))
-    code_period = get_code_length(acq_plan.system) / get_code_frequency(acq_plan.system)
-    powers_per_sats, complex_sigs_per_sats =
-        power_over_doppler_and_codes!(acq_plan, signal, prns, interm_freq, doppler_offset,time_shift_amt)
-    map(powers_per_sats, complex_sigs_per_sats, prns) do powers, complex_sig, prn
-        signal_power, noise_power, code_index, doppler_index = est_signal_noise_power(
-            powers,
-            acq_plan.sampling_freq,
-            get_code_frequency(acq_plan.system),
-            noise_power,
-        )
-        CN0 = 10 * log10(signal_power / noise_power / code_period / 1.0Hz)
-        doppler =
-            (doppler_index - 1) * step(acq_plan.dopplers) +
-            first(acq_plan.dopplers) +
-            doppler_offset
-        code_phase =
-            (code_index - 1) /
-            (acq_plan.sampling_freq / get_code_frequency(acq_plan.system))
-        AcquisitionResults(
-            acq_plan.system,
-            prn,
-            acq_plan.sampling_freq,
-            doppler,
-            code_phase,
-            CN0,
-            noise_power,
-            powers,
-            complex_sig,
-            (acq_plan.dopplers .+ doppler_offset) / 1.0Hz,
-        )
-    end
-  end =#
-
-
-  function noncoherent_integrate!(fp, prn, noncoherent_rounds, center_frequency, plan::AcquisitionPlan; intermediate_freq=0, compensate_doppler_code=false)
-    rate = ustrip(plan.sampling_freq)
-  
-    samples_1ms = Int(round(rate * 0.001))
-    power_bin_ncoh3 = zeros(Float32,plan.signal_length,length(plan.dopplers))
-    for (chunk,round_idx) in zip(Iterators.partition(fp[1:(noncoherent_rounds*plan.signal_length)],plan.signal_length), 0:noncoherent_rounds-1)
-      acq = acquire_mt!(plan,chunk, [prn]; interm_freq=(intermediate_freq+center_frequency)*Hz)
-      #power_bin_ncoh3 += acq.power_bins
-        #for each dopplers compensate for code drift
-        #for idx1 in 1:length(plan.dopplers)
-        for (acc,power_doppler,dop) in zip(eachcol(power_bin_ncoh3),eachcol(acq[1]),plan.dopplers)
-            #CM-ABS algo 3 step 6 eqn 7
-            #doppler1 = ustrip(plan.dopplers[idx1])
-            doppler1 = ustrip(dop)
-            if compensate_doppler_code == :negative
-                Ns = sign(doppler1 - center_frequency) * round(round_idx*0.001* ustrip(plan.sampling_freq) * abs(doppler1 - center_frequency)/ustrip(get_center_frequency(plan.system)), RoundNearest)
-                #power_bin_ncoh3[:,idx1] = power_bin_ncoh3[:,idx1] .+ circshift(acq.power_bins[:,idx1],Ns)
-                acc .= acc .+ circshift(power_doppler,-Ns)
-            elseif compensate_doppler_code == :positive
-                Ns = sign(doppler1 - center_frequency) * round(round_idx*0.001* ustrip(plan.sampling_freq) * abs(doppler1 - center_frequency)/ustrip(get_center_frequency(plan.system)), RoundNearest)
-                #power_bin_ncoh3[:,idx1] = power_bin_ncoh3[:,idx1] .+ circshift(acq.power_bins[:,idx1],Ns)
-                acc .= acc .+ circshift(power_doppler,Ns)
-            else
-                acc .= acc .+ power_doppler
-            end
-        end
-
-    end
-    return power_bin_ncoh3  
-  end
 
 function acquire!(
     acq_plan::CoarseFineAcquisitionPlan,

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -74,7 +74,7 @@ function acquire!(
         signal_power, noise_power, code_index, doppler_index = est_signal_noise_power(
             powers,
             acq_plan.sampling_freq,
-            get_code_frequency(acq_plan.system),
+            get_code_frequency(acq_plan.system), 
             noise_power,
         )
         CN0 = 10 * log10(signal_power / noise_power / code_period / 1.0Hz)
@@ -167,7 +167,7 @@ function acquire!(
     end
   end
 
-function noncoherent_integrate(fp, prn, noncoherent_rounds; intermediate_freq=0, max_doppler=20000.0, compensate_doppler_code=true, time_shift_amt=0)
+#= function noncoherent_integrate(fp, prn, noncoherent_rounds; intermediate_freq=0, max_doppler=20000.0, compensate_doppler_code=true, time_shift_amt=0)
     rate = fp.samplerate
     samples_1ms = Int(round(rate * 0.001))
     @floop for (chunk,samplestep) in zip(Iterators.partition(fp[1:(noncoherent_rounds*samples_1ms)],samples_1ms), Iterators.partition(0:noncoherent_rounds-1, 1))

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -16,8 +16,10 @@ function acquire(
     dopplers = -max_doppler:1/3/(0.001s):max_doppler,
     noncoherent_rounds = 1,
     compensate_doppler_code = :positive,
-    coherent_integration_length_samples=4096
+    coherent_integration_length=get_code_length(system)/get_code_frequency(system)
 )
+
+    coherent_integration_length_samples = Int(ceil(upreferred(coherent_integration_length * sampling_freq)))
     acq_plan = AcquisitionPlan(
         system,
         coherent_integration_length_samples,
@@ -317,10 +319,13 @@ function acquire(
     prn::Integer;
     interm_freq = 0.0Hz,
     max_doppler = 7000Hz,
-    dopplers = -max_doppler:1/3/(length(signal)/sampling_freq):max_doppler,
-    noncoherent_rounds=1
-)
-    only(acquire(system, signal, sampling_freq, [prn]; interm_freq, dopplers, noncoherent_rounds))
+    noncoherent_rounds=1,
+    coherent_integration_length=get_code_length(system)/get_code_frequency(system),
+    dopplers = -max_doppler:1/3/(coherent_integration_length):max_doppler
+    )
+
+    only(acquire(system, signal, sampling_freq, [prn]; interm_freq, dopplers, coherent_integration_length,noncoherent_rounds))
+
 end
 
 function acquire!(

--- a/src/calc_powers.jl
+++ b/src/calc_powers.jl
@@ -80,7 +80,7 @@ function power_over_code!(
             code_freq_domain .* conj.(signal_baseband_freq_domain)
         ldiv!(code_baseband, fft_plan, code_freq_baseband_freq_domain)
         signal_power[:, doppler_idx] .= abs2.(view(code_baseband, 1:size(signal_power, 1)))
-        complex_sig[:, doppler_idx] .= view(code_baseband, 1:size(signal_power, 1))
+        #complex_sig[:, doppler_idx] .= view(code_baseband, 1:size(signal_power, 1))
     end
 end
 
@@ -101,12 +101,11 @@ function power_over_code!(
     time_shift_amt,
     compensate_doppler_code
 )
-    downconvert!(signal_baseband, signal, interm_freq + doppler, sampling_freq,samplestep)
+    downconvert!(signal_baseband, signal, interm_freq + doppler, sampling_freq)
     mul!(signal_baseband_freq_domain, fft_plan, signal_baseband)
-    timestep = samplestep ./ Float32(ustrip(sampling_freq))
-    #println(time_shift_amt) 
-    doppler_correction = exp.(1im .* 2pi .* time_shift_amt .*Float32(ustrip(sampling_freq)) .* collect(0:(length(signal_baseband_freq_domain)-1)) .* (ustrip(doppler) / 1575.42e6))
-    #println(doppler_correction)
+    #timestep = samplestep ./ Float32(ustrip(sampling_freq))
+    doppler_correction = exp.(-1im .* 2pi .* time_shift_amt .* ustrip(doppler) ./ length(signal_baseband_freq_domain) .* collect(0:(length(signal_baseband_freq_domain)-1)))
+    #println(time_shift_amt)
     foreach(codes_freq_domain, signal_powers, complex_signal) do code_freq_domain, signal_power, complex_sig
         if compensate_doppler_code
             code_freq_baseband_freq_domain .=

--- a/src/calc_powers.jl
+++ b/src/calc_powers.jl
@@ -3,12 +3,42 @@ function power_over_doppler_and_codes!(
     signal,
     sat_prns,
     interm_freq,
-    doppler_offset,
+    doppler_offset;
 )
     prn_channels = findall(x -> x in sat_prns, acq_plan.avail_prn_channels)
     foreach(enumerate(acq_plan.dopplers)) do (doppler_idx, doppler)
         power_over_code!(
             view(acq_plan.signal_powers, prn_channels),
+            view(acq_plan.complex_signal, prn_channels),
+            doppler_idx,
+            acq_plan.signal_baseband,
+            acq_plan.signal_baseband_freq_domain,
+            acq_plan.code_freq_baseband_freq_domain,
+            acq_plan.code_baseband,
+            signal,
+            acq_plan.fft_plan,
+            view(acq_plan.codes_freq_domain, prn_channels),
+            doppler + doppler_offset,
+            acq_plan.sampling_freq,
+            interm_freq;
+        )
+    end
+    (view(acq_plan.signal_powers, prn_channels),view(acq_plan.complex_signal, prn_channels))
+end
+
+function power_over_doppler_and_codes!(
+    acq_plan::AcquisitionPlan,
+    signal,
+    sat_prns,
+    interm_freq,
+    doppler_offset,
+    time_shift_amt
+)
+    prn_channels = findall(x -> x in sat_prns, acq_plan.avail_prn_channels)
+    foreach(enumerate(acq_plan.dopplers)) do (doppler_idx, doppler)
+        power_over_code!(
+            view(acq_plan.signal_powers, prn_channels),
+            view(acq_plan.complex_signal, prn_channels),
             doppler_idx,
             acq_plan.signal_baseband,
             acq_plan.signal_baseband_freq_domain,
@@ -20,13 +50,17 @@ function power_over_doppler_and_codes!(
             doppler + doppler_offset,
             acq_plan.sampling_freq,
             interm_freq,
+            time_shift_amt,
+            acq_plan.compensate_doppler_code
         )
     end
-    view(acq_plan.signal_powers, prn_channels)
+    (view(acq_plan.signal_powers, prn_channels),view(acq_plan.complex_signal, prn_channels))
 end
+
 
 function power_over_code!(
     signal_powers,
+    complex_signal,
     doppler_idx,
     signal_baseband,
     signal_baseband_freq_domain,
@@ -41,10 +75,48 @@ function power_over_code!(
 )
     downconvert!(signal_baseband, signal, interm_freq + doppler, sampling_freq)
     mul!(signal_baseband_freq_domain, fft_plan, signal_baseband)
-    foreach(codes_freq_domain, signal_powers) do code_freq_domain, signal_power
+    foreach(codes_freq_domain, signal_powers, complex_signal) do code_freq_domain, signal_power, complex_sig
         code_freq_baseband_freq_domain .=
             code_freq_domain .* conj.(signal_baseband_freq_domain)
         ldiv!(code_baseband, fft_plan, code_freq_baseband_freq_domain)
         signal_power[:, doppler_idx] .= abs2.(view(code_baseband, 1:size(signal_power, 1)))
+        complex_sig[:, doppler_idx] .= view(code_baseband, 1:size(signal_power, 1))
+    end
+end
+
+function power_over_code!(
+    signal_powers,
+    complex_signal,
+    doppler_idx,
+    signal_baseband,
+    signal_baseband_freq_domain,
+    code_freq_baseband_freq_domain,
+    code_baseband,
+    signal,
+    fft_plan,
+    codes_freq_domain,
+    doppler,
+    sampling_freq,
+    interm_freq,
+    time_shift_amt,
+    compensate_doppler_code
+)
+    downconvert!(signal_baseband, signal, interm_freq + doppler, sampling_freq,samplestep)
+    mul!(signal_baseband_freq_domain, fft_plan, signal_baseband)
+    timestep = samplestep ./ Float32(ustrip(sampling_freq))
+    #println(time_shift_amt) 
+    doppler_correction = exp.(1im .* 2pi .* time_shift_amt .*Float32(ustrip(sampling_freq)) .* collect(0:(length(signal_baseband_freq_domain)-1)) .* (ustrip(doppler) / 1575.42e6))
+    #println(doppler_correction)
+    foreach(codes_freq_domain, signal_powers, complex_signal) do code_freq_domain, signal_power, complex_sig
+        if compensate_doppler_code
+            code_freq_baseband_freq_domain .=
+                code_freq_domain .* conj.(signal_baseband_freq_domain) .* doppler_correction
+        else
+            code_freq_baseband_freq_domain .=
+                code_freq_domain .* conj.(signal_baseband_freq_domain)
+        end
+        ldiv!(code_baseband, fft_plan, code_freq_baseband_freq_domain)
+        signal_power[:, doppler_idx] .= abs2.(view(code_baseband, 1:size(signal_power, 1)))
+        complex_sig[:, doppler_idx] .= view(code_baseband, 1:size(signal_power, 1))
     end
 end

--- a/src/downconvert.jl
+++ b/src/downconvert.jl
@@ -1,4 +1,4 @@
-function downconvert!(downconverted_signal, signal, frequency, sampling_freq)
+ #=function downconvert!(downconverted_signal, signal, frequency, sampling_freq)
     downconverted_signal .=
         signal .*
         cis.(
@@ -15,7 +15,7 @@ function downconvert!(downconverted_signal, signal, frequency, sampling_freq, sa
             Float32(sampling_freq)
         )
 end
-
+ =#
 
 function downconvert!(
     downconverted_signal::Vector{Complex{T}},

--- a/src/downconvert.jl
+++ b/src/downconvert.jl
@@ -7,6 +7,16 @@ function downconvert!(downconverted_signal, signal, frequency, sampling_freq)
         )
 end
 
+function downconvert!(downconverted_signal, signal, frequency, sampling_freq, samplestep)
+    downconverted_signal .=
+        signal .*
+        cis.(
+            Float32(-2π) .* samplestep .* Float32(frequency) ./
+            Float32(sampling_freq)
+        )
+end
+
+
 function downconvert!(
     downconverted_signal::Vector{Complex{T}},
     signal::AbstractVector{Complex{TS}},

--- a/src/downconvert.jl
+++ b/src/downconvert.jl
@@ -18,7 +18,7 @@ end
  =#
 
 function downconvert!(
-    downconverted_signal::Vector{Complex{T}},
+    downconverted_signal::AbstractVector{Complex{T}},
     signal::AbstractVector{Complex{TS}},
     frequency,
     sampling_freq,

--- a/src/downconvert.jl
+++ b/src/downconvert.jl
@@ -34,3 +34,21 @@ function downconvert!(
     end
     downconverted_signal
 end
+
+function downconvert!(
+    downconverted_signal::AbstractVector{Complex{T}},
+    signal::AbstractVector{TS},
+    frequency,
+    sampling_freq,
+) where {T,TS <: Real}
+    signal_real = reinterpret(reshape, TS, signal)
+    downconverted_signal_real = reinterpret(reshape, T, downconverted_signal)
+    @turbo for i = 1:length(signal)
+        c_im, c_re = sincos(T(2π) * (i - 1) * T(frequency / sampling_freq))
+        downconverted_signal_real[1, i] = signal[i] * c_re
+            #signal_real[1, i] * c_re + signal_real[2, i] * c_im
+        downconverted_signal_real[2, i] = signal[i] * c_im
+            #signal_real[2, i] * c_re - signal_real[1, i] * c_im
+    end
+    downconverted_signal
+end

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -171,3 +171,13 @@ function common_buffers(system, signal_length, sampling_freq, prns, fft_flag)
     codes_freq_domain,
     fft_plan
 end
+
+function preallocate_thread_local_buffer(signal_length,doppler_taps)
+    #todo: align buffers to fftw friendly offsets
+    signal_length = 16368
+    signal_baseband_buffer = Array{ComplexF32}(undef, signal_length,doppler_taps)
+    signal_baseband_freq_domain_buffer = similar(signal_baseband_buffer)
+
+    return signal_baseband_buffer,signal_baseband_freq_domain_buffer
+
+end


### PR DESCRIPTION
This pull request added support for noncoherent integration for `acquire` function.

Now `acquire` function have new keyword arguments:

- `noncoherent_integration_round` :  How many noncoherent integration rounds, default is 1
- `coherent_integration_length`: Length of single coherent integration in seconds. This is API breaking, previously coherent integration length is defined by the length of the samples passed into the function. I found it to be a bit unintuitive 
- `compensate_doppler_code`: Apply doppler compensation to try to compensate code drift caused by doppler effect, some reference on the code drift problem: https://enac.hal.science/hal-00937060/document. It can take these values: `:disabled`, `:positive`, which is the default, and `:negative`


This will close https://github.com/JuliaGNSS/Acquisition.jl/issues/10

Some code cleanup is still necessary before we can merge it with upstream