### PR TITLE
feat: add non-coherent integration for signals longer than bit period

### DIFF
--- a/src/downconvert.jl
+++ b/src/downconvert.jl
@@ -12,10 +12,11 @@ function downconvert!(
     signal::AbstractVector{Complex{TS}},
     frequency,
     sampling_freq,
+    num_samples::Int,
 ) where {T,TS}
     signal_real = reinterpret(reshape, TS, signal)
     downconverted_signal_real = reinterpret(reshape, T, downconverted_signal)
-    @turbo for i = 1:length(signal)
+    @turbo for i = 1:num_samples
         c_im, c_re = sincos(T(2π) * (i - 1) * T(frequency / sampling_freq))
         downconverted_signal_real[1, i] =
             signal_real[1, i] * c_re + signal_real[2, i] * c_im
@@ -23,4 +24,13 @@ function downconvert!(
             signal_real[2, i] * c_re - signal_real[1, i] * c_im
     end
     downconverted_signal
+end
+
+function downconvert!(
+    downconverted_signal::Vector{Complex{T}},
+    signal::Vector{Complex{TS}},
+    frequency,
+    sampling_freq,
+) where {T,TS}
+    downconvert!(downconverted_signal, signal, frequency, sampling_freq, length(signal))
 end


### PR DESCRIPTION
- Add chunking support to process signals in bit-period-sized chunks
- Accumulate correlation powers non-coherently across chunks
- Add convenience constructors that default to one bit period chunk size
- Update CN0 calculation to only include coherent integration gain (no explicit non-coherent gain to avoid false detections on noise)
- Add non-coherent integration support to KAAcquisitionPlan (GPU)
- Add benchmarks for non-coherent integration (conditionally enabled)