### PR TITLE
feat: make acquire! allocation-free for result handling

### DIFF
--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -44,7 +44,7 @@ plot(result, true)  # Use log scale (dB)
 # See also
 [`acquire`](@ref), [`coarse_fine_acquire`](@ref)
 """
-struct AcquisitionResults{S<:AbstractGNSS,T}
+struct AcquisitionResults{S<:AbstractGNSS,T,D<:AbstractRange}
     system::S
     prn::Int
     sampling_frequency::typeof(1.0Hz)
@@ -53,11 +53,7 @@ struct AcquisitionResults{S<:AbstractGNSS,T}
     CN0::Float64
     noise_power::T
     power_bins::Matrix{T}
-    dopplers::StepRangeLen{
-        Float64,
-        Base.TwicePrecision{Float64},
-        Base.TwicePrecision{Float64},
-    }
+    dopplers::D
 end
 
 function Base.show(io::IO, ::MIME"text/plain", acq::AcquisitionResults)
@@ -83,7 +79,7 @@ function _format_cn0(cn0, use_color::Bool)
     end
 end
 
-function Base.show(io::IO, ::MIME"text/plain", acq_channels::Vector{Acquisition.AcquisitionResults{T1,T2}}) where {T1,T2}
+function Base.show(io::IO, ::MIME"text/plain", acq_channels::Vector{<:Acquisition.AcquisitionResults})
     column_labels = ["PRN", "CN0 (dBHz)", "Carrier Doppler (Hz)", "Code phase (chips)"]
     use_color = get(io, :color, false)
     data = reduce(vcat, map(acq -> permutedims([acq.prn, _format_cn0(acq.CN0, use_color), acq.carrier_doppler, acq.code_phase]), acq_channels))

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -32,6 +32,9 @@ struct AcquisitionPlan{T<:AbstractFloat,S,DS,CS,P,IP,PS}
     fft_plan::P
     ifft_plan::IP
     avail_prn_channels::PS
+    results::Vector{AcquisitionResults{S,Float32,DS}}
+    prn_indices::Vector{Int}
+    output_results::Vector{AcquisitionResults{S,Float32,DS}}
 end
 
 """
@@ -97,6 +100,22 @@ function AcquisitionPlan(
             length(dopplers),
         ) for _ in prns
     ]
+    results = [
+        AcquisitionResults(
+            system,
+            prn,
+            sampling_freq,
+            0.0Hz,
+            0.0,
+            0.0,
+            Float32(0),
+            signal_powers[i],
+            dopplers,
+        )
+        for (i, prn) in enumerate(prns)
+    ]
+    prn_indices = Vector{Int}(undef, length(prns))
+    output_results = Vector{Base.eltype(results)}(undef, length(prns))
     AcquisitionPlan(
         system,
         signal_length,
@@ -111,6 +130,9 @@ function AcquisitionPlan(
         fft_plan,
         ifft_plan,
         prns,
+        results,
+        prn_indices,
+        output_results,
     )
 end
 
@@ -211,6 +233,22 @@ function CoarseFineAcquisitionPlan(
             length(fine_doppler_range),
         ) for _ in prns
     ]
+    coarse_results = [
+        AcquisitionResults(
+            system,
+            prn,
+            sampling_freq,
+            0.0Hz,
+            0.0,
+            0.0,
+            Float32(0),
+            coarse_signal_powers[i],
+            coarse_dopplers,
+        )
+        for (i, prn) in enumerate(prns)
+    ]
+    coarse_prn_indices = Vector{Int}(undef, length(prns))
+    coarse_output_results = Vector{Base.eltype(coarse_results)}(undef, length(prns))
     coarse_plan = AcquisitionPlan(
         system,
         signal_length,
@@ -225,7 +263,26 @@ function CoarseFineAcquisitionPlan(
         fft_plan,
         ifft_plan,
         prns,
+        coarse_results,
+        coarse_prn_indices,
+        coarse_output_results,
     )
+    fine_results = [
+        AcquisitionResults(
+            system,
+            prn,
+            sampling_freq,
+            0.0Hz,
+            0.0,
+            0.0,
+            Float32(0),
+            fine_signal_powers[i],
+            fine_doppler_range,
+        )
+        for (i, prn) in enumerate(prns)
+    ]
+    fine_prn_indices = Vector{Int}(undef, length(prns))
+    fine_output_results = Vector{Base.eltype(fine_results)}(undef, length(prns))
     fine_plan = AcquisitionPlan(
         system,
         signal_length,
@@ -240,6 +297,9 @@ function CoarseFineAcquisitionPlan(
         fft_plan,
         ifft_plan,
         prns,
+        fine_results,
+        fine_prn_indices,
+        fine_output_results,
     )
     CoarseFineAcquisitionPlan(coarse_plan, fine_plan)
 end


### PR DESCRIPTION
Changes:
- Add `results`, `prn_indices`, and `output_results` fields to `AcquisitionPlan` for pre-allocation
- `AcquisitionResults.dopplers` is now Unitful instead of unitless
- Remove redundant `dopplers_unitless` field from `AcquisitionPlan`
- Return pre-allocated `output_results` vector using `resize!` which preserves capacity and avoids allocation when shrinking or staying within original size
- Make `CoarseFineAcquisitionPlan` allocation-free by inlining fine acquisition

<img width="854" height="677" alt="image" src="https://github.com/user-attachments/assets/ab19caf3-5ebe-468a-9875-4b88a9e0b631" />


The return type remains `Vector{AcquisitionResults}`, preserving API compatibility.