### PR TITLE
feat: allow to set minimum doppler and have a better default step

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,41 @@
+---
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v6
+        id: semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          RUNNER_DEBUG: 1
+        with:
+          branches: |
+            ['+([0-9])?(.{+([0-9]),x}).x', 'master', 'main', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]
+          extends: |
+            @ethima/semantic-release-configuration
+          extra_plugins: |
+            @ethima/semantic-release-configuration
+      - name: Notify JuliaRegistrator of new release
+        uses: peter-evans/commit-comment@v4
+        if: steps.semantic-release.outputs.new_release_published == 'true'
+        with:
+          sha: ${{ steps.semantic-release.outputs.new_release_git_head }}
+          body: |
+            @JuliaRegistrator register
+
+            Release notes:
+
+            ${{ steps.semantic-release.outputs.new_release_notes }}

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -2,9 +2,9 @@
 $(SIGNATURES)
 Perform the aquisition of multiple satellites with `prns` in system `system` with signal `signal`
 sampled at rate `sampling_freq`. Optional arguments are the intermediate frequency `interm_freq`
-(default 0Hz), the maximum expected Doppler `max_doppler` (default 7000Hz). If the maximum Doppler
-is too unspecific you can instead pass a Doppler range with with your individual step size using
-the argument `dopplers`.
+(default 0Hz), the minimum expected Doppler `min_doppler` (default -7000Hz), and maximum expected
+Doppler `max_doppler` (default 7000Hz). If the Doppler range is too unspecific you can instead
+pass a Doppler range with with your individual step size using the argument `dopplers`.
 """
 function acquire(
     system::AbstractGNSS,
@@ -13,7 +13,8 @@ function acquire(
     prns::AbstractVector{<:Integer};
     interm_freq = 0.0Hz,
     max_doppler = 7000Hz,
-    dopplers = -max_doppler:1/3/(length(signal)/sampling_freq):max_doppler,
+    min_doppler = -max_doppler,
+    dopplers = min_doppler:250Hz:max_doppler,
 )
     acq_plan = AcquisitionPlan(
         system,
@@ -96,9 +97,9 @@ end
 $(SIGNATURES)
 Perform the aquisition of a single satellite `prn` in system `system` with signal `signal`
 sampled at rate `sampling_freq`. Optional arguments are the intermediate frequency `interm_freq`
-(default 0Hz), the maximum expected Doppler `max_doppler` (default 7000Hz). If the maximum Doppler
-is too unspecific you can instead pass a Doppler range with with your individual step size using
-the argument `dopplers`.
+(default 0Hz), the minimum expected Doppler `min_doppler` (default -7000Hz), and maximum expected
+Doppler `max_doppler` (default 7000Hz). If the Doppler range is too unspecific you can instead
+pass a Doppler range with with your individual step size using the argument `dopplers`.
 """
 function acquire(
     system::AbstractGNSS,
@@ -107,7 +108,8 @@ function acquire(
     prn::Integer;
     interm_freq = 0.0Hz,
     max_doppler = 7000Hz,
-    dopplers = -max_doppler:1/3/(length(signal)/sampling_freq):max_doppler,
+    min_doppler = -max_doppler,
+    dopplers = min_doppler:250Hz:max_doppler,
 )
     only(acquire(system, signal, sampling_freq, [prn]; interm_freq, dopplers))
 end
@@ -145,14 +147,16 @@ function coarse_fine_acquire(
     prns::AbstractVector{<:Integer};
     interm_freq = 0.0Hz,
     max_doppler = 7000Hz,
-    coarse_step = 1 / 3 / (length(signal) / sampling_freq),
-    fine_step = 1 / 12 / (length(signal) / sampling_freq),
+    min_doppler = -max_doppler,
+    coarse_step = 250Hz,
+    fine_step = 25Hz,
 )
     acq_plan = CoarseFineAcquisitionPlan(
         system,
         length(signal),
         sampling_freq;
         max_doppler,
+        min_doppler,
         coarse_step,
         fine_step,
         prns,
@@ -174,8 +178,9 @@ function coarse_fine_acquire(
     prn::Integer;
     interm_freq = 0.0Hz,
     max_doppler = 7000Hz,
-    coarse_step = 1 / 3 / (length(signal) / sampling_freq),
-    fine_step = 1 / 12 / (length(signal) / sampling_freq),
+    min_doppler = -max_doppler,
+    coarse_step = 250Hz,
+    fine_step = 25Hz,
 )
     only(
         coarse_fine_acquire(
@@ -185,6 +190,7 @@ function coarse_fine_acquire(
             [prn];
             interm_freq,
             max_doppler,
+            min_doppler,
             coarse_step,
             fine_step,
         ),

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -18,7 +18,8 @@ function AcquisitionPlan(
     signal_length,
     sampling_freq;
     max_doppler = 7000Hz,
-    dopplers = -max_doppler:1/3/(signal_length/sampling_freq):max_doppler,
+    min_doppler = -max_doppler,
+    dopplers = min_doppler:250Hz:max_doppler,
     prns = 1:34,
     fft_flag = FFTW.MEASURE,
 )
@@ -63,12 +64,13 @@ function CoarseFineAcquisitionPlan(
     signal_length,
     sampling_freq;
     max_doppler = 7000Hz,
-    coarse_step = 1 / 3 / (signal_length / sampling_freq),
-    fine_step = 1 / 12 / (signal_length / sampling_freq),
+    min_doppler = -max_doppler,
+    coarse_step = 250Hz,
+    fine_step = 25Hz,
     prns = 1:34,
     fft_flag = FFTW.MEASURE,
 )
-    coarse_dopplers = -max_doppler:coarse_step:max_doppler
+    coarse_dopplers = min_doppler:coarse_step:max_doppler
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -34,7 +34,7 @@
     end
 
     max_doppler = 7000Hz
-    dopplers = -max_doppler:1/3/(length(signal)/sampling_freq):max_doppler
+    dopplers = -max_doppler:250Hz:max_doppler
 
     acq_res = acquire(system, signal_typed, sampling_freq, prn; interm_freq, dopplers)
 
@@ -70,4 +70,81 @@
     @test abs(inplace_inplace_acq_res.carrier_doppler - doppler) < step(dopplers) / 2
     @test inplace_inplace_acq_res.prn == prn
     @test inplace_inplace_acq_res.CN0 ≈ CN0 atol = 7
+end
+
+@testset "Acquire with asymmetric Doppler range" begin
+    Random.seed!(2345)
+    system = GPSL1()
+    num_samples = 60000
+    doppler = 1234Hz
+    code_phase = 110.613261
+    prn = 1
+    sampling_freq = 15e6Hz - 1Hz
+    interm_freq = 243.0Hz
+    CN0 = 45
+
+    code = gen_code(
+        num_samples,
+        system,
+        prn,
+        sampling_freq,
+        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
+        code_phase,
+    )
+
+    carrier =
+        cis.(2π * (0:num_samples-1) * (interm_freq + doppler) / sampling_freq .+ π / 8)
+
+    noise_power = 10 * log10(sampling_freq / 1.0Hz)
+    signal_power = CN0
+    noise = randn(ComplexF64, num_samples)
+    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    signal_typed = Complex{Float64}.(signal)
+
+    # Test asymmetric Doppler range: 0Hz to 7000Hz (positive only)
+    min_doppler = 0Hz
+    max_doppler = 7000Hz
+    dopplers = min_doppler:250Hz:max_doppler
+
+    # Test acquire with min_doppler
+    acq_res = acquire(system, signal_typed, sampling_freq, prn; interm_freq, min_doppler, max_doppler)
+
+    @test acq_res.code_phase ≈ code_phase atol = 0.08
+    @test abs(acq_res.carrier_doppler - doppler) < step(dopplers) / 2
+    @test acq_res.prn == prn
+    @test acq_res.CN0 ≈ CN0 atol = 7
+
+    # Test AcquisitionPlan with min_doppler
+    acq_plan = AcquisitionPlan(system, length(signal_typed), sampling_freq; min_doppler, max_doppler, prns = 1:34)
+
+    @test first(acq_plan.dopplers) ≈ min_doppler
+    @test last(acq_plan.dopplers) >= max_doppler - step(acq_plan.dopplers)
+
+    inplace_acq_res = acquire!(acq_plan, signal_typed, prn; interm_freq)
+
+    @test inplace_acq_res.code_phase ≈ code_phase atol = 0.08
+    @test abs(inplace_acq_res.carrier_doppler - doppler) < step(dopplers) / 2
+    @test inplace_acq_res.prn == prn
+    @test inplace_acq_res.CN0 ≈ CN0 atol = 7
+
+    # Test coarse_fine_acquire with min_doppler
+    coarse_fine_acq_res = coarse_fine_acquire(system, signal_typed, sampling_freq, prn; interm_freq, min_doppler, max_doppler)
+
+    @test coarse_fine_acq_res.code_phase ≈ code_phase atol = 0.08
+    @test abs(coarse_fine_acq_res.carrier_doppler - doppler) < step(dopplers) / 2
+    @test coarse_fine_acq_res.prn == prn
+    @test coarse_fine_acq_res.CN0 ≈ CN0 atol = 7
+
+    # Test CoarseFineAcquisitionPlan with min_doppler
+    coarse_fine_acq_plan = CoarseFineAcquisitionPlan(system, length(signal_typed), sampling_freq; min_doppler, max_doppler, prns = 1:34)
+
+    @test first(coarse_fine_acq_plan.coarse_plan.dopplers) ≈ min_doppler
+    @test last(coarse_fine_acq_plan.coarse_plan.dopplers) >= max_doppler - step(coarse_fine_acq_plan.coarse_plan.dopplers)
+
+    inplace_coarse_fine_acq_res = acquire!(coarse_fine_acq_plan, signal_typed, prn; interm_freq)
+
+    @test inplace_coarse_fine_acq_res.code_phase ≈ code_phase atol = 0.08
+    @test abs(inplace_coarse_fine_acq_res.carrier_doppler - doppler) < step(dopplers) / 2
+    @test inplace_coarse_fine_acq_res.prn == prn
+    @test inplace_coarse_fine_acq_res.CN0 ≈ CN0 atol = 7
 end

--- a/test/calc_powers.jl
+++ b/test/calc_powers.jl
@@ -90,7 +90,7 @@ end
     signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
 
     max_doppler = 7000Hz
-    dopplers = -max_doppler:1/3/(length(signal)/sampling_freq):max_doppler
+    dopplers = -max_doppler:250Hz:max_doppler
 
     acq_plan = AcquisitionPlan(system, length(signal), sampling_freq; dopplers, prns = 1:1)
 


### PR DESCRIPTION
Allow to set a minimum Doppler as in min_doppler:step:max_doppler. And set the default coarse step size to 250Hz and the default fine step size to 25Hz.