### PR TITLE
Add docs and remove some allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+docs/build/

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Acquisition"
 uuid = "d4bbf60b-102b-5ffb-8f97-a7ea5817e69f"
-authors = ["Soeren Schoenbrod <soeren.schoenbrod@nav.rwth-aachen.de>"]
 version = "0.2.1"
+authors = ["Soeren Schoenbrod <soeren.schoenbrod@nav.rwth-aachen.de>"]
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/Project.toml
+++ b/Project.toml
@@ -15,19 +15,24 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+Aqua = "0.8"
 DocStringExtensions = "0.6, 0.7, 0.8, 0.9"
 FFTW = "1.0"
 GNSSSignals = "0.17"
+LinearAlgebra = "1"
 LoopVectorization = "0.12"
 PrettyTables = "3"
+Random = "1"
 RecipesBase = "1.0"
 Statistics = "1"
+Test = "1"
 Unitful = "0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 1.0"
 julia = "1.10"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Aqua", "Test", "Random"]

--- a/README.md
+++ b/README.md
@@ -1,34 +1,42 @@
+# Acquisition.jl
+
 [![Tests](https://github.com/JuliaGNSS/Acquisition.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/JuliaGNSS/Acquisition.jl/actions)
 [![codecov](https://codecov.io/gh/JuliaGNSS/Acquisition.jl/branch/master/graph/badge.svg?token=GFRAHP6R3S)](https://codecov.io/gh/JuliaGNSS/Acquisition.jl)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaGNSS.github.io/Acquisition.jl/stable)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGNSS.github.io/Acquisition.jl/dev)
 
-# Acquisition.jl
-Acquire GNSS signals
+GNSS signal acquisition using parallel code phase search.
 
-## Getting started
+Part of the [JuliaGNSS](https://github.com/JuliaGNSS) ecosystem.
 
-Install:
+## Installation
+
 ```julia
-julia> ]
-pkg> add Acquisition
+using Pkg
+Pkg.add("Acquisition")
 ```
 
-## Usage
+## Quick Start
 
 ```julia
-using Acquisition, Plots
-import Acquisition: GPSL1, Hz
-stream = open("signal.dat")
-signal = Vector{Complex{Int16}}(undef, 10000)
-read!(stream, signal)
-gpsl1 = GPSL1()
-acq_res = acquire(gpsl1, signal, 5e6Hz, 1:32)
-# or acq_res = coarse_fine_acquire(gpsl1, signal, 5e6Hz, 1:32)
-plot(acq_res[1])
+using Acquisition, GNSSSignals
+
+# Acquire GPS L1 C/A signals
+results = acquire(GPSL1(), signal, 5e6Hz, 1:32)
+
+# Coarse-fine acquisition for better Doppler resolution
+results = coarse_fine_acquire(GPSL1(), signal, 5e6Hz, 1:32)
+
+# Plot results
+using Plots
+plot(results[1])
 ```
 
 ![Acquisition plot](media/acquisition_plot.png)
 
-The acquisition results include: `CN0`, `carrier_doppler`, `code_phase`, etc.
+## Documentation
+
+See the [documentation](https://JuliaGNSS.github.io/Acquisition.jl/stable) for detailed usage and API reference.
 
 ## License
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -9,6 +9,31 @@ num_samples = 20000
 
 const SUITE = BenchmarkGroup()
 
+# Check if eltype keyword is supported (added in later versions)
+const _supports_eltype = hasmethod(AcquisitionPlan,
+    Tuple{typeof(GPSL1()), Int, typeof(1.0Hz)},
+    (:prns, :fft_flag, :eltype))
+
+function _make_acq_plan(system, num_samples, sampling_freq, buffer_eltype)
+    if _supports_eltype
+        AcquisitionPlan(system, num_samples, sampling_freq;
+            prns = 1:1, fft_flag = FFTW.ESTIMATE, eltype = buffer_eltype)
+    else
+        AcquisitionPlan(system, num_samples, sampling_freq;
+            prns = 1:1, fft_flag = FFTW.ESTIMATE)
+    end
+end
+
+function _make_coarse_fine_plan(system, num_samples, sampling_freq, buffer_eltype)
+    if _supports_eltype
+        CoarseFineAcquisitionPlan(system, num_samples, sampling_freq;
+            prns = 1:1, fft_flag = FFTW.ESTIMATE, eltype = buffer_eltype)
+    else
+        CoarseFineAcquisitionPlan(system, num_samples, sampling_freq;
+            prns = 1:1, fft_flag = FFTW.ESTIMATE)
+    end
+end
+
 for type in [Float64, Float32, Int16, Int32]
     for system_type in [GPSL1, GalileoE1B]#[GPSL1, GPSL5, GalileoE1B]
         system = system_type()
@@ -19,22 +44,12 @@ for type in [Float64, Float32, Int16, Int32]
         else
             signal_typed = Complex{type}.(signal)
         end
-        acq_plan = AcquisitionPlan(
-            system,
-            num_samples,
-            sampling_freq;
-            prns = 1:1,
-            fft_flag = FFTW.ESTIMATE,
-        )
+        # Use matching eltype for floating point signals to avoid allocations
+        buffer_eltype = type <: AbstractFloat ? type : Float32
+        acq_plan = _make_acq_plan(system, num_samples, sampling_freq, buffer_eltype)
         SUITE["Acquire"][type][system_type] =
             @benchmarkable acquire!($acq_plan, $signal_typed, $(1:1))
-        coarse_fine_acq_plan = CoarseFineAcquisitionPlan(
-            system,
-            num_samples,
-            sampling_freq;
-            prns = 1:1,
-            fft_flag = FFTW.ESTIMATE,
-        )
+        coarse_fine_acq_plan = _make_coarse_fine_plan(system, num_samples, sampling_freq, buffer_eltype)
         SUITE["Coarse Fine Acquire"][type][system_type] =
             @benchmarkable acquire!($coarse_fine_acq_plan, $signal_typed, $(1:1))
     end

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Acquisition = "d4bbf60b-102b-5ffb-8f97-a7ea5817e69f"
+GNSSSignals = "52c80523-2a4e-5c38-8979-05588f836870"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,22 @@
+using Documenter
+using Acquisition
+
+makedocs(
+    sitename = "Acquisition.jl",
+    modules = [Acquisition],
+    authors = "Soeren Schoenbrod",
+    format = Documenter.HTML(
+        prettyurls = get(ENV, "CI", nothing) == "true",
+        canonical = "https://JuliaGNSS.github.io/Acquisition.jl",
+    ),
+    pages = [
+        "Home" => "index.md",
+        "Usage Guide" => "guide.md",
+        "API Reference" => "api.md",
+    ],
+)
+
+deploydocs(
+    repo = "github.com/JuliaGNSS/Acquisition.jl.git",
+    devbranch = "master",
+)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,23 @@
+# API Reference
+
+## Acquisition Functions
+
+```@docs
+acquire
+acquire!
+coarse_fine_acquire
+coarse_fine_acquire!
+```
+
+## Types
+
+```@docs
+AcquisitionResults
+AcquisitionPlan
+CoarseFineAcquisitionPlan
+```
+
+## Index
+
+```@index
+```

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -1,0 +1,106 @@
+# Usage Guide
+
+## Basic Acquisition
+
+The simplest way to acquire GNSS signals is with the [`acquire`](@ref) function:
+
+```julia
+using Acquisition, GNSSSignals
+
+# Acquire all GPS L1 C/A PRNs
+results = acquire(GPSL1(), signal, 5e6Hz, 1:32)
+
+# Acquire a single PRN
+result = acquire(GPSL1(), signal, 5e6Hz, 1)
+```
+
+Each result contains:
+- `carrier_doppler`: Estimated Doppler frequency
+- `code_phase`: Code phase in chips
+- `CN0`: Carrier-to-noise density ratio (dB-Hz)
+- `power_bins`: Correlation power matrix
+
+## Coarse-Fine Acquisition
+
+For better Doppler resolution without the computational cost of a high-resolution search, use [`coarse_fine_acquire`](@ref):
+
+```julia
+results = coarse_fine_acquire(GPSL1(), signal, 5e6Hz, 1:32;
+    coarse_step = 250Hz,  # Initial search step
+    fine_step = 25Hz      # Refined search step
+)
+```
+
+This performs an initial coarse search, then refines the Doppler estimate around detected peaks.
+
+## Custom Doppler Range
+
+Specify custom Doppler search bounds or a custom range:
+
+```julia
+# Custom bounds
+results = acquire(GPSL1(), signal, 5e6Hz, 1:32;
+    min_doppler = -5000Hz,
+    max_doppler = 5000Hz
+)
+
+# Custom range with specific step
+results = acquire(GPSL1(), signal, 5e6Hz, 1:32;
+    dopplers = -7000Hz:100Hz:7000Hz
+)
+```
+
+## Using Acquisition Plans
+
+For repeated acquisitions with the same parameters, pre-compute an acquisition plan to avoid redundant FFT planning and memory allocation:
+
+```julia
+# Create plan once
+plan = AcquisitionPlan(GPSL1(), 10000, 5e6Hz; prns=1:32)
+
+# Reuse for multiple signals
+for signal in signals
+    results = acquire!(plan, signal, 1:32)
+end
+```
+
+Similarly for coarse-fine acquisition:
+
+```julia
+plan = CoarseFineAcquisitionPlan(GPSL1(), 10000, 5e6Hz; prns=1:32)
+results = acquire!(plan, signal, 1:32)
+```
+
+## Plotting Results
+
+Acquisition results can be plotted directly with Plots.jl:
+
+```julia
+using Plots
+
+# 3D surface plot of correlation power
+plot(results[1])
+
+# Log scale (dB)
+plot(results[1], true)
+```
+
+## Interpreting Results
+
+A successful acquisition typically shows:
+- **CN0 > 35-40 dB-Hz**: Signal is likely present
+- Clear correlation peak in the power bins
+
+Print results in a table format:
+
+```julia
+julia> results
+┌─────┬─────────────┬─────────────────────┬────────────────────┐
+│ PRN │ CN0 (dBHz)  │ Carrier Doppler (Hz)│ Code phase (chips) │
+├─────┼─────────────┼─────────────────────┼────────────────────┤
+│   1 │      45.234 │             1250.0  │           234.567  │
+│   2 │      32.100 │             -500.0  │           891.234  │
+...
+```
+
+PRNs with CN0 > 42 dB-Hz are highlighted in green, others in red.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,47 @@
+# Acquisition.jl
+
+GNSS signal acquisition using parallel code phase search.
+
+Acquisition.jl is part of the [JuliaGNSS](https://github.com/JuliaGNSS) ecosystem and works with [GNSSSignals.jl](https://github.com/JuliaGNSS/GNSSSignals.jl) for signal definitions.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("Acquisition")
+```
+
+## Quick Start
+
+```julia
+using Acquisition, GNSSSignals
+
+# Load your signal data
+signal = # ... your complex baseband samples
+
+# Acquire GPS L1 C/A signals
+results = acquire(GPSL1(), signal, 5e6Hz, 1:32)
+
+# Or use coarse-fine acquisition for better Doppler resolution
+results = coarse_fine_acquire(GPSL1(), signal, 5e6Hz, 1:32)
+```
+
+## Features
+
+- **Parallel code phase search**: FFT-based correlation for fast acquisition
+- **Coarse-fine acquisition**: Two-stage search for improved Doppler resolution
+- **Pre-computed plans**: Reuse FFT plans and buffers for batch processing
+- **Plotting support**: Visualize acquisition results with Plots.jl
+
+## Background
+
+For an introduction to GNSS signal acquisition, see:
+- Kaplan & Hegarty, *Understanding GPS/GNSS: Principles and Applications*, Chapter 8
+- [GPS signal acquisition (navipedia.net)](https://gssc.esa.int/navipedia/index.php/Acquisition)
+
+## Contents
+
+```@contents
+Pages = ["guide.md", "api.md"]
+Depth = 2
+```

--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -7,13 +7,40 @@ import Unitful: s, Hz
 using PrettyTables: pretty_table, TextHighlighter, @crayon_str
 
 export acquire,
-    plot_acquisition_results,
     coarse_fine_acquire,
     coarse_fine_acquire!,
     acquire!,
     AcquisitionPlan,
-    CoarseFineAcquisitionPlan
+    CoarseFineAcquisitionPlan,
+    AcquisitionResults
 
+"""
+    AcquisitionResults{S,T}
+
+Results from GNSS signal acquisition for a single PRN.
+
+# Fields
+- `system::S`: GNSS system used for acquisition
+- `prn::Int`: PRN number of the satellite
+- `sampling_frequency`: Sampling frequency of the signal
+- `carrier_doppler`: Estimated carrier Doppler frequency
+- `code_phase::Float64`: Estimated code phase in chips
+- `CN0::Float64`: Carrier-to-noise density ratio in dB-Hz
+- `noise_power::T`: Estimated noise power
+- `power_bins::Matrix{T}`: Correlation power over code phase and Doppler (for plotting)
+- `dopplers`: Doppler frequencies searched
+
+# Plotting
+`AcquisitionResults` can be plotted directly using Plots.jl:
+```julia
+using Plots
+plot(result)  # 3D surface plot of correlation power
+plot(result, true)  # Use log scale (dB)
+```
+
+# See also
+[`acquire`](@ref), [`coarse_fine_acquire`](@ref)
+"""
 struct AcquisitionResults{S<:AbstractGNSS,T}
     system::S
     prn::Int

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -94,7 +94,7 @@ function acquire!(
     doppler_offset = 0.0Hz,
     noise_power = nothing,
 )
-    all(map(prn -> prn in acq_plan.avail_prn_channels, prns)) ||
+    all(prn -> prn in acq_plan.avail_prn_channels, prns) ||
         throw(ArgumentError("You'll need to plan every PRN"))
     code_period = get_code_length(acq_plan.system) / get_code_frequency(acq_plan.system)
     powers_per_sats =

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -1,10 +1,38 @@
 """
-$(SIGNATURES)
-Perform the aquisition of multiple satellites with `prns` in system `system` with signal `signal`
-sampled at rate `sampling_freq`. Optional arguments are the intermediate frequency `interm_freq`
-(default 0Hz), the minimum expected Doppler `min_doppler` (default -7000Hz), and maximum expected
-Doppler `max_doppler` (default 7000Hz). If the Doppler range is too unspecific you can instead
-pass a Doppler range with with your individual step size using the argument `dopplers`.
+    acquire(system, signal, sampling_freq, prns; kwargs...) -> Vector{AcquisitionResults}
+
+Perform parallel code phase search acquisition for multiple satellites.
+
+Searches for GNSS signals by correlating the input signal with locally generated
+replica codes across a grid of Doppler frequencies and code phases.
+
+# Arguments
+- `system`: GNSS system (e.g., `GPSL1()` from GNSSSignals.jl)
+- `signal`: Complex baseband signal samples
+- `sampling_freq`: Sampling frequency of the signal
+- `prns`: PRN numbers to search (e.g., `1:32`)
+
+# Keyword Arguments
+- `interm_freq`: Intermediate frequency (default: `0.0Hz`)
+- `max_doppler`: Maximum Doppler frequency (default: `7000Hz`)
+- `min_doppler`: Minimum Doppler frequency (default: `-max_doppler`)
+- `dopplers`: Custom Doppler search range (default: `min_doppler:250Hz:max_doppler`)
+
+# Returns
+Vector of [`AcquisitionResults`](@ref), one per PRN, containing:
+- `carrier_doppler`: Estimated Doppler frequency
+- `code_phase`: Estimated code phase in chips
+- `CN0`: Carrier-to-noise density ratio in dB-Hz
+- `power_bins`: Correlation power matrix for plotting
+
+# Example
+```julia
+using Acquisition, GNSSSignals
+results = acquire(GPSL1(), signal, 5e6Hz, 1:32)
+```
+
+# See also
+[`acquire!`](@ref), [`coarse_fine_acquire`](@ref), [`AcquisitionPlan`](@ref)
 """
 function acquire(
     system::AbstractGNSS,
@@ -28,9 +56,35 @@ function acquire(
 end
 
 """
-$(SIGNATURES)
-This acquisition function uses a predefined acquisition plan to accelerate the computing time.
-This will be useful, if you have to calculate the acquisition multiple time in a row.
+    acquire!(acq_plan, signal, prns; kwargs...) -> Vector{AcquisitionResults}
+
+Perform acquisition using a pre-computed [`AcquisitionPlan`](@ref).
+
+Using a pre-computed plan avoids repeated memory allocation and FFT planning,
+which significantly improves performance when acquiring multiple signals.
+
+# Arguments
+- `acq_plan`: Pre-computed [`AcquisitionPlan`](@ref)
+- `signal`: Complex baseband signal samples
+- `prns`: PRN numbers to search (must be subset of `acq_plan.avail_prn_channels`)
+
+# Keyword Arguments
+- `interm_freq`: Intermediate frequency (default: `0.0Hz`)
+- `doppler_offset`: Offset added to Doppler search range (default: `0.0Hz`)
+- `noise_power`: Pre-computed noise power, or `nothing` to estimate (default: `nothing`)
+
+# Returns
+Vector of [`AcquisitionResults`](@ref), one per PRN.
+
+# Example
+```julia
+using Acquisition, GNSSSignals
+plan = AcquisitionPlan(GPSL1(), 10000, 5e6Hz; prns=1:32)
+results = acquire!(plan, signal, 1:32)
+```
+
+# See also
+[`acquire`](@ref), [`AcquisitionPlan`](@ref)
 """
 function acquire!(
     acq_plan::AcquisitionPlan,
@@ -94,12 +148,35 @@ function acquire!(
 end
 
 """
-$(SIGNATURES)
-Perform the aquisition of a single satellite `prn` in system `system` with signal `signal`
-sampled at rate `sampling_freq`. Optional arguments are the intermediate frequency `interm_freq`
-(default 0Hz), the minimum expected Doppler `min_doppler` (default -7000Hz), and maximum expected
-Doppler `max_doppler` (default 7000Hz). If the Doppler range is too unspecific you can instead
-pass a Doppler range with with your individual step size using the argument `dopplers`.
+    acquire(system, signal, sampling_freq, prn::Integer; kwargs...) -> AcquisitionResults
+
+Perform acquisition for a single satellite PRN.
+
+Convenience method that calls the multi-PRN version and returns a single result.
+
+# Arguments
+- `system`: GNSS system (e.g., `GPSL1()`)
+- `signal`: Complex baseband signal samples
+- `sampling_freq`: Sampling frequency of the signal
+- `prn`: Single PRN number to search
+
+# Keyword Arguments
+- `interm_freq`: Intermediate frequency (default: `0.0Hz`)
+- `max_doppler`: Maximum Doppler frequency (default: `7000Hz`)
+- `min_doppler`: Minimum Doppler frequency (default: `-max_doppler`)
+- `dopplers`: Custom Doppler search range (default: `min_doppler:250Hz:max_doppler`)
+
+# Returns
+Single [`AcquisitionResults`](@ref) for the requested PRN.
+
+# Example
+```julia
+using Acquisition, GNSSSignals
+result = acquire(GPSL1(), signal, 5e6Hz, 1)
+```
+
+# See also
+[`acquire`](@ref), [`coarse_fine_acquire`](@ref)
 """
 function acquire(
     system::AbstractGNSS,
@@ -135,10 +212,38 @@ function acquire!(
 end
 
 """
-$(SIGNATURES)
-Performs a coarse aquisition and fine acquisition of multiple satellites `prns` in system `system` with signal `signal`
-sampled at rate `sampling_freq`. The aquisition is performed as parallel code phase
-search using the Doppler frequencies with coarse step size `coarse_step` and fine step size `fine_step`.
+    coarse_fine_acquire(system, signal, sampling_freq, prns; kwargs...) -> Vector{AcquisitionResults}
+
+Perform two-stage coarse-fine acquisition for multiple satellites.
+
+First performs a coarse search with large Doppler steps, then refines the estimate
+with a fine search around the detected Doppler. This approach provides high Doppler
+resolution while reducing computational cost compared to a single high-resolution search.
+
+# Arguments
+- `system`: GNSS system (e.g., `GPSL1()`)
+- `signal`: Complex baseband signal samples
+- `sampling_freq`: Sampling frequency of the signal
+- `prns`: PRN numbers to search (e.g., `1:32`)
+
+# Keyword Arguments
+- `interm_freq`: Intermediate frequency (default: `0.0Hz`)
+- `max_doppler`: Maximum Doppler frequency (default: `7000Hz`)
+- `min_doppler`: Minimum Doppler frequency (default: `-max_doppler`)
+- `coarse_step`: Doppler step for coarse search (default: `250Hz`)
+- `fine_step`: Doppler step for fine search (default: `25Hz`)
+
+# Returns
+Vector of [`AcquisitionResults`](@ref), one per PRN, with refined Doppler estimates.
+
+# Example
+```julia
+using Acquisition, GNSSSignals
+results = coarse_fine_acquire(GPSL1(), signal, 5e6Hz, 1:32)
+```
+
+# See also
+[`acquire`](@ref), [`coarse_fine_acquire!`](@ref), [`CoarseFineAcquisitionPlan`](@ref)
 """
 function coarse_fine_acquire(
     system::AbstractGNSS,
@@ -166,10 +271,36 @@ function coarse_fine_acquire(
 end
 
 """
-$(SIGNATURES)
-Performs a coarse aquisition and fine acquisition of a single satellite with PRN `prn` in system `system` with signal `signal`
-sampled at rate `sampling_freq`. The aquisition is performed as parallel code phase
-search using the Doppler frequencies with coarse step size `coarse_step` and fine step size `fine_step`.
+    coarse_fine_acquire(system, signal, sampling_freq, prn::Integer; kwargs...) -> AcquisitionResults
+
+Perform two-stage coarse-fine acquisition for a single satellite PRN.
+
+Convenience method that calls the multi-PRN version and returns a single result.
+
+# Arguments
+- `system`: GNSS system (e.g., `GPSL1()`)
+- `signal`: Complex baseband signal samples
+- `sampling_freq`: Sampling frequency of the signal
+- `prn`: Single PRN number to search
+
+# Keyword Arguments
+- `interm_freq`: Intermediate frequency (default: `0.0Hz`)
+- `max_doppler`: Maximum Doppler frequency (default: `7000Hz`)
+- `min_doppler`: Minimum Doppler frequency (default: `-max_doppler`)
+- `coarse_step`: Doppler step for coarse search (default: `250Hz`)
+- `fine_step`: Doppler step for fine search (default: `25Hz`)
+
+# Returns
+Single [`AcquisitionResults`](@ref) for the requested PRN.
+
+# Example
+```julia
+using Acquisition, GNSSSignals
+result = coarse_fine_acquire(GPSL1(), signal, 5e6Hz, 1)
+```
+
+# See also
+[`coarse_fine_acquire`](@ref), [`acquire`](@ref)
 """
 function coarse_fine_acquire(
     system::AbstractGNSS,
@@ -196,3 +327,33 @@ function coarse_fine_acquire(
         ),
     )
 end
+
+"""
+    coarse_fine_acquire!(acq_plan::CoarseFineAcquisitionPlan, signal, prns; kwargs...)
+
+Perform two-stage coarse-fine acquisition using a pre-computed plan.
+
+Alias for `acquire!(acq_plan::CoarseFineAcquisitionPlan, ...)`.
+
+# Arguments
+- `acq_plan`: Pre-computed [`CoarseFineAcquisitionPlan`](@ref)
+- `signal`: Complex baseband signal samples
+- `prns`: PRN numbers to search
+
+# Keyword Arguments
+- `interm_freq`: Intermediate frequency (default: `0.0Hz`)
+
+# Returns
+Vector of [`AcquisitionResults`](@ref), one per PRN.
+
+# Example
+```julia
+using Acquisition, GNSSSignals
+plan = CoarseFineAcquisitionPlan(GPSL1(), 10000, 5e6Hz; prns=1:32)
+results = coarse_fine_acquire!(plan, signal, 1:32)
+```
+
+# See also
+[`coarse_fine_acquire`](@ref), [`CoarseFineAcquisitionPlan`](@ref)
+"""
+const coarse_fine_acquire! = acquire!

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -1,3 +1,21 @@
+"""
+    AcquisitionPlan
+
+Pre-computed acquisition plan for efficient repeated acquisition over the same signal parameters.
+
+Contains pre-allocated buffers and FFT plans to avoid repeated memory allocation when acquiring
+multiple signals with the same length and sampling frequency.
+
+# Fields
+- `system`: GNSS system (e.g., `GPSL1()`)
+- `signal_length`: Number of samples in the signal
+- `sampling_freq`: Sampling frequency
+- `dopplers`: Range of Doppler frequencies to search
+- `avail_prn_channels`: PRN channels available in this plan
+
+# See also
+[`acquire!`](@ref), [`CoarseFineAcquisitionPlan`](@ref)
+"""
 struct AcquisitionPlan{S,DS,CS,P,PS}
     system::S
     signal_length::Int
@@ -13,6 +31,33 @@ struct AcquisitionPlan{S,DS,CS,P,PS}
     avail_prn_channels::PS
 end
 
+"""
+    AcquisitionPlan(system, signal_length, sampling_freq; kwargs...)
+
+Create an acquisition plan for efficient repeated acquisition.
+
+# Arguments
+- `system`: GNSS system (e.g., `GPSL1()`)
+- `signal_length`: Number of samples in the signal
+- `sampling_freq`: Sampling frequency of the signal
+
+# Keyword Arguments
+- `max_doppler`: Maximum Doppler frequency to search (default: `7000Hz`)
+- `min_doppler`: Minimum Doppler frequency to search (default: `-max_doppler`)
+- `dopplers`: Custom Doppler range (default: `min_doppler:250Hz:max_doppler`)
+- `prns`: PRN channels to prepare (default: `1:34`)
+- `fft_flag`: FFTW planning flag (default: `FFTW.MEASURE`)
+
+# Example
+```julia
+using Acquisition, GNSSSignals
+plan = AcquisitionPlan(GPSL1(), 10000, 5e6Hz; prns=1:32)
+results = acquire!(plan, signal, 1:32)
+```
+
+# See also
+[`acquire!`](@ref), [`CoarseFineAcquisitionPlan`](@ref)
+"""
 function AcquisitionPlan(
     system,
     signal_length,
@@ -54,11 +99,55 @@ function AcquisitionPlan(
     )
 end
 
+"""
+    CoarseFineAcquisitionPlan
+
+Pre-computed acquisition plan for two-stage coarse-fine acquisition.
+
+Performs an initial coarse search to find approximate Doppler, then refines with a
+fine search around that estimate. This approach is more efficient than a single
+high-resolution search.
+
+# Fields
+- `coarse_plan`: [`AcquisitionPlan`](@ref) for the initial coarse search
+- `fine_plan`: [`AcquisitionPlan`](@ref) for the refined fine search
+
+# See also
+[`coarse_fine_acquire`](@ref), [`AcquisitionPlan`](@ref)
+"""
 struct CoarseFineAcquisitionPlan{C<:AcquisitionPlan,F<:AcquisitionPlan}
     coarse_plan::C
     fine_plan::F
 end
 
+"""
+    CoarseFineAcquisitionPlan(system, signal_length, sampling_freq; kwargs...)
+
+Create a two-stage coarse-fine acquisition plan.
+
+# Arguments
+- `system`: GNSS system (e.g., `GPSL1()`)
+- `signal_length`: Number of samples in the signal
+- `sampling_freq`: Sampling frequency of the signal
+
+# Keyword Arguments
+- `max_doppler`: Maximum Doppler frequency to search (default: `7000Hz`)
+- `min_doppler`: Minimum Doppler frequency to search (default: `-max_doppler`)
+- `coarse_step`: Doppler step size for coarse search (default: `250Hz`)
+- `fine_step`: Doppler step size for fine search (default: `25Hz`)
+- `prns`: PRN channels to prepare (default: `1:34`)
+- `fft_flag`: FFTW planning flag (default: `FFTW.MEASURE`)
+
+# Example
+```julia
+using Acquisition, GNSSSignals
+plan = CoarseFineAcquisitionPlan(GPSL1(), 10000, 5e6Hz; prns=1:32)
+results = acquire!(plan, signal, 1:32)
+```
+
+# See also
+[`coarse_fine_acquire`](@ref), [`AcquisitionPlan`](@ref)
+"""
 function CoarseFineAcquisitionPlan(
     system,
     signal_length,

--- a/test/calc_powers.jl
+++ b/test/calc_powers.jl
@@ -41,6 +41,7 @@
     code_freq_baseband_freq_domain = similar(signal_baseband)
     code_baseband = similar(signal_baseband)
     fft_plan = plan_fft(signal_baseband)
+    ifft_plan = plan_ifft(signal_baseband)
 
     Acquisition.power_over_code!(
         signal_powers,
@@ -51,6 +52,7 @@
         code_baseband,
         signal,
         fft_plan,
+        ifft_plan,
         codes_freq_domain,
         doppler,
         sampling_freq,

--- a/test/calc_powers.jl
+++ b/test/calc_powers.jl
@@ -43,7 +43,7 @@
     fft_plan = plan_fft(signal_baseband)
     ifft_plan = plan_ifft(signal_baseband)
 
-    Acquisition.power_over_code!(
+    @inferred Acquisition.power_over_code!(
         signal_powers,
         1,
         signal_baseband,
@@ -96,8 +96,13 @@ end
 
     acq_plan = AcquisitionPlan(system, length(signal), sampling_freq; dopplers, prns = 1:1)
 
-    powers_per_sats =
-        Acquisition.power_over_doppler_and_codes!(acq_plan, signal, [1], interm_freq, 0.0Hz)
+    powers_per_sats = @inferred Acquisition.power_over_doppler_and_codes!(
+        acq_plan,
+        signal,
+        [1],
+        interm_freq,
+        0.0Hz,
+    )
 
     maxval, maxidx = findmax(powers_per_sats[1])
     @test (maxidx[1] - 1) * get_code_frequency(system) / sampling_freq ≈ code_phase atol =

--- a/test/downconvert.jl
+++ b/test/downconvert.jl
@@ -2,6 +2,6 @@
     signal = rand(Complex{Int16}, 20000)
     downconverted_signal = Vector{ComplexF32}(undef, length(signal))
 
-    Acquisition.downconvert!(downconverted_signal, signal, 2000Hz, 5e6Hz)
+    @inferred Acquisition.downconvert!(downconverted_signal, signal, 2000Hz, 5e6Hz)
     @test downconverted_signal ≈ signal .* cis.(-2π * (0:length(signal)-1) * 2000Hz / 5e6Hz)
 end

--- a/test/est_signal_noise_power.jl
+++ b/test/est_signal_noise_power.jl
@@ -3,7 +3,7 @@
     power_bins = abs2.(1 / sqrt(2) * complex.(ones(1023, 29), ones(1023, 29)))
     power_bins[489, 11] = power_bins[489, 11] + 10^(15 / 10) # 15 dB SNR
     signal_power, noise_power, code_index, doppler_index =
-        Acquisition.est_signal_noise_power(power_bins, 4e6, 1e6, nothing)
+        @inferred Acquisition.est_signal_noise_power(power_bins, 4e6, 1e6, nothing)
 
     @test noise_power ≈ 1
     @test signal_power ≈ 10^(15 / 10)
@@ -14,7 +14,7 @@
     power_bins = abs2.(1 / sqrt(2) * complex.(ones(1023, 29), ones(1023, 29)))
     power_bins[1, 1] = power_bins[1, 1] + 10^(15 / 10) # 15 dB SNR
     signal_power, noise_power, code_index, doppler_index =
-        Acquisition.est_signal_noise_power(power_bins, 4e6, 1e6, nothing)
+        @inferred Acquisition.est_signal_noise_power(power_bins, 4e6, 1e6, nothing)
 
     @test noise_power ≈ 1
     @test signal_power ≈ 10^(15 / 10)
@@ -24,7 +24,7 @@
     power_bins = abs2.(1 / sqrt(2) * complex.(ones(1023, 29), ones(1023, 29)))
     power_bins[1023, 29] = power_bins[1023, 29] + 10^(15 / 10) # 15 dB SNR
     signal_power, noise_power, code_index, doppler_index =
-        Acquisition.est_signal_noise_power(power_bins, 4e6, 1e6, nothing)
+        @inferred Acquisition.est_signal_noise_power(power_bins, 4e6, 1e6, nothing)
 
     @test noise_power ≈ 1
     @test signal_power ≈ 10^(15 / 10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
-using Test, FFTW, Acquisition, GNSSSignals, Random
+using Test, FFTW, Acquisition, GNSSSignals, Random, Aqua
 import Unitful: Hz
+
+@testset "Aqua" begin
+    Aqua.test_all(Acquisition; ambiguities=false)
+end
 
 include("downconvert.jl")
 include("est_signal_noise_power.jl")


### PR DESCRIPTION
Preparation for version 1.0.0

- Add docstrings for all exported functions and types
- Set up Documenter.jl with index, usage guide, and API reference
- Overhaul README with badges and cleaner quick start
- Export AcquisitionResults type
- Remove undefined plot_acquisition_results export
- Add Aqua.jl tests and missing compat bounds
- Add eltype parameter to AcquisitionPlan for matching buffer types
  to signal types (Float64 buffers for ComplexF64 signals)
- Add ifft_plan to AcquisitionPlan struct and use mul! instead of
  ldiv! to eliminate 2 allocations per Doppler bin
- Replace foreach with for loops to avoid closure allocations
- Use all(f, collection) instead of all(map(f, collection))
- Update benchmarks to use matching eltype for floating point signals