### PR TITLE
Add code Doppler compensation, frequency-domain zero-padding, and DBZP linear correlation

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -35,6 +35,6 @@ if isdefined(Acquisition, :KAAcquisitionPlan)
     include(joinpath(@__DIR__, "ka_benchmarks.jl"))
 
     for (key, group) in KA_SUITE
-        SUITE["GPU $key"] = group
+        SUITE["$KA_BACKEND_LABEL $key"] = group
     end
 end

--- a/benchmark/cpu_benchmarks.jl
+++ b/benchmark/cpu_benchmarks.jl
@@ -20,20 +20,20 @@ const _supports_eltype = hasmethod(AcquisitionPlan,
 function _make_acq_plan(system, num_samples, sampling_freq, buffer_eltype; prns=1:32)
     if _supports_eltype
         AcquisitionPlan(system, num_samples, sampling_freq;
-            prns=prns, fft_flag=FFTW.ESTIMATE, eltype=buffer_eltype)
+            prns=prns, fft_flag=FFTW.MEASURE, eltype=buffer_eltype)
     else
         AcquisitionPlan(system, num_samples, sampling_freq;
-            prns=prns, fft_flag=FFTW.ESTIMATE)
+            prns=prns, fft_flag=FFTW.MEASURE)
     end
 end
 
 function _make_coarse_fine_plan(system, num_samples, sampling_freq, buffer_eltype; prns=1:32)
     if _supports_eltype
         CoarseFineAcquisitionPlan(system, num_samples, sampling_freq;
-            prns=prns, fft_flag=FFTW.ESTIMATE, eltype=buffer_eltype)
+            prns=prns, fft_flag=FFTW.MEASURE, eltype=buffer_eltype)
     else
         CoarseFineAcquisitionPlan(system, num_samples, sampling_freq;
-            prns=prns, fft_flag=FFTW.ESTIMATE)
+            prns=prns, fft_flag=FFTW.MEASURE)
     end
 end
 
@@ -147,7 +147,7 @@ if _supports_noncoherent
         num_samples = ceil(Int, multiplier * bit_period_samples)
 
         # Create plan with default bit period chunk size (single PRN for faster benchmarks)
-        plan = AcquisitionPlan(system, CPU_SAMPLING_FREQ; prns=1:1, fft_flag=FFTW.ESTIMATE)
+        plan = AcquisitionPlan(system, CPU_SAMPLING_FREQ; prns=1:1, fft_flag=FFTW.MEASURE)
         signal = _make_signal(num_samples, Float32)
 
         CPU_SUITE["NonCoherent"]["$(multiplier)x_bit_period"] =
@@ -161,7 +161,7 @@ if _supports_noncoherent
         bit_period_samples = ceil(Int, CPU_SAMPLING_FREQ / get_data_frequency(system))
         num_samples = ceil(Int, multiplier * bit_period_samples)
 
-        plan = CoarseFineAcquisitionPlan(system, CPU_SAMPLING_FREQ; prns=1:1, fft_flag=FFTW.ESTIMATE)
+        plan = CoarseFineAcquisitionPlan(system, CPU_SAMPLING_FREQ; prns=1:1, fft_flag=FFTW.MEASURE)
         signal = _make_signal(num_samples, Float32)
 
         CPU_SUITE["NonCoherent CoarseFine"]["$(multiplier)x_bit_period"] =

--- a/benchmark/cpu_benchmarks.jl
+++ b/benchmark/cpu_benchmarks.jl
@@ -7,37 +7,65 @@ using FFTW
 const CPU_SUITE = BenchmarkGroup()
 
 const CPU_SAMPLE_SIZES = [16368, 32736, 60000]
-const CPU_PRN_COUNTS = [1, 8, 32]
+const CPU_PRN_COUNTS = [1, 32]
 const CPU_SAMPLING_FREQ = 16.368e6Hz
-const CPU_SIGNAL_TYPES = [Float64, Float32, Int16, Int32]
-const CPU_SYSTEM_TYPES = [GPSL1, GalileoE1B]
 
 # Check if eltype keyword is supported (added in later versions)
-const _supports_eltype = hasmethod(AcquisitionPlan,
-    Tuple{typeof(GPSL1()), Int, typeof(1.0Hz)},
-    (:prns, :fft_flag, :eltype))
+const _supports_eltype = hasmethod(
+    AcquisitionPlan,
+    Tuple{typeof(GPSL1()),Int,typeof(1.0Hz)},
+    (:prns, :fft_flag, :eltype),
+)
 
-function _make_acq_plan(system, num_samples, sampling_freq, buffer_eltype; prns=1:32)
+function _make_acq_plan(system, num_samples, sampling_freq, buffer_eltype; prns = 1:32)
     if _supports_eltype
-        AcquisitionPlan(system, num_samples, sampling_freq;
-            prns=prns, fft_flag=FFTW.MEASURE, eltype=buffer_eltype)
+        AcquisitionPlan(
+            system,
+            num_samples,
+            sampling_freq;
+            prns = prns,
+            fft_flag = FFTW.MEASURE,
+            eltype = buffer_eltype,
+        )
     else
-        AcquisitionPlan(system, num_samples, sampling_freq;
-            prns=prns, fft_flag=FFTW.MEASURE)
+        AcquisitionPlan(
+            system,
+            num_samples,
+            sampling_freq;
+            prns = prns,
+            fft_flag = FFTW.MEASURE,
+        )
     end
 end
 
-function _make_coarse_fine_plan(system, num_samples, sampling_freq, buffer_eltype; prns=1:32)
+function _make_coarse_fine_plan(
+    system,
+    num_samples,
+    sampling_freq,
+    buffer_eltype;
+    prns = 1:32,
+)
     if _supports_eltype
-        CoarseFineAcquisitionPlan(system, num_samples, sampling_freq;
-            prns=prns, fft_flag=FFTW.MEASURE, eltype=buffer_eltype)
+        CoarseFineAcquisitionPlan(
+            system,
+            num_samples,
+            sampling_freq;
+            prns = prns,
+            fft_flag = FFTW.MEASURE,
+            eltype = buffer_eltype,
+        )
     else
-        CoarseFineAcquisitionPlan(system, num_samples, sampling_freq;
-            prns=prns, fft_flag=FFTW.MEASURE)
+        CoarseFineAcquisitionPlan(
+            system,
+            num_samples,
+            sampling_freq;
+            prns = prns,
+            fft_flag = FFTW.MEASURE,
+        )
     end
 end
 
-function _make_signal(num_samples, ::Type{T}) where T
+function _make_signal(num_samples, ::Type{T}) where {T}
     signal = randn(ComplexF64, num_samples)
     if T <: Integer
         complex.(floor.(T, real.(signal)), floor.(T, imag.(signal)))
@@ -59,7 +87,7 @@ for num_samples in CPU_SAMPLE_SIZES
         prns = 1:num_prns
         system = GPSL1()
         signal = _make_signal(num_samples, Float32)
-        plan = _make_acq_plan(system, num_samples, CPU_SAMPLING_FREQ, Float32; prns=1:32)
+        plan = _make_acq_plan(system, num_samples, CPU_SAMPLING_FREQ, Float32; prns = 1:32)
 
         CPU_SUITE["Acquire"]["$(num_samples)_samples"]["$(num_prns)_prns"] =
             @benchmarkable acquire!($plan, $signal, $prns)
@@ -79,7 +107,13 @@ for num_samples in CPU_SAMPLE_SIZES
         prns = 1:num_prns
         system = GPSL1()
         signal = _make_signal(num_samples, Float32)
-        plan = _make_coarse_fine_plan(system, num_samples, CPU_SAMPLING_FREQ, Float32; prns=1:32)
+        plan = _make_coarse_fine_plan(
+            system,
+            num_samples,
+            CPU_SAMPLING_FREQ,
+            Float32;
+            prns = 1:32,
+        )
 
         CPU_SUITE["CoarseFine"]["$(num_samples)_samples"]["$(num_prns)_prns"] =
             @benchmarkable acquire!($plan, $signal, $prns)
@@ -87,41 +121,26 @@ for num_samples in CPU_SAMPLE_SIZES
 end
 
 # ============================================================================
-# Type and system benchmarks (varying signal types and GNSS systems)
+# Type benchmarks (Float32 vs Float64 buffer performance)
 # ============================================================================
 
 const TYPE_BENCHMARK_SAMPLES = 20000
 
 CPU_SUITE["Types"] = BenchmarkGroup()
 
-for signal_type in CPU_SIGNAL_TYPES
-    CPU_SUITE["Types"][string(signal_type)] = BenchmarkGroup()
+for signal_type in [Float32, Float64]
+    system = GPSL1()
+    signal = _make_signal(TYPE_BENCHMARK_SAMPLES, signal_type)
+    plan = _make_acq_plan(
+        system,
+        TYPE_BENCHMARK_SAMPLES,
+        CPU_SAMPLING_FREQ,
+        signal_type;
+        prns = 1:1,
+    )
 
-    for system_type in CPU_SYSTEM_TYPES
-        system = system_type()
-        signal = _make_signal(TYPE_BENCHMARK_SAMPLES, signal_type)
-        buffer_eltype = signal_type <: AbstractFloat ? signal_type : Float32
-        plan = _make_acq_plan(system, TYPE_BENCHMARK_SAMPLES, CPU_SAMPLING_FREQ, buffer_eltype; prns=1:1)
-
-        CPU_SUITE["Types"][string(signal_type)][string(system_type)] =
-            @benchmarkable acquire!($plan, $signal, $(1:1))
-    end
-end
-
-CPU_SUITE["CoarseFine Types"] = BenchmarkGroup()
-
-for signal_type in CPU_SIGNAL_TYPES
-    CPU_SUITE["CoarseFine Types"][string(signal_type)] = BenchmarkGroup()
-
-    for system_type in CPU_SYSTEM_TYPES
-        system = system_type()
-        signal = _make_signal(TYPE_BENCHMARK_SAMPLES, signal_type)
-        buffer_eltype = signal_type <: AbstractFloat ? signal_type : Float32
-        plan = _make_coarse_fine_plan(system, TYPE_BENCHMARK_SAMPLES, CPU_SAMPLING_FREQ, buffer_eltype; prns=1:1)
-
-        CPU_SUITE["CoarseFine Types"][string(signal_type)][string(system_type)] =
-            @benchmarkable acquire!($plan, $signal, $(1:1))
-    end
+    CPU_SUITE["Types"][string(signal_type)] =
+        @benchmarkable acquire!($plan, $signal, $(1:1))
 end
 
 # ============================================================================
@@ -130,41 +149,22 @@ end
 # ============================================================================
 
 # Check if convenience constructor exists (added with non-coherent integration support)
-const _supports_noncoherent = hasmethod(AcquisitionPlan,
-    Tuple{typeof(GPSL1()), typeof(1.0Hz)},
-    (:prns, :fft_flag))
+const _supports_noncoherent =
+    hasmethod(AcquisitionPlan, Tuple{typeof(GPSL1()),typeof(1.0Hz)}, (:prns, :fft_flag))
 
 if _supports_noncoherent
     CPU_SUITE["NonCoherent"] = BenchmarkGroup()
 
-    # Test with signals spanning 1, 1.5, 2, and 3 bit periods
-    const BIT_PERIOD_MULTIPLIERS = [1.0, 1.5, 2.0, 3.0]
-
-    for multiplier in BIT_PERIOD_MULTIPLIERS
+    for multiplier in [1.0, 2.0]
         system = GPSL1()
-        # Calculate bit period in samples at our sampling frequency
         bit_period_samples = ceil(Int, CPU_SAMPLING_FREQ / get_data_frequency(system))
         num_samples = ceil(Int, multiplier * bit_period_samples)
 
-        # Create plan with default bit period chunk size (single PRN for faster benchmarks)
-        plan = AcquisitionPlan(system, CPU_SAMPLING_FREQ; prns=1:1, fft_flag=FFTW.MEASURE)
+        plan =
+            AcquisitionPlan(system, CPU_SAMPLING_FREQ; prns = 1:1, fft_flag = FFTW.MEASURE)
         signal = _make_signal(num_samples, Float32)
 
         CPU_SUITE["NonCoherent"]["$(multiplier)x_bit_period"] =
-            @benchmarkable acquire!($plan, $signal, $(1:1))
-    end
-
-    CPU_SUITE["NonCoherent CoarseFine"] = BenchmarkGroup()
-
-    for multiplier in BIT_PERIOD_MULTIPLIERS
-        system = GPSL1()
-        bit_period_samples = ceil(Int, CPU_SAMPLING_FREQ / get_data_frequency(system))
-        num_samples = ceil(Int, multiplier * bit_period_samples)
-
-        plan = CoarseFineAcquisitionPlan(system, CPU_SAMPLING_FREQ; prns=1:1, fft_flag=FFTW.MEASURE)
-        signal = _make_signal(num_samples, Float32)
-
-        CPU_SUITE["NonCoherent CoarseFine"]["$(multiplier)x_bit_period"] =
             @benchmarkable acquire!($plan, $signal, $(1:1))
     end
 end

--- a/benchmark/ka_benchmarks.jl
+++ b/benchmark/ka_benchmarks.jl
@@ -19,15 +19,15 @@ catch
     false
 end
 
-const GPUArrayType = if HAS_ROCM
+const GPUArrayType, KA_BACKEND_LABEL = if HAS_ROCM
     @info "GPU backend: AMDGPU (ROCm)"
-    AMDGPU.ROCArray
+    AMDGPU.ROCArray, "ROCm"
 elseif HAS_CUDA
     @info "GPU backend: CUDA"
-    CUDA.CuArray
+    CUDA.CuArray, "CUDA"
 else
     @info "GPU backend: None (using CPU Array fallback)"
-    Array
+    Array, "KA-CPU"
 end
 
 const KA_SUITE = BenchmarkGroup()

--- a/benchmark/ka_benchmarks.jl
+++ b/benchmark/ka_benchmarks.jl
@@ -33,7 +33,7 @@ end
 const KA_SUITE = BenchmarkGroup()
 
 const KA_SAMPLE_SIZES = [16368, 32736, 60000]
-const KA_PRN_COUNTS = [1, 8, 32]
+const KA_PRN_COUNTS = [1, 32]
 const KA_SAMPLING_FREQ = 16.368e6Hz
 
 function _ka_make_signal(num_samples)
@@ -48,7 +48,13 @@ for num_samples in KA_SAMPLE_SIZES
         system = GPSL1()
         signal_cpu = _ka_make_signal(num_samples)
 
-        plan = KAAcquisitionPlan(system, num_samples, KA_SAMPLING_FREQ, GPUArrayType; prns=1:32)
+        plan = KAAcquisitionPlan(
+            system,
+            num_samples,
+            KA_SAMPLING_FREQ,
+            GPUArrayType;
+            prns = 1:32,
+        )
         signal = GPUArrayType(signal_cpu)
 
         KA_SUITE["$(num_samples)_samples"]["$(num_prns)_prns"] =

--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -3,8 +3,8 @@ module Acquisition
 using DocStringExtensions,
     GNSSSignals, RecipesBase, FFTW, Statistics, LinearAlgebra, LoopVectorization, Unitful
 
-import Unitful: s, Hz
-using Unitful: ustrip
+import Unitful: s, Hz, dB
+using Unitful: ustrip, Gain
 using AbstractFFTs: fft
 using Scratch: @get_scratch!
 using PrettyTables: pretty_table, AnsiTextCell
@@ -24,18 +24,21 @@ export acquire,
 Results from GNSS signal acquisition for a single PRN.
 
 # Fields
-- `system::S`: GNSS system used for acquisition
-- `prn::Int`: PRN number of the satellite
-- `sampling_frequency`: Sampling frequency of the signal
-- `carrier_doppler`: Estimated carrier Doppler frequency
-- `code_phase::Float64`: Estimated code phase in chips
-- `CN0::Float64`: Carrier-to-noise density ratio in dB-Hz
-- `noise_power::T`: Estimated noise power
-- `power_bins::Matrix{T}`: Correlation power over code phase and Doppler (for plotting)
-- `dopplers`: Doppler frequencies searched
+
+  - `system::S`: GNSS system used for acquisition
+  - `prn::Int`: PRN number of the satellite
+  - `sampling_frequency`: Sampling frequency of the signal
+  - `carrier_doppler`: Estimated carrier Doppler frequency
+  - `code_phase::Float64`: Estimated code phase in chips
+  - `CN0::Float64`: Carrier-to-noise density ratio in dB-Hz
+  - `noise_power::T`: Estimated noise power
+  - `power_bins::Matrix{T}`: Correlation power over code phase and Doppler (for plotting)
+  - `dopplers`: Doppler frequencies searched
 
 # Plotting
+
 `AcquisitionResults` can be plotted directly using Plots.jl:
+
 ```julia
 using Plots
 plot(result)  # 3D surface plot of correlation power
@@ -43,6 +46,7 @@ plot(result, true)  # Use log scale (dB)
 ```
 
 # See also
+
 [`acquire`](@ref), [`coarse_fine_acquire`](@ref)
 """
 struct AcquisitionResults{S<:AbstractGNSS,T,D<:AbstractRange}
@@ -80,16 +84,28 @@ function _format_cn0(cn0, use_color::Bool)
     end
 end
 
-function Base.show(io::IO, ::MIME"text/plain", acq_channels::Vector{<:Acquisition.AcquisitionResults})
+function Base.show(
+    io::IO,
+    ::MIME"text/plain",
+    acq_channels::Vector{<:Acquisition.AcquisitionResults},
+)
     column_labels = ["PRN", "CN0 (dBHz)", "Carrier Doppler (Hz)", "Code phase (chips)"]
     use_color = get(io, :color, false)
-    data = reduce(vcat, map(acq -> permutedims([acq.prn, _format_cn0(acq.CN0, use_color), acq.carrier_doppler, acq.code_phase]), acq_channels))
+    data = reduce(
+        vcat,
+        map(
+            acq -> permutedims([
+                acq.prn,
+                _format_cn0(acq.CN0, use_color),
+                acq.carrier_doppler,
+                acq.code_phase,
+            ]),
+            acq_channels,
+        ),
+    )
 
-    pretty_table(io, data; column_labels=column_labels)
+    pretty_table(io, data; column_labels = column_labels)
 end
-
-
-
 
 include("plan_acquire.jl")
 include("downconvert.jl")

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -55,6 +55,7 @@ function acquire(
     samples_to_integrate_coherently = ceil(Int, sampling_freq / get_data_frequency(system)),
     doppler_step_factor = 1//3,
     dopplers = min_doppler:(doppler_step_factor * sampling_freq / samples_to_integrate_coherently):max_doppler,
+    code_doppler_tolerance = 0.01,
 )
     acq_plan = AcquisitionPlan(
         system,
@@ -63,6 +64,7 @@ function acquire(
         dopplers,
         prns,
         fft_flag = FFTW.MEASURE,
+        code_doppler_tolerance,
     )
     acquire!(acq_plan, signal, prns; interm_freq)
 end
@@ -330,8 +332,9 @@ function acquire(
     samples_to_integrate_coherently = ceil(Int, sampling_freq / get_data_frequency(system)),
     doppler_step_factor = 1//3,
     dopplers = min_doppler:(doppler_step_factor * sampling_freq / samples_to_integrate_coherently):max_doppler,
+    code_doppler_tolerance = 0.01,
 )
-    only(acquire(system, signal, sampling_freq, [prn]; interm_freq, dopplers, samples_to_integrate_coherently))
+    only(acquire(system, signal, sampling_freq, [prn]; interm_freq, dopplers, samples_to_integrate_coherently, code_doppler_tolerance))
 end
 
 function acquire!(
@@ -409,6 +412,7 @@ function coarse_fine_acquire(
     doppler_step_factor = 1//3,
     coarse_step = doppler_step_factor * sampling_freq / samples_to_integrate_coherently,
     fine_step = coarse_step / 10,
+    code_doppler_tolerance = 0.01,
 )
     acq_plan = CoarseFineAcquisitionPlan(
         system,
@@ -420,6 +424,7 @@ function coarse_fine_acquire(
         fine_step,
         prns,
         fft_flag = FFTW.MEASURE,
+        code_doppler_tolerance,
     )
     acquire!(acq_plan, signal, prns; interm_freq)
 end
@@ -476,6 +481,7 @@ function coarse_fine_acquire(
     doppler_step_factor = 1//3,
     coarse_step = doppler_step_factor * sampling_freq / samples_to_integrate_coherently,
     fine_step = coarse_step / 10,
+    code_doppler_tolerance = 0.01,
 )
     only(
         coarse_fine_acquire(
@@ -489,6 +495,7 @@ function coarse_fine_acquire(
             samples_to_integrate_coherently,
             coarse_step,
             fine_step,
+            code_doppler_tolerance,
         ),
     )
 end

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -23,6 +23,10 @@ replica codes across a grid of Doppler frequencies and code phases.
   - `doppler_step_factor`: Factor for computing Doppler step from integration time (default: `1//3`).
     The step is `doppler_step_factor / T` where `T = samples_to_integrate_coherently / sampling_freq`.
   - `dopplers`: Custom Doppler search range (default: computed from `doppler_step_factor`)
+  - `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
+    Controls how many code replicas are pre-computed at different code Doppler offsets.
+    Smaller values improve accuracy at high Dopplers with long integration times, at the
+    cost of more memory.
 
 # Returns
 
@@ -384,6 +388,10 @@ resolution while reducing computational cost compared to a single high-resolutio
     The coarse step is `doppler_step_factor / T` where `T = samples_to_integrate_coherently / sampling_freq`.
   - `coarse_step`: Doppler step for coarse search (default: computed from `doppler_step_factor`)
   - `fine_step`: Doppler step for fine search (default: `coarse_step / 10`)
+  - `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
+    Controls how many code replicas are pre-computed at different code Doppler offsets.
+    Smaller values improve accuracy at high Dopplers with long integration times, at the
+    cost of more memory.
 
 # Returns
 

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -59,7 +59,7 @@ function acquire(
     doppler_step_factor = 1//3,
     dopplers = min_doppler:(doppler_step_factor*sampling_freq/samples_to_integrate_coherently):max_doppler,
     max_code_doppler_loss = 0.5dB,
-    zero_pad_power::Int = 1,
+    zero_pad_power::Int = 0,
 )
     acq_plan = AcquisitionPlan(
         system,
@@ -352,7 +352,7 @@ function acquire(
     doppler_step_factor = 1//3,
     dopplers = min_doppler:(doppler_step_factor*sampling_freq/samples_to_integrate_coherently):max_doppler,
     max_code_doppler_loss = 0.5dB,
-    zero_pad_power::Int = 1,
+    zero_pad_power::Int = 0,
 )
     only(
         acquire(
@@ -450,7 +450,7 @@ function coarse_fine_acquire(
     coarse_step = doppler_step_factor * sampling_freq / samples_to_integrate_coherently,
     fine_step = coarse_step / 10,
     max_code_doppler_loss = 0.5dB,
-    zero_pad_power::Int = 1,
+    zero_pad_power::Int = 0,
 )
     acq_plan = CoarseFineAcquisitionPlan(
         system,
@@ -521,7 +521,7 @@ function coarse_fine_acquire(
     coarse_step = doppler_step_factor * sampling_freq / samples_to_integrate_coherently,
     fine_step = coarse_step / 10,
     max_code_doppler_loss = 0.5dB,
-    zero_pad_power::Int = 1,
+    zero_pad_power::Int = 0,
 )
     only(
         coarse_fine_acquire(

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -164,9 +164,10 @@ function acquire!(
             (doppler_index - 1) * step(acq_plan.dopplers) +
             first(acq_plan.dopplers) +
             doppler_offset
+        code_doppler = doppler * get_code_center_frequency_ratio(acq_plan.system)
         code_phase =
             (code_index - 1) /
-            (acq_plan.sampling_freq / get_code_frequency(acq_plan.system))
+            (acq_plan.sampling_freq / (get_code_frequency(acq_plan.system) + code_doppler))
         result = AcquisitionResults(
             acq_plan.system,
             prn,
@@ -265,9 +266,10 @@ function acquire!(
             (doppler_index - 1) * step(fine_plan.dopplers) +
             first(fine_plan.dopplers) +
             doppler_offset
+        code_doppler = doppler * get_code_center_frequency_ratio(fine_plan.system)
         code_phase =
             (code_index - 1) /
-            (fine_plan.sampling_freq / get_code_frequency(fine_plan.system))
+            (fine_plan.sampling_freq / (get_code_frequency(fine_plan.system) + code_doppler))
         result = AcquisitionResults(
             fine_plan.system,
             prn,

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -23,10 +23,9 @@ replica codes across a grid of Doppler frequencies and code phases.
   - `doppler_step_factor`: Factor for computing Doppler step from integration time (default: `1//3`).
     The step is `doppler_step_factor / T` where `T = samples_to_integrate_coherently / sampling_freq`.
   - `dopplers`: Custom Doppler search range (default: computed from `doppler_step_factor`)
-  - `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
-    Controls how many code replicas are pre-computed at different code Doppler offsets.
-    Smaller values improve accuracy at high Dopplers with long integration times, at the
-    cost of more memory.
+  - `max_code_doppler_loss`: Maximum acceptable correlation loss in dB from code Doppler
+    mismatch (default: `0.5`). Controls how many code replicas are pre-computed at different
+    code Doppler offsets. Works uniformly across all GNSS systems regardless of chip rate.
 
 # Returns
 
@@ -59,7 +58,7 @@ function acquire(
     samples_to_integrate_coherently = ceil(Int, sampling_freq / get_data_frequency(system)),
     doppler_step_factor = 1//3,
     dopplers = min_doppler:(doppler_step_factor*sampling_freq/samples_to_integrate_coherently):max_doppler,
-    code_doppler_tolerance = 0.01,
+    max_code_doppler_loss = 0.5dB,
     zero_pad_power::Int = 1,
 )
     acq_plan = AcquisitionPlan(
@@ -69,7 +68,7 @@ function acquire(
         dopplers,
         prns,
         fft_flag = FFTW.MEASURE,
-        code_doppler_tolerance,
+        max_code_doppler_loss,
         zero_pad_power,
     )
     acquire!(acq_plan, signal, prns; interm_freq)
@@ -349,7 +348,7 @@ function acquire(
     samples_to_integrate_coherently = ceil(Int, sampling_freq / get_data_frequency(system)),
     doppler_step_factor = 1//3,
     dopplers = min_doppler:(doppler_step_factor*sampling_freq/samples_to_integrate_coherently):max_doppler,
-    code_doppler_tolerance = 0.01,
+    max_code_doppler_loss = 0.5dB,
     zero_pad_power::Int = 1,
 )
     only(
@@ -361,7 +360,7 @@ function acquire(
             interm_freq,
             dopplers,
             samples_to_integrate_coherently,
-            code_doppler_tolerance,
+            max_code_doppler_loss,
             zero_pad_power,
         ),
     )
@@ -414,10 +413,9 @@ resolution while reducing computational cost compared to a single high-resolutio
     The coarse step is `doppler_step_factor / T` where `T = samples_to_integrate_coherently / sampling_freq`.
   - `coarse_step`: Doppler step for coarse search (default: computed from `doppler_step_factor`)
   - `fine_step`: Doppler step for fine search (default: `coarse_step / 10`)
-  - `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
-    Controls how many code replicas are pre-computed at different code Doppler offsets.
-    Smaller values improve accuracy at high Dopplers with long integration times, at the
-    cost of more memory.
+  - `max_code_doppler_loss`: Maximum acceptable correlation loss in dB from code Doppler
+    mismatch (default: `0.5`). Controls how many code replicas are pre-computed at different
+    code Doppler offsets. Works uniformly across all GNSS systems regardless of chip rate.
 
 # Returns
 
@@ -446,7 +444,7 @@ function coarse_fine_acquire(
     doppler_step_factor = 1//3,
     coarse_step = doppler_step_factor * sampling_freq / samples_to_integrate_coherently,
     fine_step = coarse_step / 10,
-    code_doppler_tolerance = 0.01,
+    max_code_doppler_loss = 0.5dB,
     zero_pad_power::Int = 1,
 )
     acq_plan = CoarseFineAcquisitionPlan(
@@ -459,7 +457,7 @@ function coarse_fine_acquire(
         fine_step,
         prns,
         fft_flag = FFTW.MEASURE,
-        code_doppler_tolerance,
+        max_code_doppler_loss,
         zero_pad_power,
     )
     acquire!(acq_plan, signal, prns; interm_freq)
@@ -517,7 +515,7 @@ function coarse_fine_acquire(
     doppler_step_factor = 1//3,
     coarse_step = doppler_step_factor * sampling_freq / samples_to_integrate_coherently,
     fine_step = coarse_step / 10,
-    code_doppler_tolerance = 0.01,
+    max_code_doppler_loss = 0.5dB,
     zero_pad_power::Int = 1,
 )
     only(
@@ -532,7 +530,7 @@ function coarse_fine_acquire(
             samples_to_integrate_coherently,
             coarse_step,
             fine_step,
-            code_doppler_tolerance,
+            max_code_doppler_loss,
             zero_pad_power,
         ),
     )

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -65,6 +65,8 @@ function acquire(
         system,
         min(length(signal), samples_to_integrate_coherently),
         sampling_freq;
+        min_doppler,
+        max_doppler,
         dopplers,
         prns,
         fft_flag = FFTW.MEASURE,
@@ -147,7 +149,8 @@ function acquire!(
     end
     powers_per_sats = view(acq_plan.signal_powers, acq_plan.prn_indices)
 
-    effective_sampling_freq = acq_plan.sampling_freq * acq_plan.bfft_size / chunk_samples
+    effective_sampling_freq =
+        acq_plan.sampling_freq * acq_plan.bfft_size / acq_plan.linear_fft_size
 
     # resize! does not allocate when shrinking or staying within original capacity
     resize!(acq_plan.output_results, length(prns))
@@ -209,7 +212,8 @@ function acquire!(
     chunk_samples = fine_plan.num_samples_to_integrate_coherently
     num_signal_samples = length(signal)
     num_chunks = cld(num_signal_samples, chunk_samples)
-    effective_sampling_freq = fine_plan.sampling_freq * fine_plan.bfft_size / chunk_samples
+    effective_sampling_freq =
+        fine_plan.sampling_freq * fine_plan.bfft_size / fine_plan.linear_fft_size
 
     # resize! does not allocate when shrinking or staying within original capacity
     resize!(fine_plan.output_results, length(prns))
@@ -357,6 +361,8 @@ function acquire(
             sampling_freq,
             [prn];
             interm_freq,
+            min_doppler,
+            max_doppler,
             dopplers,
             samples_to_integrate_coherently,
             max_code_doppler_loss,

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -224,12 +224,11 @@ function acquire!(
 
         ratio = get_code_center_frequency_ratio(fine_plan.system)
         @inbounds for (doppler_idx, doppler) in enumerate(fine_plan.dopplers)
-            cd_idx = clamp(
-                round(
-                    Int,
-                    ustrip(doppler + doppler_offset) * ratio / fine_plan.code_doppler_step,
-                ) + fine_plan.code_doppler_offset_idx,
-                1,
+            cd_idx = code_doppler_index(
+                ustrip(doppler + doppler_offset),
+                ratio,
+                fine_plan.code_doppler_step,
+                fine_plan.code_doppler_offset_idx,
                 fine_plan.num_code_dopplers,
             )
             # Process signal in chunks, accumulating powers non-coherently

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -58,8 +58,9 @@ function acquire(
     min_doppler = -max_doppler,
     samples_to_integrate_coherently = ceil(Int, sampling_freq / get_data_frequency(system)),
     doppler_step_factor = 1//3,
-    dopplers = min_doppler:(doppler_step_factor * sampling_freq / samples_to_integrate_coherently):max_doppler,
+    dopplers = min_doppler:(doppler_step_factor*sampling_freq/samples_to_integrate_coherently):max_doppler,
     code_doppler_tolerance = 0.01,
+    zero_pad_power::Int = 1,
 )
     acq_plan = AcquisitionPlan(
         system,
@@ -69,6 +70,7 @@ function acquire(
         prns,
         fft_flag = FFTW.MEASURE,
         code_doppler_tolerance,
+        zero_pad_power,
     )
     acquire!(acq_plan, signal, prns; interm_freq)
 end
@@ -146,13 +148,15 @@ function acquire!(
     end
     powers_per_sats = view(acq_plan.signal_powers, acq_plan.prn_indices)
 
+    effective_sampling_freq = acq_plan.sampling_freq * acq_plan.bfft_size / chunk_samples
+
     # resize! does not allocate when shrinking or staying within original capacity
     resize!(acq_plan.output_results, length(prns))
     for (i, (powers, prn, prn_idx)) in
         enumerate(zip(powers_per_sats, prns, acq_plan.prn_indices))
         signal_power, noise_power_est, code_index, doppler_index = est_signal_noise_power(
             powers,
-            acq_plan.sampling_freq,
+            effective_sampling_freq,
             get_code_frequency(acq_plan.system),
             noise_power,
         )
@@ -167,11 +171,11 @@ function acquire!(
         code_doppler = doppler * get_code_center_frequency_ratio(acq_plan.system)
         code_phase =
             (code_index - 1) /
-            (acq_plan.sampling_freq / (get_code_frequency(acq_plan.system) + code_doppler))
+            (effective_sampling_freq / (get_code_frequency(acq_plan.system) + code_doppler))
         result = AcquisitionResults(
             acq_plan.system,
             prn,
-            acq_plan.sampling_freq,
+            effective_sampling_freq,
             doppler,
             code_phase,
             CN0,
@@ -206,6 +210,7 @@ function acquire!(
     chunk_samples = fine_plan.num_samples_to_integrate_coherently
     num_signal_samples = length(signal)
     num_chunks = cld(num_signal_samples, chunk_samples)
+    effective_sampling_freq = fine_plan.sampling_freq * fine_plan.bfft_size / chunk_samples
 
     # resize! does not allocate when shrinking or staying within original capacity
     resize!(fine_plan.output_results, length(prns))
@@ -221,8 +226,12 @@ function acquire!(
         ratio = get_code_center_frequency_ratio(fine_plan.system)
         @inbounds for (doppler_idx, doppler) in enumerate(fine_plan.dopplers)
             cd_idx = clamp(
-                round(Int, ustrip(doppler + doppler_offset) * ratio / fine_plan.code_doppler_step) + fine_plan.code_doppler_offset_idx,
-                1, fine_plan.num_code_dopplers
+                round(
+                    Int,
+                    ustrip(doppler + doppler_offset) * ratio / fine_plan.code_doppler_step,
+                ) + fine_plan.code_doppler_offset_idx,
+                1,
+                fine_plan.num_code_dopplers,
             )
             # Process signal in chunks, accumulating powers non-coherently
             for chunk_idx = 1:num_chunks
@@ -239,7 +248,7 @@ function acquire!(
                     fine_plan.code_baseband,
                     signal_chunk,
                     fine_plan.fft_plan,
-                    fine_plan.ifft_plan,
+                    fine_plan.bfft_plan,
                     codes_freq_domain_view,
                     cd_idx,
                     doppler + doppler_offset,
@@ -254,7 +263,7 @@ function acquire!(
         powers = fine_plan.signal_powers[prn_idx]
         signal_power, noise_power_est, code_index, doppler_index = est_signal_noise_power(
             powers,
-            fine_plan.sampling_freq,
+            effective_sampling_freq,
             get_code_frequency(fine_plan.system),
             noise_power,
         )
@@ -268,12 +277,14 @@ function acquire!(
             doppler_offset
         code_doppler = doppler * get_code_center_frequency_ratio(fine_plan.system)
         code_phase =
-            (code_index - 1) /
-            (fine_plan.sampling_freq / (get_code_frequency(fine_plan.system) + code_doppler))
+            (code_index - 1) / (
+                effective_sampling_freq /
+                (get_code_frequency(fine_plan.system) + code_doppler)
+            )
         result = AcquisitionResults(
             fine_plan.system,
             prn,
-            fine_plan.sampling_freq,
+            effective_sampling_freq,
             doppler,
             code_phase,
             CN0,
@@ -337,10 +348,23 @@ function acquire(
     min_doppler = -max_doppler,
     samples_to_integrate_coherently = ceil(Int, sampling_freq / get_data_frequency(system)),
     doppler_step_factor = 1//3,
-    dopplers = min_doppler:(doppler_step_factor * sampling_freq / samples_to_integrate_coherently):max_doppler,
+    dopplers = min_doppler:(doppler_step_factor*sampling_freq/samples_to_integrate_coherently):max_doppler,
     code_doppler_tolerance = 0.01,
+    zero_pad_power::Int = 1,
 )
-    only(acquire(system, signal, sampling_freq, [prn]; interm_freq, dopplers, samples_to_integrate_coherently, code_doppler_tolerance))
+    only(
+        acquire(
+            system,
+            signal,
+            sampling_freq,
+            [prn];
+            interm_freq,
+            dopplers,
+            samples_to_integrate_coherently,
+            code_doppler_tolerance,
+            zero_pad_power,
+        ),
+    )
 end
 
 function acquire!(
@@ -423,6 +447,7 @@ function coarse_fine_acquire(
     coarse_step = doppler_step_factor * sampling_freq / samples_to_integrate_coherently,
     fine_step = coarse_step / 10,
     code_doppler_tolerance = 0.01,
+    zero_pad_power::Int = 1,
 )
     acq_plan = CoarseFineAcquisitionPlan(
         system,
@@ -435,6 +460,7 @@ function coarse_fine_acquire(
         prns,
         fft_flag = FFTW.MEASURE,
         code_doppler_tolerance,
+        zero_pad_power,
     )
     acquire!(acq_plan, signal, prns; interm_freq)
 end
@@ -492,6 +518,7 @@ function coarse_fine_acquire(
     coarse_step = doppler_step_factor * sampling_freq / samples_to_integrate_coherently,
     fine_step = coarse_step / 10,
     code_doppler_tolerance = 0.01,
+    zero_pad_power::Int = 1,
 )
     only(
         coarse_fine_acquire(
@@ -506,6 +533,7 @@ function coarse_fine_acquire(
             coarse_step,
             fine_step,
             code_doppler_tolerance,
+            zero_pad_power,
         ),
     )
 end

--- a/src/calc_powers.jl
+++ b/src/calc_powers.jl
@@ -19,12 +19,11 @@ function power_over_doppler_and_codes!(
         cd_idx = if iszero(ustrip(doppler_offset))
             acq_plan.code_doppler_indices[doppler_idx]
         else
-            clamp(
-                round(
-                    Int,
-                    ustrip(doppler + doppler_offset) * ratio / acq_plan.code_doppler_step,
-                ) + acq_plan.code_doppler_offset_idx,
-                1,
+            code_doppler_index(
+                ustrip(doppler + doppler_offset),
+                ratio,
+                acq_plan.code_doppler_step,
+                acq_plan.code_doppler_offset_idx,
                 acq_plan.num_code_dopplers,
             )
         end
@@ -122,43 +121,4 @@ function power_over_code!(
             signal_power_col .= abs2.(code_baseband_view)
         end
     end
-end
-
-# Backward-compatible method: when codes_freq_domain is a flat Vector{Vector}
-# (no code Doppler dimension), wrap each entry and delegate to the new method.
-function power_over_code!(
-    signal_powers,
-    doppler_idx,
-    signal_baseband,
-    signal_baseband_freq_domain,
-    code_freq_baseband_freq_domain,
-    code_baseband,
-    signal,
-    fft_plan,
-    bfft_plan,
-    codes_freq_domain,
-    doppler,
-    sampling_freq,
-    interm_freq;
-    accumulate = false,
-)
-    # Wrap each code vector in a single-element vector to match the new nested format
-    wrapped_codes = [[c] for c in codes_freq_domain]
-    power_over_code!(
-        signal_powers,
-        doppler_idx,
-        signal_baseband,
-        signal_baseband_freq_domain,
-        code_freq_baseband_freq_domain,
-        code_baseband,
-        signal,
-        fft_plan,
-        bfft_plan,
-        wrapped_codes,
-        1,
-        doppler,
-        sampling_freq,
-        interm_freq;
-        accumulate,
-    )
 end

--- a/src/calc_powers.jl
+++ b/src/calc_powers.jl
@@ -20,8 +20,12 @@ function power_over_doppler_and_codes!(
             acq_plan.code_doppler_indices[doppler_idx]
         else
             clamp(
-                round(Int, ustrip(doppler + doppler_offset) * ratio / acq_plan.code_doppler_step) + acq_plan.code_doppler_offset_idx,
-                1, acq_plan.num_code_dopplers
+                round(
+                    Int,
+                    ustrip(doppler + doppler_offset) * ratio / acq_plan.code_doppler_step,
+                ) + acq_plan.code_doppler_offset_idx,
+                1,
+                acq_plan.num_code_dopplers,
             )
         end
         power_over_code!(
@@ -33,7 +37,7 @@ function power_over_doppler_and_codes!(
             acq_plan.code_baseband,
             signal,
             acq_plan.fft_plan,
-            acq_plan.ifft_plan,
+            acq_plan.bfft_plan,
             codes_freq_domain_view,
             cd_idx,
             doppler + doppler_offset,
@@ -54,7 +58,7 @@ function power_over_code!(
     code_baseband,
     signal,
     fft_plan,
-    ifft_plan,
+    bfft_plan,
     codes_freq_domain,
     code_doppler_idx::Int,
     doppler,
@@ -64,18 +68,51 @@ function power_over_code!(
 )
     signal_samples = length(signal)
     buffer_length = length(signal_baseband)
+    bfft_length = length(code_freq_baseband_freq_domain)
     # Zero-pad remaining samples if signal is shorter than buffer
     if signal_samples < buffer_length
-        signal_baseband[signal_samples+1:buffer_length] .= zero(eltype(signal_baseband))
+        signal_baseband[(signal_samples+1):buffer_length] .= zero(eltype(signal_baseband))
     end
     # Downconvert actual signal samples
-    downconvert!(signal_baseband, signal, interm_freq + doppler, sampling_freq, signal_samples)
+    downconvert!(
+        signal_baseband,
+        signal,
+        interm_freq + doppler,
+        sampling_freq,
+        signal_samples,
+    )
     mul!(signal_baseband_freq_domain, fft_plan, signal_baseband)
-    @inbounds for (code_freq_domain_variants, signal_power) in zip(codes_freq_domain, signal_powers)
+    # When zero-padding, zero the middle gap once before the PRN loop.
+    # Positive freqs (1..pos_end) and negative freqs (bfft_length-neg_count+1..bfft_length)
+    # are overwritten each iteration, so only the gap in between needs to stay zero.
+    if bfft_length > buffer_length
+        pos_end = buffer_length ÷ 2 + 1
+        neg_count = buffer_length - pos_end
+        gap_start = pos_end + 1
+        gap_end = bfft_length - neg_count
+        @inbounds for i = gap_start:gap_end
+            code_freq_baseband_freq_domain[i] = zero(eltype(code_freq_baseband_freq_domain))
+        end
+    end
+    @inbounds for (code_freq_domain_variants, signal_power) in
+                  zip(codes_freq_domain, signal_powers)
         code_freq_domain = code_freq_domain_variants[code_doppler_idx]
-        code_freq_baseband_freq_domain .=
-            code_freq_domain .* conj.(signal_baseband_freq_domain)
-        mul!(code_baseband, ifft_plan, code_freq_baseband_freq_domain)
+        if bfft_length > buffer_length
+            neg_dest_start = bfft_length - neg_count
+            @inbounds for i = 1:pos_end
+                code_freq_baseband_freq_domain[i] =
+                    code_freq_domain[i] * conj(signal_baseband_freq_domain[i])
+            end
+            @inbounds for i = 1:neg_count
+                code_freq_baseband_freq_domain[neg_dest_start+i] =
+                    code_freq_domain[pos_end+i] *
+                    conj(signal_baseband_freq_domain[pos_end+i])
+            end
+        else
+            code_freq_baseband_freq_domain .=
+                code_freq_domain .* conj.(signal_baseband_freq_domain)
+        end
+        mul!(code_baseband, bfft_plan, code_freq_baseband_freq_domain)
         num_code_samples = size(signal_power, 1)
         signal_power_col = view(signal_power, :, doppler_idx)
         code_baseband_view = view(code_baseband, 1:num_code_samples)
@@ -98,7 +135,7 @@ function power_over_code!(
     code_baseband,
     signal,
     fft_plan,
-    ifft_plan,
+    bfft_plan,
     codes_freq_domain,
     doppler,
     sampling_freq,
@@ -116,7 +153,7 @@ function power_over_code!(
         code_baseband,
         signal,
         fft_plan,
-        ifft_plan,
+        bfft_plan,
         wrapped_codes,
         1,
         doppler,

--- a/src/calc_powers.jl
+++ b/src/calc_powers.jl
@@ -68,10 +68,8 @@ function power_over_code!(
     signal_samples = length(signal)
     buffer_length = length(signal_baseband)
     bfft_length = length(code_freq_baseband_freq_domain)
-    # Zero-pad remaining samples if signal is shorter than buffer
-    if signal_samples < buffer_length
-        signal_baseband[(signal_samples+1):buffer_length] .= zero(eltype(signal_baseband))
-    end
+    # Zero-pad the portion beyond the signal (DBZP: buffer is 2N, signal is ≤ N)
+    signal_baseband[(signal_samples+1):buffer_length] .= zero(eltype(signal_baseband))
     # Downconvert actual signal samples
     downconvert!(
         signal_baseband,

--- a/src/ka_acquire.jl
+++ b/src/ka_acquire.jl
@@ -46,12 +46,16 @@ results = acquire!(plan, signal_gpu, 1:32)
 # See also
 [`acquire!`](@ref), [`AcquisitionPlan`](@ref)
 """
-struct KAAcquisitionPlan{T,S<:AbstractGNSS,A1<:AbstractVector,A2<:AbstractMatrix,A3<:AbstractMatrix,AI<:AbstractVector{Int},P,BP}
+struct KAAcquisitionPlan{T,S<:AbstractGNSS,A1<:AbstractVector,A2<:AbstractMatrix,A3<:AbstractMatrix,A4<:AbstractArray,AI<:AbstractVector{Int},P,BP}
     system::S
     num_samples_to_integrate_coherently::Int
     dopplers::StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}
     sampling_frequency::typeof(1.0Hz)
-    codes_freq_domain::A2                   # (samples × prns)
+    codes_freq_domain::A4                   # (samples × prns × code_dopplers)
+    code_doppler_indices::Vector{Int}       # maps doppler_idx → code_doppler_idx
+    code_doppler_step::Float64              # code Doppler step in Hz
+    code_doppler_offset_idx::Int            # index of zero code Doppler
+    num_code_dopplers::Int                  # total number of code Doppler bins
     dopplers_gpu::A1                        # Doppler frequencies on GPU (num_dopplers,)
     downconvert_phases::A2                  # Precomputed phase factors (samples × dopplers)
     signal_baseband::A2                     # (samples × dopplers)
@@ -113,6 +117,7 @@ function KAAcquisitionPlan(
     doppler_step_factor=1//3,
     doppler_step=doppler_step_factor * sampling_freq / num_samples_to_integrate_coherently,
     dopplers=min_doppler:doppler_step:max_doppler,
+    code_doppler_tolerance=0.01,
     prns=1:34,
 ) where {T<:AbstractFloat,S<:AbstractGNSS}
     # Normalize dopplers to Float64 StepRangeLen for consistency
@@ -120,11 +125,23 @@ function KAAcquisitionPlan(
     num_dopplers = length(dopplers_hz)
     num_prns = length(prns)
 
-    # Generate replica codes on CPU
-    codes_cpu = reduce(hcat, [
-        gen_code(num_samples_to_integrate_coherently, system, prn, sampling_freq)
-        for prn in prns
-    ])  # (num_samples_to_integrate_coherently × num_prns)
+    # Code Doppler grid (reuse helpers from plan_acquire.jl)
+    T_coh = num_samples_to_integrate_coherently / sampling_freq
+    code_doppler_step_val = code_doppler_tolerance / ustrip(T_coh)
+    code_dopplers_grid, n_neg = compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step_val)
+    code_doppler_offset_idx = n_neg + 1
+    num_code_dopplers_val = length(code_dopplers_grid)
+    code_doppler_indices = compute_code_doppler_indices(dopplers_hz, system, code_doppler_step_val, code_doppler_offset_idx, num_code_dopplers_val)
+
+    # Generate 3D codes on CPU: (samples × num_prns × num_code_dopplers)
+    codes_cpu = Array{T}(undef, num_samples_to_integrate_coherently, num_prns, num_code_dopplers_val)
+    for (cd_idx, cd) in enumerate(code_dopplers_grid)
+        for (p_idx, prn) in enumerate(prns)
+            codes_cpu[:, p_idx, cd_idx] .= gen_code(
+                num_samples_to_integrate_coherently, system, prn, sampling_freq,
+                get_code_frequency(system) + cd * 1.0Hz)
+        end
+    end
 
     # Store Doppler frequencies on GPU (small vector for kernel when offset needed)
     dopplers_gpu = ArrayType{T}(collect(T, dopplers_hz))
@@ -168,20 +185,25 @@ function KAAcquisitionPlan(
     bfft_plan = plan_bfft(code_baseband_freq_domain, 1)
 
     # Transform codes to frequency domain
-    # First transfer to GPU, then apply FFT plan on a reshaped view
+    # Transfer 3D array to GPU and FFT each (sample) column
     codes_gpu = ArrayType{Complex{T}}(codes_cpu)
-    # Apply 1D FFT to each column - reshape to match signal_baseband dimensions temporarily
     codes_freq_domain = similar(codes_gpu)
-    for p in 1:num_prns
-        codes_freq_domain[:, p] .= fft(view(codes_gpu, :, p))
+    for cd_idx in 1:num_code_dopplers_val
+        for p_idx in 1:num_prns
+            codes_freq_domain[:, p_idx, cd_idx] .= fft(view(codes_gpu, :, p_idx, cd_idx))
+        end
     end
 
-    KAAcquisitionPlan{T,S,typeof(dopplers_gpu),typeof(codes_freq_domain),typeof(power_buffer),typeof(findmax_idxs_gpu),typeof(fft_plan),typeof(bfft_plan)}(
+    KAAcquisitionPlan{T,S,typeof(dopplers_gpu),typeof(signal_baseband),typeof(power_buffer),typeof(codes_freq_domain),typeof(findmax_idxs_gpu),typeof(fft_plan),typeof(bfft_plan)}(
         system,
         num_samples_to_integrate_coherently,
         dopplers_hz,
         sampling_freq,
         codes_freq_domain,
+        code_doppler_indices,
+        code_doppler_step_val,
+        code_doppler_offset_idx,
+        num_code_dopplers_val,
         dopplers_gpu,
         downconvert_phases,
         signal_baseband,
@@ -382,6 +404,22 @@ function acquire!(
     # Get PRN indices upfront
     prn_indices = [findfirst(==(prn), plan.avail_prn_channels) for prn in prns]
     num_prns = length(prns)
+    num_dopplers = length(plan.dopplers)
+    dopplers_hz = plan.dopplers
+
+    # Compute active code Doppler indices (handle doppler_offset)
+    active_cd_indices = if !iszero(ustrip(doppler_offset))
+        ratio = get_code_center_frequency_ratio(plan.system)
+        [
+            clamp(
+                round(Int, (dopplers_hz[d] + Float64(ustrip(doppler_offset))) * ratio / plan.code_doppler_step) + plan.code_doppler_offset_idx,
+                1, plan.num_code_dopplers
+            )
+            for d in 1:num_dopplers
+        ]
+    else
+        plan.code_doppler_indices
+    end
 
     # Allocate per-PRN power accumulators (reuse power_buffer for first PRN, allocate rest)
     # We need to track accumulated powers per PRN across chunks
@@ -426,9 +464,18 @@ function acquire!(
 
         # 3-5. Process each PRN with the already-transformed signal
         for (p_idx, prn_idx) in enumerate(prn_indices)
-            # 3. Code multiplication for this PRN
-            plan.code_baseband_freq_domain .=
-                view(plan.codes_freq_domain, :, prn_idx) .* conj.(plan.signal_baseband_freq_domain)
+            # 3. Code multiplication for this PRN, grouped by code Doppler index
+            group_start = 1
+            for d_idx in 1:num_dopplers
+                cd_idx = active_cd_indices[d_idx]
+                if d_idx == num_dopplers || active_cd_indices[d_idx + 1] != cd_idx
+                    code_col = view(plan.codes_freq_domain, :, prn_idx, cd_idx)
+                    doppler_range = group_start:d_idx
+                    view(plan.code_baseband_freq_domain, :, doppler_range) .=
+                        code_col .* conj.(view(plan.signal_baseband_freq_domain, :, doppler_range))
+                    group_start = d_idx + 1
+                end
+            end
 
             # 4. Backward FFT
             mul!(plan.code_baseband, plan.bfft_plan, plan.code_baseband_freq_domain)

--- a/src/ka_acquire.jl
+++ b/src/ka_acquire.jl
@@ -95,6 +95,10 @@ Create a GPU-accelerated acquisition plan.
   `T = num_samples_to_integrate_coherently / sampling_freq`)
 - `doppler_step_factor`: Factor for computing Doppler step from integration time (default: `1//3`)
 - `prns`: PRN channels to prepare (default: `1:34`)
+- `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
+  Controls how many code replicas are pre-computed at different code Doppler offsets.
+  Smaller values improve accuracy at high Dopplers with long integration times, at the
+  cost of more memory.
 
 # Example
 ```julia

--- a/src/ka_acquire.jl
+++ b/src/ka_acquire.jl
@@ -63,6 +63,7 @@ struct KAAcquisitionPlan{
 }
     system::S
     num_samples_to_integrate_coherently::Int
+    linear_fft_size::Int
     bfft_size::Int
     dopplers::StepRangeLen{
         Float64,
@@ -146,7 +147,7 @@ function KAAcquisitionPlan(
     dopplers = min_doppler:doppler_step:max_doppler,
     max_code_doppler_loss = 0.5dB,
     prns = 1:34,
-    zero_pad_power::Int = 1,
+    zero_pad_power::Int = 0,
 ) where {T<:AbstractFloat,S<:AbstractGNSS}
     # Normalize dopplers to Float64 StepRangeLen for consistency
     dopplers_hz =
@@ -156,10 +157,10 @@ function KAAcquisitionPlan(
     num_dopplers = length(dopplers_hz)
     num_prns = length(prns)
 
-    bfft_size =
-        zero_pad_power > 0 ?
-        fftw_friendly_size(num_samples_to_integrate_coherently) << (zero_pad_power - 1) :
-        num_samples_to_integrate_coherently
+    # Double Block Zero Padding (DBZP): pad to >= 2N for linear correlation
+    # (same as CPU path in AcquisitionPlan)
+    linear_fft_size = fftw_friendly_size(2 * num_samples_to_integrate_coherently)
+    bfft_size = fftw_friendly_size(linear_fft_size << zero_pad_power)
 
     # Convert dB loss to max phase error (cycles), then to code Doppler step (Hz)
     T_coh = num_samples_to_integrate_coherently / sampling_freq
@@ -177,16 +178,12 @@ function KAAcquisitionPlan(
         num_code_dopplers_val,
     )
 
-    # Generate 3D codes on CPU: (samples × num_prns × num_code_dopplers)
-    codes_cpu = Array{T}(
-        undef,
-        num_samples_to_integrate_coherently,
-        num_prns,
-        num_code_dopplers_val,
-    )
+    # Generate 3D codes on CPU: (linear_fft_size × num_prns × num_code_dopplers)
+    # Zero-pad codes from N to linear_fft_size for DBZP linear correlation
+    codes_cpu = zeros(T, linear_fft_size, num_prns, num_code_dopplers_val)
     for (cd_idx, cd) in enumerate(code_dopplers_grid)
         for (p_idx, prn) in enumerate(prns)
-            codes_cpu[:, p_idx, cd_idx] .= gen_code(
+            codes_cpu[1:num_samples_to_integrate_coherently, p_idx, cd_idx] .= gen_code(
                 num_samples_to_integrate_coherently,
                 system,
                 prn,
@@ -201,26 +198,27 @@ function KAAcquisitionPlan(
 
     # Precompute downconversion phase factors on CPU, then transfer to GPU
     # phase[i,d] = cis(-2π * doppler[d] * (i-1) / sampling_freq)
+    # Only N phases needed; indices N+1:linear_fft_size are zero-padded (DBZP)
     sampling_freq_val = T(ustrip(sampling_freq))
     downconvert_phases_cpu = [
-        cis(T(-2) * T(π) * T(dopplers_hz[d]) * T(i - 1) / sampling_freq_val) for
-        i = 1:num_samples_to_integrate_coherently, d = 1:num_dopplers
+        i <= num_samples_to_integrate_coherently ?
+        cis(T(-2) * T(π) * T(dopplers_hz[d]) * T(i - 1) / sampling_freq_val) :
+        zero(Complex{T}) for i = 1:linear_fft_size, d = 1:num_dopplers
     ]
     downconvert_phases = ArrayType{Complex{T}}(downconvert_phases_cpu)
 
     # Allocate buffers on GPU - use 2D arrays to reduce memory (reused per PRN)
-    signal_baseband =
-        ArrayType{Complex{T}}(undef, num_samples_to_integrate_coherently, num_dopplers)
+    # Signal buffers are linear_fft_size (DBZP: 2N) for forward FFT
+    signal_baseband = ArrayType{Complex{T}}(undef, linear_fft_size, num_dopplers)
     signal_baseband_freq_domain = similar(signal_baseband)
-    # BFFT buffers are sized at bfft_size for zero-padding
+    # BFFT buffers are sized at bfft_size for additional zero-padding
     code_baseband_freq_domain = ArrayType{Complex{T}}(undef, bfft_size, num_dopplers)
     code_baseband = similar(code_baseband_freq_domain)
 
     # Preallocate power buffer using effective sampling freq for proper row count
     Δt = num_samples_to_integrate_coherently / sampling_freq
     code_period = get_code_length(system) / get_code_frequency(system)
-    effective_sampling_freq =
-        sampling_freq * bfft_size / num_samples_to_integrate_coherently
+    effective_sampling_freq = sampling_freq * bfft_size / linear_fft_size
     num_code_samples = ceil(Int, effective_sampling_freq * min(Δt, code_period))
     power_buffer = ArrayType{T}(undef, num_code_samples, num_dopplers)
     power_accumulator = ArrayType{T}(undef, num_code_samples, num_dopplers)
@@ -263,6 +261,7 @@ function KAAcquisitionPlan(
     }(
         system,
         num_samples_to_integrate_coherently,
+        linear_fft_size,
         bfft_size,
         dopplers_hz,
         sampling_freq,
@@ -485,7 +484,7 @@ function acquire!(
     num_chunks = cld(num_signal_samples, chunk_samples)
     code_period = get_code_length(plan.system) / get_code_frequency(plan.system)
     Δt = chunk_samples / plan.sampling_frequency
-    effective_sampling_freq = plan.sampling_frequency * plan.bfft_size / chunk_samples
+    effective_sampling_freq = plan.sampling_frequency * plan.bfft_size / plan.linear_fft_size
     num_code_samples = ceil(Int, effective_sampling_freq * min(Δt, code_period))
     samples_per_chip = floor(Int, effective_sampling_freq / get_code_frequency(plan.system))
     backend = get_backend(plan.signal_baseband)
@@ -529,13 +528,12 @@ function acquire!(
         signal_chunk = view(signal, start_idx:end_idx)
 
         # 1. Batched downconversion for this chunk (ONCE per chunk, not per PRN)
-        # Zero-pad for partial chunks
-        if actual_chunk_size < chunk_samples
-            plan.signal_baseband .= zero(eltype(plan.signal_baseband))
-        end
+        # Zero the full buffer (DBZP: signal_baseband is linear_fft_size ≈ 2N,
+        # only first actual_chunk_size samples get signal data)
+        plan.signal_baseband .= zero(eltype(plan.signal_baseband))
 
         if iszero(ustrip(interm_freq)) && iszero(ustrip(doppler_offset))
-            # Fast path: use precomputed phases
+            # Fast path: use precomputed phases (phases beyond N are already zero)
             signal_view = view(plan.signal_baseband, 1:actual_chunk_size, :)
             phases_view = view(plan.downconvert_phases, 1:actual_chunk_size, :)
             signal_view .= signal_chunk .* phases_view
@@ -557,7 +555,7 @@ function acquire!(
         mul!(plan.signal_baseband_freq_domain, plan.fft_plan, plan.signal_baseband)
 
         # 3-5. Process each PRN with the already-transformed signal
-        N = chunk_samples
+        N = plan.linear_fft_size
         N_pad = plan.bfft_size
         needs_padding = N_pad > N
         for (p_idx, prn_idx) in enumerate(prn_indices)

--- a/src/ka_acquire.jl
+++ b/src/ka_acquire.jl
@@ -505,13 +505,11 @@ function acquire!(
     active_cd_indices = if !iszero(ustrip(doppler_offset))
         ratio = get_code_center_frequency_ratio(plan.system)
         [
-            clamp(
-                round(
-                    Int,
-                    (dopplers_hz[d] + Float64(ustrip(doppler_offset))) * ratio /
-                    plan.code_doppler_step,
-                ) + plan.code_doppler_offset_idx,
-                1,
+            code_doppler_index(
+                dopplers_hz[d] + Float64(ustrip(doppler_offset)),
+                ratio,
+                plan.code_doppler_step,
+                plan.code_doppler_offset_idx,
                 plan.num_code_dopplers,
             ) for d = 1:num_dopplers
         ]

--- a/src/ka_acquire.jl
+++ b/src/ka_acquire.jl
@@ -116,10 +116,9 @@ Create a GPU-accelerated acquisition plan.
     `T = num_samples_to_integrate_coherently / sampling_freq`)
   - `doppler_step_factor`: Factor for computing Doppler step from integration time (default: `1//3`)
   - `prns`: PRN channels to prepare (default: `1:34`)
-  - `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
-    Controls how many code replicas are pre-computed at different code Doppler offsets.
-    Smaller values improve accuracy at high Dopplers with long integration times, at the
-    cost of more memory.
+  - `max_code_doppler_loss`: Maximum acceptable correlation loss in dB from code Doppler
+    mismatch (default: `0.5`). Controls how many code replicas are pre-computed at different
+    code Doppler offsets. Works uniformly across all GNSS systems regardless of chip rate.
 
 # Example
 
@@ -145,7 +144,7 @@ function KAAcquisitionPlan(
     doppler_step = doppler_step_factor * sampling_freq /
                    num_samples_to_integrate_coherently,
     dopplers = min_doppler:doppler_step:max_doppler,
-    code_doppler_tolerance = 0.01,
+    max_code_doppler_loss = 0.5dB,
     prns = 1:34,
     zero_pad_power::Int = 1,
 ) where {T<:AbstractFloat,S<:AbstractGNSS}
@@ -162,9 +161,10 @@ function KAAcquisitionPlan(
         fftw_friendly_size(num_samples_to_integrate_coherently) << (zero_pad_power - 1) :
         num_samples_to_integrate_coherently
 
-    # Code Doppler grid (reuse helpers from plan_acquire.jl)
+    # Convert dB loss to max phase error (cycles), then to code Doppler step (Hz)
     T_coh = num_samples_to_integrate_coherently / sampling_freq
-    code_doppler_step_val = code_doppler_tolerance / ustrip(T_coh)
+    max_phase_err = max_phase_error_from_loss(max_code_doppler_loss)
+    code_doppler_step_val = max_phase_err > 0 ? max_phase_err / ustrip(T_coh) : Inf
     code_dopplers_grid, n_neg =
         compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step_val)
     code_doppler_offset_idx = n_neg + 1

--- a/src/ka_acquire.jl
+++ b/src/ka_acquire.jl
@@ -120,6 +120,9 @@ Create a GPU-accelerated acquisition plan.
   - `max_code_doppler_loss`: Maximum acceptable correlation loss in dB from code Doppler
     mismatch (default: `0.5`). Controls how many code replicas are pre-computed at different
     code Doppler offsets. Works uniformly across all GNSS systems regardless of chip rate.
+  - `fft_flag`: FFTW planning flag for CPU Arrays (default: `FFTW.MEASURE`). Ignored for
+    GPU arrays. `FFTW.MEASURE` spends extra time during plan creation to find the fastest
+    FFT algorithm for the given size, then caches the result via FFTW wisdom.
 
 # Example
 
@@ -148,6 +151,7 @@ function KAAcquisitionPlan(
     max_code_doppler_loss = 0.5dB,
     prns = 1:34,
     zero_pad_power::Int = 0,
+    fft_flag = FFTW.MEASURE,
 ) where {T<:AbstractFloat,S<:AbstractGNSS}
     # Normalize dopplers to Float64 StepRangeLen for consistency
     dopplers_hz =
@@ -232,11 +236,20 @@ function KAAcquisitionPlan(
     sum_buffer_gpu = ArrayType{T}(undef, num_reduction_threads)
     sum_buffer_cpu = Vector{T}(undef, num_reduction_threads)         # CPU side for final reduction
 
-    # Create FFT plans using AbstractFFTs (will use cuFFT/rocFFT etc.)
-    # Plan along dimension 1 (samples) — FFT on original-size signal
-    fft_plan = plan_fft(signal_baseband, 1)
-    # BFFT plan on the (possibly padded) buffer
-    bfft_plan = plan_bfft(code_baseband_freq_domain, 1)
+    # Create FFT plans. For CPU Arrays, use FFTW with configurable planning flags
+    # (MEASURE/PATIENT find faster algorithms). For GPU arrays, use AbstractFFTs
+    # which delegates to cuFFT/rocFFT (no planning flags needed).
+    fft_plan, bfft_plan = if ArrayType <: Array && fft_flag != FFTW.ESTIMATE
+        with_fftw_wisdom() do
+            plan_fft(signal_baseband, 1; flags = fft_flag),
+            plan_bfft(code_baseband_freq_domain, 1; flags = fft_flag)
+        end
+    elseif ArrayType <: Array
+        plan_fft(signal_baseband, 1; flags = fft_flag),
+        plan_bfft(code_baseband_freq_domain, 1; flags = fft_flag)
+    else
+        plan_fft(signal_baseband, 1), plan_bfft(code_baseband_freq_domain, 1)
+    end
 
     # Transform codes to frequency domain
     # Transfer 3D array to GPU and FFT each (sample) column
@@ -516,29 +529,112 @@ function acquire!(
         plan.code_doppler_indices
     end
 
-    # Allocate per-PRN power accumulators (reuse power_buffer for first PRN, allocate rest)
-    # We need to track accumulated powers per PRN across chunks
+    N = plan.linear_fft_size
+    N_pad = plan.bfft_size
+    needs_padding = N_pad > N
+
+    # For single-chunk signals, process each PRN inline to avoid allocating
+    # per-PRN power matrices (~10 MiB each). Instead, reuse plan.power_buffer.
+    if num_chunks == 1
+        signal_chunk = view(signal, 1:min(chunk_samples, num_signal_samples))
+        actual_chunk_size = length(signal_chunk)
+
+        # 1. Batched downconversion
+        # Zero only the DBZP pad region (signal region will be overwritten by downconvert)
+        if actual_chunk_size < size(plan.signal_baseband, 1)
+            view(plan.signal_baseband, (actual_chunk_size+1):size(plan.signal_baseband, 1), :) .=
+                zero(eltype(plan.signal_baseband))
+        end
+
+        if iszero(ustrip(interm_freq)) && iszero(ustrip(doppler_offset))
+            signal_view = view(plan.signal_baseband, 1:actual_chunk_size, :)
+            phases_view = view(plan.downconvert_phases, 1:actual_chunk_size, :)
+            signal_view .= signal_chunk .* phases_view
+        else
+            freq_offset = T(ustrip(doppler_offset + interm_freq))
+            inv_sampling_freq = T(1.0 / ustrip(plan.sampling_frequency))
+            ka_downconvert_kernel!(backend)(
+                plan.signal_baseband,
+                signal_chunk,
+                plan.dopplers_gpu,
+                freq_offset,
+                inv_sampling_freq;
+                ndrange = (actual_chunk_size, size(plan.signal_baseband, 2)),
+            )
+            # Zero pad region for kernel path (kernel only writes 1:actual_chunk_size)
+            if actual_chunk_size < size(plan.signal_baseband, 1)
+                view(
+                    plan.signal_baseband,
+                    (actual_chunk_size+1):size(plan.signal_baseband, 1),
+                    :,
+                ) .= zero(eltype(plan.signal_baseband))
+            end
+        end
+
+        # 2. Batched FFT
+        mul!(plan.signal_baseband_freq_domain, plan.fft_plan, plan.signal_baseband)
+
+        # 3-6. Process each PRN: correlate → power → findmax → result
+        return map(enumerate(prns)) do (p_idx, prn)
+            prn_idx = prn_indices[p_idx]
+            _ka_correlate_prn!(
+                plan,
+                prn_idx,
+                active_cd_indices,
+                num_dopplers,
+                N,
+                N_pad,
+                needs_padding,
+            )
+
+            # Compute power into pre-allocated buffer
+            plan.power_buffer .= abs2.(view(plan.code_baseband, 1:num_code_samples, :))
+
+            _ka_make_result(
+                plan,
+                prn,
+                plan.power_buffer,
+                num_code_samples,
+                samples_per_chip,
+                code_period,
+                effective_sampling_freq,
+                doppler_offset,
+                result_dopplers,
+                backend,
+                store_powers,
+            )
+        end
+    end
+
+    # Multi-chunk path: need per-PRN accumulators across chunks
     power_accumulators = [similar(plan.power_accumulator) for _ = 1:num_prns]
 
-    # Process signal in chunks - downconvert/FFT once per chunk for all PRNs
+    # Zero the DBZP pad region once (it stays zero across all chunks since
+    # downconvert only writes to 1:actual_chunk_size)
+    pad_start = chunk_samples + 1
+    if pad_start <= size(plan.signal_baseband, 1)
+        view(plan.signal_baseband, pad_start:size(plan.signal_baseband, 1), :) .=
+            zero(eltype(plan.signal_baseband))
+    end
+
     for chunk_idx = 1:num_chunks
         start_idx = (chunk_idx - 1) * chunk_samples + 1
         end_idx = min(chunk_idx * chunk_samples, num_signal_samples)
         actual_chunk_size = end_idx - start_idx + 1
         signal_chunk = view(signal, start_idx:end_idx)
 
-        # 1. Batched downconversion for this chunk (ONCE per chunk, not per PRN)
-        # Zero the full buffer (DBZP: signal_baseband is linear_fft_size ≈ 2N,
-        # only first actual_chunk_size samples get signal data)
-        plan.signal_baseband .= zero(eltype(plan.signal_baseband))
+        # 1. Batched downconversion for this chunk
+        # For partial last chunk, zero the unfilled signal region
+        if actual_chunk_size < chunk_samples
+            view(plan.signal_baseband, (actual_chunk_size+1):chunk_samples, :) .=
+                zero(eltype(plan.signal_baseband))
+        end
 
         if iszero(ustrip(interm_freq)) && iszero(ustrip(doppler_offset))
-            # Fast path: use precomputed phases (phases beyond N are already zero)
             signal_view = view(plan.signal_baseband, 1:actual_chunk_size, :)
             phases_view = view(plan.downconvert_phases, 1:actual_chunk_size, :)
             signal_view .= signal_chunk .* phases_view
         else
-            # Slow path: use kernel for runtime frequency offsets
             freq_offset = T(ustrip(doppler_offset + interm_freq))
             inv_sampling_freq = T(1.0 / ustrip(plan.sampling_frequency))
             ka_downconvert_kernel!(backend)(
@@ -551,62 +647,22 @@ function acquire!(
             )
         end
 
-        # 2. Batched FFT along sample dimension (ONCE per chunk, not per PRN)
+        # 2. Batched FFT
         mul!(plan.signal_baseband_freq_domain, plan.fft_plan, plan.signal_baseband)
 
         # 3-5. Process each PRN with the already-transformed signal
-        N = plan.linear_fft_size
-        N_pad = plan.bfft_size
-        needs_padding = N_pad > N
         for (p_idx, prn_idx) in enumerate(prn_indices)
-            # 3. Code multiplication for this PRN, grouped by code Doppler index
-            # When zero-padding, clear the padded buffer first, then write
-            # positive freqs (1..N÷2+1) and negative freqs (N_pad-neg_count+1..N_pad)
-            if needs_padding
-                plan.code_baseband_freq_domain .=
-                    zero(eltype(plan.code_baseband_freq_domain))
-                pos_end = N ÷ 2 + 1
-                neg_count = N - pos_end
-                group_start = 1
-                for d_idx = 1:num_dopplers
-                    cd_idx = active_cd_indices[d_idx]
-                    if d_idx == num_dopplers || active_cd_indices[d_idx+1] != cd_idx
-                        code_col = view(plan.codes_freq_domain, :, prn_idx, cd_idx)
-                        doppler_range = group_start:d_idx
-                        sig_view = view(plan.signal_baseband_freq_domain, :, doppler_range)
-                        # Positive frequencies
-                        view(plan.code_baseband_freq_domain, 1:pos_end, doppler_range) .=
-                            view(code_col, 1:pos_end) .* conj.(view(sig_view, 1:pos_end, :))
-                        # Negative frequencies
-                        view(
-                            plan.code_baseband_freq_domain,
-                            (N_pad-neg_count+1):N_pad,
-                            doppler_range,
-                        ) .=
-                            view(code_col, (pos_end+1):N) .*
-                            conj.(view(sig_view, (pos_end+1):N, :))
-                        group_start = d_idx + 1
-                    end
-                end
-            else
-                group_start = 1
-                for d_idx = 1:num_dopplers
-                    cd_idx = active_cd_indices[d_idx]
-                    if d_idx == num_dopplers || active_cd_indices[d_idx+1] != cd_idx
-                        code_col = view(plan.codes_freq_domain, :, prn_idx, cd_idx)
-                        doppler_range = group_start:d_idx
-                        view(plan.code_baseband_freq_domain, :, doppler_range) .=
-                            code_col .*
-                            conj.(view(plan.signal_baseband_freq_domain, :, doppler_range))
-                        group_start = d_idx + 1
-                    end
-                end
-            end
+            _ka_correlate_prn!(
+                plan,
+                prn_idx,
+                active_cd_indices,
+                num_dopplers,
+                N,
+                N_pad,
+                needs_padding,
+            )
 
-            # 4. Backward FFT
-            mul!(plan.code_baseband, plan.bfft_plan, plan.code_baseband_freq_domain)
-
-            # 5. Compute power and accumulate
+            # Compute power and accumulate
             if chunk_idx == 1
                 power_accumulators[p_idx] .=
                     abs2.(view(plan.code_baseband, 1:num_code_samples, :))
@@ -619,71 +675,153 @@ function acquire!(
 
     # 6. Process results for each PRN
     map(enumerate(prns)) do (p_idx, prn)
-        power_acc = power_accumulators[p_idx]
-
-        # Fused findmax + sum on accumulated powers
-        signal_noise_power, linear_idx, total_power = gpu_findmax_and_sum!(
-            plan.findmax_vals_gpu,
-            plan.findmax_vals_cpu,
-            plan.findmax_idxs_gpu,
-            plan.findmax_idxs_cpu,
-            plan.sum_buffer_gpu,
-            plan.sum_buffer_cpu,
-            power_acc,
-            backend,
-        )
-
-        # Convert linear index to (code_index, doppler_index)
-        doppler_index = div(linear_idx - 1, num_code_samples) + 1
-        code_index = mod(linear_idx - 1, num_code_samples) + 1
-
-        # Compute noise power from total minus peak region
-        num_dopplers = size(power_acc, 2)
-        lower_end = max(1, code_index - samples_per_chip)
-        upper_start = min(num_code_samples, code_index + samples_per_chip) + 1
-        peak_rows = (upper_start - 1) - (lower_end - 1)
-        peak_region_samples = peak_rows * num_dopplers
-        total_samples = length(power_acc)
-        noise_samples = total_samples - peak_region_samples
-
-        noise_power = noise_samples > 0 ? (total_power / total_samples) : zero(T)
-        signal_power = signal_noise_power - noise_power
-
-        # CN0 includes coherent integration gain (normalized by code_period).
-        # Non-coherent integration improves detection probability but doesn't increase
-        # the measured SNR ratio, so no explicit gain is added here.
-        snr = max(signal_power / noise_power, T(1e-10))
-        CN0 = 10 * log10(snr / code_period / 1.0Hz)
-        doppler =
-            (doppler_index - 1) * step(plan.dopplers) +
-            first(plan.dopplers) +
-            Float64(ustrip(doppler_offset))
-        code_doppler = doppler * get_code_center_frequency_ratio(plan.system)
-        code_phase =
-            (code_index - 1) / (
-                effective_sampling_freq /
-                (get_code_frequency(plan.system) + code_doppler * 1.0Hz)
-            )
-
-        # Only keep full power matrix if requested
-        result_powers = if store_powers
-            Matrix{Float32}(Array(power_acc))
-        else
-            Matrix{Float32}(undef, 0, 0)
-        end
-
-        AcquisitionResults(
-            plan.system,
+        _ka_make_result(
+            plan,
             prn,
+            power_accumulators[p_idx],
+            num_code_samples,
+            samples_per_chip,
+            code_period,
             effective_sampling_freq,
-            doppler * 1.0Hz,
-            code_phase,
-            CN0,
-            Float32(noise_power),
-            result_powers,
+            doppler_offset,
             result_dopplers,
+            backend,
+            store_powers,
         )
     end
+end
+
+"""
+Correlate a single PRN: code multiplication + backward FFT.
+Operates on plan's pre-allocated buffers (code_baseband_freq_domain → code_baseband).
+"""
+function _ka_correlate_prn!(
+    plan,
+    prn_idx,
+    active_cd_indices,
+    num_dopplers,
+    N,
+    N_pad,
+    needs_padding,
+)
+    if needs_padding
+        plan.code_baseband_freq_domain .= zero(eltype(plan.code_baseband_freq_domain))
+        pos_end = N ÷ 2 + 1
+        neg_count = N - pos_end
+        group_start = 1
+        for d_idx = 1:num_dopplers
+            cd_idx = active_cd_indices[d_idx]
+            if d_idx == num_dopplers || active_cd_indices[d_idx+1] != cd_idx
+                code_col = view(plan.codes_freq_domain, :, prn_idx, cd_idx)
+                doppler_range = group_start:d_idx
+                sig_view = view(plan.signal_baseband_freq_domain, :, doppler_range)
+                # Positive frequencies
+                view(plan.code_baseband_freq_domain, 1:pos_end, doppler_range) .=
+                    view(code_col, 1:pos_end) .* conj.(view(sig_view, 1:pos_end, :))
+                # Negative frequencies
+                view(
+                    plan.code_baseband_freq_domain,
+                    (N_pad-neg_count+1):N_pad,
+                    doppler_range,
+                ) .=
+                    view(code_col, (pos_end+1):N) .*
+                    conj.(view(sig_view, (pos_end+1):N, :))
+                group_start = d_idx + 1
+            end
+        end
+    else
+        group_start = 1
+        for d_idx = 1:num_dopplers
+            cd_idx = active_cd_indices[d_idx]
+            if d_idx == num_dopplers || active_cd_indices[d_idx+1] != cd_idx
+                code_col = view(plan.codes_freq_domain, :, prn_idx, cd_idx)
+                doppler_range = group_start:d_idx
+                view(plan.code_baseband_freq_domain, :, doppler_range) .=
+                    code_col .*
+                    conj.(view(plan.signal_baseband_freq_domain, :, doppler_range))
+                group_start = d_idx + 1
+            end
+        end
+    end
+
+    # Backward FFT
+    mul!(plan.code_baseband, plan.bfft_plan, plan.code_baseband_freq_domain)
+    return nothing
+end
+
+"""
+Build AcquisitionResults from a power matrix (either plan.power_buffer or an accumulator).
+"""
+function _ka_make_result(
+    plan::KAAcquisitionPlan{T,S},
+    prn,
+    power_acc,
+    num_code_samples,
+    samples_per_chip,
+    code_period,
+    effective_sampling_freq,
+    doppler_offset,
+    result_dopplers,
+    backend,
+    store_powers,
+) where {T,S}
+    signal_noise_power, linear_idx, total_power = gpu_findmax_and_sum!(
+        plan.findmax_vals_gpu,
+        plan.findmax_vals_cpu,
+        plan.findmax_idxs_gpu,
+        plan.findmax_idxs_cpu,
+        plan.sum_buffer_gpu,
+        plan.sum_buffer_cpu,
+        power_acc,
+        backend,
+    )
+
+    # Convert linear index to (code_index, doppler_index)
+    doppler_index = div(linear_idx - 1, num_code_samples) + 1
+    code_index = mod(linear_idx - 1, num_code_samples) + 1
+
+    # Compute noise power from total minus peak region
+    num_dopplers = size(power_acc, 2)
+    lower_end = max(1, code_index - samples_per_chip)
+    upper_start = min(num_code_samples, code_index + samples_per_chip) + 1
+    peak_rows = (upper_start - 1) - (lower_end - 1)
+    peak_region_samples = peak_rows * num_dopplers
+    total_samples = length(power_acc)
+    noise_samples = total_samples - peak_region_samples
+
+    noise_power = noise_samples > 0 ? (total_power / total_samples) : zero(T)
+    signal_power = signal_noise_power - noise_power
+
+    snr = max(signal_power / noise_power, T(1e-10))
+    CN0 = 10 * log10(snr / code_period / 1.0Hz)
+    doppler =
+        (doppler_index - 1) * step(plan.dopplers) +
+        first(plan.dopplers) +
+        Float64(ustrip(doppler_offset))
+    code_doppler = doppler * get_code_center_frequency_ratio(plan.system)
+    code_phase =
+        (code_index - 1) / (
+            effective_sampling_freq /
+            (get_code_frequency(plan.system) + code_doppler * 1.0Hz)
+        )
+
+    result_powers = if store_powers
+        Matrix{Float32}(Array(power_acc))
+    else
+        Matrix{Float32}(undef, 0, 0)
+    end
+
+    AcquisitionResults(
+        plan.system,
+        prn,
+        effective_sampling_freq,
+        doppler * 1.0Hz,
+        code_phase,
+        CN0,
+        Float32(noise_power),
+        result_powers,
+        result_dopplers,
+    )
 end
 
 # Single PRN convenience method

--- a/src/ka_acquire.jl
+++ b/src/ka_acquire.jl
@@ -12,31 +12,34 @@ simultaneously. Works with any GPU backend supported by KernelAbstractions.jl (C
 Metal, oneAPI) via the AbstractFFTs interface.
 
 # Type Parameters
-- `T`: Element type (e.g., `Float32`, `Float64`)
-- `S`: GNSS system type
-- `A`: Array type (e.g., `CuArray`, `ROCArray`)
-- `P`: FFT plan type
-- `IP`: Inverse FFT plan type
+
+  - `T`: Element type (e.g., `Float32`, `Float64`)
+  - `S`: GNSS system type
+  - `A`: Array type (e.g., `CuArray`, `ROCArray`)
+  - `P`: FFT plan type
+  - `IP`: Inverse FFT plan type
 
 # Fields
-- `system`: GNSS system (e.g., `GPSL1()`)
-- `dopplers`: Range of Doppler frequencies to search
-- `sampling_frequency`: Sampling frequency of the signal
-- `codes_freq_domain`: Pre-computed frequency-domain replica codes (samples × prns)
-- `signal_baseband`: Batched downconverted signal buffer (samples × dopplers)
-- `signal_baseband_freq_domain`: Batched FFT of downconverted signal (samples × dopplers)
-- `code_baseband_freq_domain`: Batched correlation in frequency domain (samples × dopplers × prns)
-- `code_baseband`: Batched correlation in time domain (samples × dopplers × prns)
-- `fft_plan`: Forward FFT plan
-- `bfft_plan`: Backward FFT plan (unnormalized inverse)
-- `avail_prn_channels`: PRN channels available in this plan
+
+  - `system`: GNSS system (e.g., `GPSL1()`)
+  - `dopplers`: Range of Doppler frequencies to search
+  - `sampling_frequency`: Sampling frequency of the signal
+  - `codes_freq_domain`: Pre-computed frequency-domain replica codes (samples × prns)
+  - `signal_baseband`: Batched downconverted signal buffer (samples × dopplers)
+  - `signal_baseband_freq_domain`: Batched FFT of downconverted signal (samples × dopplers)
+  - `code_baseband_freq_domain`: Batched correlation in frequency domain (samples × dopplers × prns)
+  - `code_baseband`: Batched correlation in time domain (samples × dopplers × prns)
+  - `fft_plan`: Forward FFT plan
+  - `bfft_plan`: Backward FFT plan (unnormalized inverse)
+  - `avail_prn_channels`: PRN channels available in this plan
 
 # Example
+
 ```julia
 using Acquisition, GNSSSignals, AMDGPU  # or CUDA
 
 # Create GPU plan
-plan = KAAcquisitionPlan(GPSL1(), 16368, 16.368e6Hz, ROCArray; prns=1:32)
+plan = KAAcquisitionPlan(GPSL1(), 16368, 16.368e6Hz, ROCArray; prns = 1:32)
 
 # Transfer signal to GPU and acquire
 signal_gpu = ROCArray(signal_cpu)
@@ -44,12 +47,28 @@ results = acquire!(plan, signal_gpu, 1:32)
 ```
 
 # See also
+
 [`acquire!`](@ref), [`AcquisitionPlan`](@ref)
 """
-struct KAAcquisitionPlan{T,S<:AbstractGNSS,A1<:AbstractVector,A2<:AbstractMatrix,A3<:AbstractMatrix,A4<:AbstractArray,AI<:AbstractVector{Int},P,BP}
+struct KAAcquisitionPlan{
+    T,
+    S<:AbstractGNSS,
+    A1<:AbstractVector,
+    A2<:AbstractMatrix,
+    A3<:AbstractMatrix,
+    A4<:AbstractArray,
+    AI<:AbstractVector{Int},
+    P,
+    BP,
+}
     system::S
     num_samples_to_integrate_coherently::Int
-    dopplers::StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}
+    bfft_size::Int
+    dopplers::StepRangeLen{
+        Float64,
+        Base.TwicePrecision{Float64},
+        Base.TwicePrecision{Float64},
+    }
     sampling_frequency::typeof(1.0Hz)
     codes_freq_domain::A4                   # (samples × prns × code_dopplers)
     code_doppler_indices::Vector{Int}       # maps doppler_idx → code_doppler_idx
@@ -81,33 +100,37 @@ end
 Create a GPU-accelerated acquisition plan.
 
 # Arguments
-- `system`: GNSS system (e.g., `GPSL1()`)
-- `num_samples_to_integrate_coherently`: Number of samples per coherent integration chunk
-- `sampling_freq`: Sampling frequency of the signal
-- `ArrayType`: GPU array constructor (e.g., `CuArray`, `ROCArray`, `Array` for CPU)
+
+  - `system`: GNSS system (e.g., `GPSL1()`)
+  - `num_samples_to_integrate_coherently`: Number of samples per coherent integration chunk
+  - `sampling_freq`: Sampling frequency of the signal
+  - `ArrayType`: GPU array constructor (e.g., `CuArray`, `ROCArray`, `Array` for CPU)
 
 # Keyword Arguments
-- `eltype`: Element type for internal buffers (default: `Float32`)
-- `max_doppler`: Maximum Doppler frequency to search (default: `7000Hz`)
-- `min_doppler`: Minimum Doppler frequency to search (default: `-max_doppler`)
-- `dopplers`: Custom Doppler range (default: computed from `doppler_step`)
-- `doppler_step`: Doppler frequency step size (default: `doppler_step_factor / T` where
-  `T = num_samples_to_integrate_coherently / sampling_freq`)
-- `doppler_step_factor`: Factor for computing Doppler step from integration time (default: `1//3`)
-- `prns`: PRN channels to prepare (default: `1:34`)
-- `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
-  Controls how many code replicas are pre-computed at different code Doppler offsets.
-  Smaller values improve accuracy at high Dopplers with long integration times, at the
-  cost of more memory.
+
+  - `eltype`: Element type for internal buffers (default: `Float32`)
+  - `max_doppler`: Maximum Doppler frequency to search (default: `7000Hz`)
+  - `min_doppler`: Minimum Doppler frequency to search (default: `-max_doppler`)
+  - `dopplers`: Custom Doppler range (default: computed from `doppler_step`)
+  - `doppler_step`: Doppler frequency step size (default: `doppler_step_factor / T` where
+    `T = num_samples_to_integrate_coherently / sampling_freq`)
+  - `doppler_step_factor`: Factor for computing Doppler step from integration time (default: `1//3`)
+  - `prns`: PRN channels to prepare (default: `1:34`)
+  - `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
+    Controls how many code replicas are pre-computed at different code Doppler offsets.
+    Smaller values improve accuracy at high Dopplers with long integration times, at the
+    cost of more memory.
 
 # Example
+
 ```julia
 using Acquisition, GNSSSignals, AMDGPU
 
-plan = KAAcquisitionPlan(GPSL1(), 16.368e6Hz, ROCArray; prns=1:32)
+plan = KAAcquisitionPlan(GPSL1(), 16.368e6Hz, ROCArray; prns = 1:32)
 ```
 
 # See also
+
 [`acquire!`](@ref), [`AcquisitionPlan`](@ref)
 """
 function KAAcquisitionPlan(
@@ -115,35 +138,61 @@ function KAAcquisitionPlan(
     num_samples_to_integrate_coherently::Integer,
     sampling_freq,
     ArrayType::Type{<:AbstractArray};
-    eltype::Type{T}=Float32,
-    max_doppler=7000Hz,
-    min_doppler=-max_doppler,
-    doppler_step_factor=1//3,
-    doppler_step=doppler_step_factor * sampling_freq / num_samples_to_integrate_coherently,
-    dopplers=min_doppler:doppler_step:max_doppler,
-    code_doppler_tolerance=0.01,
-    prns=1:34,
+    eltype::Type{T} = Float32,
+    max_doppler = 7000Hz,
+    min_doppler = -max_doppler,
+    doppler_step_factor = 1//3,
+    doppler_step = doppler_step_factor * sampling_freq /
+                   num_samples_to_integrate_coherently,
+    dopplers = min_doppler:doppler_step:max_doppler,
+    code_doppler_tolerance = 0.01,
+    prns = 1:34,
+    zero_pad_power::Int = 1,
 ) where {T<:AbstractFloat,S<:AbstractGNSS}
     # Normalize dopplers to Float64 StepRangeLen for consistency
-    dopplers_hz = Float64(ustrip(first(dopplers))):Float64(ustrip(step(dopplers))):Float64(ustrip(last(dopplers)))
+    dopplers_hz =
+        Float64(ustrip(first(dopplers))):Float64(ustrip(step(dopplers))):Float64(
+            ustrip(last(dopplers)),
+        )
     num_dopplers = length(dopplers_hz)
     num_prns = length(prns)
+
+    bfft_size =
+        zero_pad_power > 0 ?
+        fftw_friendly_size(num_samples_to_integrate_coherently) << (zero_pad_power - 1) :
+        num_samples_to_integrate_coherently
 
     # Code Doppler grid (reuse helpers from plan_acquire.jl)
     T_coh = num_samples_to_integrate_coherently / sampling_freq
     code_doppler_step_val = code_doppler_tolerance / ustrip(T_coh)
-    code_dopplers_grid, n_neg = compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step_val)
+    code_dopplers_grid, n_neg =
+        compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step_val)
     code_doppler_offset_idx = n_neg + 1
     num_code_dopplers_val = length(code_dopplers_grid)
-    code_doppler_indices = compute_code_doppler_indices(dopplers_hz, system, code_doppler_step_val, code_doppler_offset_idx, num_code_dopplers_val)
+    code_doppler_indices = compute_code_doppler_indices(
+        dopplers_hz,
+        system,
+        code_doppler_step_val,
+        code_doppler_offset_idx,
+        num_code_dopplers_val,
+    )
 
     # Generate 3D codes on CPU: (samples × num_prns × num_code_dopplers)
-    codes_cpu = Array{T}(undef, num_samples_to_integrate_coherently, num_prns, num_code_dopplers_val)
+    codes_cpu = Array{T}(
+        undef,
+        num_samples_to_integrate_coherently,
+        num_prns,
+        num_code_dopplers_val,
+    )
     for (cd_idx, cd) in enumerate(code_dopplers_grid)
         for (p_idx, prn) in enumerate(prns)
             codes_cpu[:, p_idx, cd_idx] .= gen_code(
-                num_samples_to_integrate_coherently, system, prn, sampling_freq,
-                get_code_frequency(system) + cd * 1.0Hz)
+                num_samples_to_integrate_coherently,
+                system,
+                prn,
+                sampling_freq,
+                get_code_frequency(system) + cd * 1.0Hz,
+            )
         end
     end
 
@@ -154,21 +203,25 @@ function KAAcquisitionPlan(
     # phase[i,d] = cis(-2π * doppler[d] * (i-1) / sampling_freq)
     sampling_freq_val = T(ustrip(sampling_freq))
     downconvert_phases_cpu = [
-        cis(T(-2) * T(π) * T(dopplers_hz[d]) * T(i - 1) / sampling_freq_val)
-        for i in 1:num_samples_to_integrate_coherently, d in 1:num_dopplers
+        cis(T(-2) * T(π) * T(dopplers_hz[d]) * T(i - 1) / sampling_freq_val) for
+        i = 1:num_samples_to_integrate_coherently, d = 1:num_dopplers
     ]
     downconvert_phases = ArrayType{Complex{T}}(downconvert_phases_cpu)
 
     # Allocate buffers on GPU - use 2D arrays to reduce memory (reused per PRN)
-    signal_baseband = ArrayType{Complex{T}}(undef, num_samples_to_integrate_coherently, num_dopplers)
+    signal_baseband =
+        ArrayType{Complex{T}}(undef, num_samples_to_integrate_coherently, num_dopplers)
     signal_baseband_freq_domain = similar(signal_baseband)
-    code_baseband_freq_domain = ArrayType{Complex{T}}(undef, num_samples_to_integrate_coherently, num_dopplers)  # 2D, reused
-    code_baseband = similar(code_baseband_freq_domain)  # 2D, reused
+    # BFFT buffers are sized at bfft_size for zero-padding
+    code_baseband_freq_domain = ArrayType{Complex{T}}(undef, bfft_size, num_dopplers)
+    code_baseband = similar(code_baseband_freq_domain)
 
-    # Preallocate power buffer (only need code_samples rows, not full num_samples_to_integrate_coherently)
+    # Preallocate power buffer using effective sampling freq for proper row count
     Δt = num_samples_to_integrate_coherently / sampling_freq
     code_period = get_code_length(system) / get_code_frequency(system)
-    num_code_samples = ceil(Int, sampling_freq * min(Δt, code_period))
+    effective_sampling_freq =
+        sampling_freq * bfft_size / num_samples_to_integrate_coherently
+    num_code_samples = ceil(Int, effective_sampling_freq * min(Δt, code_period))
     power_buffer = ArrayType{T}(undef, num_code_samples, num_dopplers)
     power_accumulator = ArrayType{T}(undef, num_code_samples, num_dopplers)
 
@@ -182,25 +235,35 @@ function KAAcquisitionPlan(
     sum_buffer_cpu = Vector{T}(undef, num_reduction_threads)         # CPU side for final reduction
 
     # Create FFT plans using AbstractFFTs (will use cuFFT/rocFFT etc.)
-    # Plan along dimension 1 (samples)
+    # Plan along dimension 1 (samples) — FFT on original-size signal
     fft_plan = plan_fft(signal_baseband, 1)
-    # Use bfft (backward FFT without normalization) to avoid ScaledPlan which requires BLAS
-    # We'll handle scaling manually or skip it since we only need relative magnitudes for peak detection
+    # BFFT plan on the (possibly padded) buffer
     bfft_plan = plan_bfft(code_baseband_freq_domain, 1)
 
     # Transform codes to frequency domain
     # Transfer 3D array to GPU and FFT each (sample) column
     codes_gpu = ArrayType{Complex{T}}(codes_cpu)
     codes_freq_domain = similar(codes_gpu)
-    for cd_idx in 1:num_code_dopplers_val
-        for p_idx in 1:num_prns
+    for cd_idx = 1:num_code_dopplers_val
+        for p_idx = 1:num_prns
             codes_freq_domain[:, p_idx, cd_idx] .= fft(view(codes_gpu, :, p_idx, cd_idx))
         end
     end
 
-    KAAcquisitionPlan{T,S,typeof(dopplers_gpu),typeof(signal_baseband),typeof(power_buffer),typeof(codes_freq_domain),typeof(findmax_idxs_gpu),typeof(fft_plan),typeof(bfft_plan)}(
+    KAAcquisitionPlan{
+        T,
+        S,
+        typeof(dopplers_gpu),
+        typeof(signal_baseband),
+        typeof(power_buffer),
+        typeof(codes_freq_domain),
+        typeof(findmax_idxs_gpu),
+        typeof(fft_plan),
+        typeof(bfft_plan),
+    }(
         system,
         num_samples_to_integrate_coherently,
+        bfft_size,
         dopplers_hz,
         sampling_freq,
         codes_freq_domain,
@@ -233,12 +296,18 @@ function KAAcquisitionPlan(
     system::S,
     sampling_freq,
     ArrayType::Type{<:AbstractArray};
-    kwargs...
+    kwargs...,
 ) where {S<:AbstractGNSS}
     # Default to one bit period worth of samples for optimal non-coherent integration
     data_frequency = get_data_frequency(system)
     num_samples_to_integrate_coherently = ceil(Int, sampling_freq / data_frequency)
-    KAAcquisitionPlan(system, num_samples_to_integrate_coherently, sampling_freq, ArrayType; kwargs...)
+    KAAcquisitionPlan(
+        system,
+        num_samples_to_integrate_coherently,
+        sampling_freq,
+        ArrayType;
+        kwargs...,
+    )
 end
 
 # ============================================================================
@@ -262,7 +331,8 @@ Each thread handles one (sample, doppler) pair. Uses @fastmath for ~10% speedup.
 
     @fastmath begin
         doppler = dopplers[d] + freq_offset
-        phase = Float32(-6.283185307179586) * doppler * Float32(i - 1) * inv_sampling_frequency
+        phase =
+            Float32(-6.283185307179586) * doppler * Float32(i - 1) * inv_sampling_frequency
         s, c = sincos(phase)
         signal_baseband[i, d] = signal[i] * Complex{Float32}(c, s)
     end
@@ -313,14 +383,27 @@ Fused findmax + sum in single GPU pass. Returns (max_value, linear_index, total_
 This reduces GPU→CPU synchronizations from 3 to 1 per PRN, giving ~15-20% speedup
 by computing the peak and total power sum in a single kernel launch.
 """
-function gpu_findmax_and_sum!(vals_gpu, vals_cpu, idxs_gpu, idxs_cpu, sums_gpu, sums_cpu, data, backend)
+function gpu_findmax_and_sum!(
+    vals_gpu,
+    vals_cpu,
+    idxs_gpu,
+    idxs_cpu,
+    sums_gpu,
+    sums_cpu,
+    data,
+    backend,
+)
     n = length(data)
     num_threads = length(vals_gpu)
 
     # Single kernel computes both findmax and sum
     ka_findmax_and_sum_kernel!(backend)(
-        vals_gpu, idxs_gpu, sums_gpu, data, n,
-        ndrange=num_threads
+        vals_gpu,
+        idxs_gpu,
+        sums_gpu,
+        data,
+        n;
+        ndrange = num_threads,
     )
 
     # Single GPU→CPU transfer for all three buffers
@@ -331,7 +414,7 @@ function gpu_findmax_and_sum!(vals_gpu, vals_cpu, idxs_gpu, idxs_cpu, sums_gpu, 
     # CPU reduction for findmax
     best_val = typemin(eltype(data))
     best_idx = 0
-    @inbounds for i in 1:num_threads
+    @inbounds for i = 1:num_threads
         if vals_cpu[i] > best_val
             best_val = vals_cpu[i]
             best_idx = idxs_cpu[i]
@@ -354,37 +437,42 @@ end
 Perform GPU-accelerated acquisition using a pre-computed [`KAAcquisitionPlan`](@ref).
 
 # Arguments
-- `plan`: Pre-computed [`KAAcquisitionPlan`](@ref)
-- `signal`: Complex baseband signal samples (GPU array)
-- `prns`: PRN numbers to search (must be subset of `plan.avail_prn_channels`)
+
+  - `plan`: Pre-computed [`KAAcquisitionPlan`](@ref)
+  - `signal`: Complex baseband signal samples (GPU array)
+  - `prns`: PRN numbers to search (must be subset of `plan.avail_prn_channels`)
 
 # Keyword Arguments
-- `interm_freq`: Intermediate frequency (default: `0.0Hz`)
-- `doppler_offset`: Offset added to Doppler search range (default: `0.0Hz`)
-- `store_powers`: If `true`, store full power matrix in results for plotting (default: `false`)
+
+  - `interm_freq`: Intermediate frequency (default: `0.0Hz`)
+  - `doppler_offset`: Offset added to Doppler search range (default: `0.0Hz`)
+  - `store_powers`: If `true`, store full power matrix in results for plotting (default: `false`)
 
 # Returns
+
 Vector of [`AcquisitionResults`](@ref), one per PRN.
 
 # Example
+
 ```julia
 using Acquisition, GNSSSignals, AMDGPU
 
-plan = KAAcquisitionPlan(GPSL1(), 16368, 16.368e6Hz, ROCArray; prns=1:32)
+plan = KAAcquisitionPlan(GPSL1(), 16368, 16.368e6Hz, ROCArray; prns = 1:32)
 signal_gpu = ROCArray(signal_cpu)
 results = acquire!(plan, signal_gpu, 1:32)
 ```
 
 # See also
+
 [`KAAcquisitionPlan`](@ref), [`acquire!`](@ref)
 """
 function acquire!(
     plan::KAAcquisitionPlan{T,S},
     signal::AbstractArray,
     prns::AbstractVector{<:Integer};
-    interm_freq=0.0Hz,
-    doppler_offset=0.0Hz,
-    store_powers=false,
+    interm_freq = 0.0Hz,
+    doppler_offset = 0.0Hz,
+    store_powers = false,
 ) where {T,S}
     all(prn -> prn in plan.avail_prn_channels, prns) ||
         throw(ArgumentError("All requested PRNs must be in plan.avail_prn_channels"))
@@ -397,13 +485,15 @@ function acquire!(
     num_chunks = cld(num_signal_samples, chunk_samples)
     code_period = get_code_length(plan.system) / get_code_frequency(plan.system)
     Δt = chunk_samples / plan.sampling_frequency
-    num_code_samples = ceil(Int, plan.sampling_frequency * min(Δt, code_period))
-    samples_per_chip = floor(Int, plan.sampling_frequency / get_code_frequency(plan.system))
+    effective_sampling_freq = plan.sampling_frequency * plan.bfft_size / chunk_samples
+    num_code_samples = ceil(Int, effective_sampling_freq * min(Δt, code_period))
+    samples_per_chip = floor(Int, effective_sampling_freq / get_code_frequency(plan.system))
     backend = get_backend(plan.signal_baseband)
 
     # Precompute doppler range (avoid allocation per result)
-    result_dopplers = iszero(ustrip(doppler_offset)) ? plan.dopplers :
-                      (plan.dopplers .+ Float64(ustrip(doppler_offset)))
+    result_dopplers =
+        iszero(ustrip(doppler_offset)) ? plan.dopplers :
+        (plan.dopplers .+ Float64(ustrip(doppler_offset)))
 
     # Get PRN indices upfront
     prn_indices = [findfirst(==(prn), plan.avail_prn_channels) for prn in prns]
@@ -416,10 +506,14 @@ function acquire!(
         ratio = get_code_center_frequency_ratio(plan.system)
         [
             clamp(
-                round(Int, (dopplers_hz[d] + Float64(ustrip(doppler_offset))) * ratio / plan.code_doppler_step) + plan.code_doppler_offset_idx,
-                1, plan.num_code_dopplers
-            )
-            for d in 1:num_dopplers
+                round(
+                    Int,
+                    (dopplers_hz[d] + Float64(ustrip(doppler_offset))) * ratio /
+                    plan.code_doppler_step,
+                ) + plan.code_doppler_offset_idx,
+                1,
+                plan.num_code_dopplers,
+            ) for d = 1:num_dopplers
         ]
     else
         plan.code_doppler_indices
@@ -427,12 +521,10 @@ function acquire!(
 
     # Allocate per-PRN power accumulators (reuse power_buffer for first PRN, allocate rest)
     # We need to track accumulated powers per PRN across chunks
-    power_accumulators = [
-        similar(plan.power_accumulator) for _ in 1:num_prns
-    ]
+    power_accumulators = [similar(plan.power_accumulator) for _ = 1:num_prns]
 
     # Process signal in chunks - downconvert/FFT once per chunk for all PRNs
-    for chunk_idx in 1:num_chunks
+    for chunk_idx = 1:num_chunks
         start_idx = (chunk_idx - 1) * chunk_samples + 1
         end_idx = min(chunk_idx * chunk_samples, num_signal_samples)
         actual_chunk_size = end_idx - start_idx + 1
@@ -458,8 +550,8 @@ function acquire!(
                 signal_chunk,
                 plan.dopplers_gpu,
                 freq_offset,
-                inv_sampling_freq,
-                ndrange=(actual_chunk_size, size(plan.signal_baseband, 2))
+                inv_sampling_freq;
+                ndrange = (actual_chunk_size, size(plan.signal_baseband, 2)),
             )
         end
 
@@ -467,17 +559,51 @@ function acquire!(
         mul!(plan.signal_baseband_freq_domain, plan.fft_plan, plan.signal_baseband)
 
         # 3-5. Process each PRN with the already-transformed signal
+        N = chunk_samples
+        N_pad = plan.bfft_size
+        needs_padding = N_pad > N
         for (p_idx, prn_idx) in enumerate(prn_indices)
             # 3. Code multiplication for this PRN, grouped by code Doppler index
-            group_start = 1
-            for d_idx in 1:num_dopplers
-                cd_idx = active_cd_indices[d_idx]
-                if d_idx == num_dopplers || active_cd_indices[d_idx + 1] != cd_idx
-                    code_col = view(plan.codes_freq_domain, :, prn_idx, cd_idx)
-                    doppler_range = group_start:d_idx
-                    view(plan.code_baseband_freq_domain, :, doppler_range) .=
-                        code_col .* conj.(view(plan.signal_baseband_freq_domain, :, doppler_range))
-                    group_start = d_idx + 1
+            # When zero-padding, clear the padded buffer first, then write
+            # positive freqs (1..N÷2+1) and negative freqs (N_pad-neg_count+1..N_pad)
+            if needs_padding
+                plan.code_baseband_freq_domain .=
+                    zero(eltype(plan.code_baseband_freq_domain))
+                pos_end = N ÷ 2 + 1
+                neg_count = N - pos_end
+                group_start = 1
+                for d_idx = 1:num_dopplers
+                    cd_idx = active_cd_indices[d_idx]
+                    if d_idx == num_dopplers || active_cd_indices[d_idx+1] != cd_idx
+                        code_col = view(plan.codes_freq_domain, :, prn_idx, cd_idx)
+                        doppler_range = group_start:d_idx
+                        sig_view = view(plan.signal_baseband_freq_domain, :, doppler_range)
+                        # Positive frequencies
+                        view(plan.code_baseband_freq_domain, 1:pos_end, doppler_range) .=
+                            view(code_col, 1:pos_end) .* conj.(view(sig_view, 1:pos_end, :))
+                        # Negative frequencies
+                        view(
+                            plan.code_baseband_freq_domain,
+                            (N_pad-neg_count+1):N_pad,
+                            doppler_range,
+                        ) .=
+                            view(code_col, (pos_end+1):N) .*
+                            conj.(view(sig_view, (pos_end+1):N, :))
+                        group_start = d_idx + 1
+                    end
+                end
+            else
+                group_start = 1
+                for d_idx = 1:num_dopplers
+                    cd_idx = active_cd_indices[d_idx]
+                    if d_idx == num_dopplers || active_cd_indices[d_idx+1] != cd_idx
+                        code_col = view(plan.codes_freq_domain, :, prn_idx, cd_idx)
+                        doppler_range = group_start:d_idx
+                        view(plan.code_baseband_freq_domain, :, doppler_range) .=
+                            code_col .*
+                            conj.(view(plan.signal_baseband_freq_domain, :, doppler_range))
+                        group_start = d_idx + 1
+                    end
                 end
             end
 
@@ -486,9 +612,11 @@ function acquire!(
 
             # 5. Compute power and accumulate
             if chunk_idx == 1
-                power_accumulators[p_idx] .= abs2.(view(plan.code_baseband, 1:num_code_samples, :))
+                power_accumulators[p_idx] .=
+                    abs2.(view(plan.code_baseband, 1:num_code_samples, :))
             else
-                power_accumulators[p_idx] .+= abs2.(view(plan.code_baseband, 1:num_code_samples, :))
+                power_accumulators[p_idx] .+=
+                    abs2.(view(plan.code_baseband, 1:num_code_samples, :))
             end
         end
     end
@@ -499,10 +627,14 @@ function acquire!(
 
         # Fused findmax + sum on accumulated powers
         signal_noise_power, linear_idx, total_power = gpu_findmax_and_sum!(
-            plan.findmax_vals_gpu, plan.findmax_vals_cpu,
-            plan.findmax_idxs_gpu, plan.findmax_idxs_cpu,
-            plan.sum_buffer_gpu, plan.sum_buffer_cpu,
-            power_acc, backend
+            plan.findmax_vals_gpu,
+            plan.findmax_vals_cpu,
+            plan.findmax_idxs_gpu,
+            plan.findmax_idxs_cpu,
+            plan.sum_buffer_gpu,
+            plan.sum_buffer_cpu,
+            power_acc,
+            backend,
         )
 
         # Convert linear index to (code_index, doppler_index)
@@ -526,10 +658,16 @@ function acquire!(
         # the measured SNR ratio, so no explicit gain is added here.
         snr = max(signal_power / noise_power, T(1e-10))
         CN0 = 10 * log10(snr / code_period / 1.0Hz)
-        doppler = (doppler_index - 1) * step(plan.dopplers) + first(plan.dopplers) +
-                  Float64(ustrip(doppler_offset))
+        doppler =
+            (doppler_index - 1) * step(plan.dopplers) +
+            first(plan.dopplers) +
+            Float64(ustrip(doppler_offset))
         code_doppler = doppler * get_code_center_frequency_ratio(plan.system)
-        code_phase = (code_index - 1) / (plan.sampling_frequency / (get_code_frequency(plan.system) + code_doppler * 1.0Hz))
+        code_phase =
+            (code_index - 1) / (
+                effective_sampling_freq /
+                (get_code_frequency(plan.system) + code_doppler * 1.0Hz)
+            )
 
         # Only keep full power matrix if requested
         result_powers = if store_powers
@@ -541,7 +679,7 @@ function acquire!(
         AcquisitionResults(
             plan.system,
             prn,
-            plan.sampling_frequency,
+            effective_sampling_freq,
             doppler * 1.0Hz,
             code_phase,
             CN0,
@@ -557,9 +695,9 @@ function acquire!(
     plan::KAAcquisitionPlan{T,S},
     signal::AbstractArray,
     prn::Integer;
-    interm_freq=0.0Hz,
-    doppler_offset=0.0Hz,
-    store_powers=false,
+    interm_freq = 0.0Hz,
+    doppler_offset = 0.0Hz,
+    store_powers = false,
 )::AcquisitionResults{S,Float32} where {T,S}
     only(acquire!(plan, signal, [prn]; interm_freq, doppler_offset, store_powers))
 end

--- a/src/ka_acquire.jl
+++ b/src/ka_acquire.jl
@@ -528,7 +528,8 @@ function acquire!(
         CN0 = 10 * log10(snr / code_period / 1.0Hz)
         doppler = (doppler_index - 1) * step(plan.dopplers) + first(plan.dopplers) +
                   Float64(ustrip(doppler_offset))
-        code_phase = (code_index - 1) / (plan.sampling_frequency / get_code_frequency(plan.system))
+        code_doppler = doppler * get_code_center_frequency_ratio(plan.system)
+        code_phase = (code_index - 1) / (plan.sampling_frequency / (get_code_frequency(plan.system) + code_doppler * 1.0Hz))
 
         # Only keep full power matrix if requested
         result_powers = if store_powers

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -67,6 +67,10 @@ Create an acquisition plan for efficient repeated acquisition.
   - `doppler_step_factor`: Factor for computing Doppler step from integration time (default: `1//3`)
   - `prns`: PRN channels to prepare (default: `1:34`)
   - `fft_flag`: FFTW planning flag (default: `FFTW.MEASURE`)
+  - `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
+    Controls how many code replicas are pre-computed at different code Doppler offsets.
+    Smaller values improve accuracy at high Dopplers with long integration times, at the
+    cost of more memory.
 
 # Example
 
@@ -222,6 +226,10 @@ Create a two-stage coarse-fine acquisition plan.
   - `doppler_step_factor`: Factor for computing coarse step from integration time (default: `1//3`)
   - `prns`: PRN channels to prepare (default: `1:34`)
   - `fft_flag`: FFTW planning flag (default: `FFTW.MEASURE`)
+  - `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
+    Controls how many code replicas are pre-computed at different code Doppler offsets.
+    Smaller values improve accuracy at high Dopplers with long integration times, at the
+    cost of more memory.
 
 # Example
 

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -24,6 +24,10 @@ struct AcquisitionPlan{T<:AbstractFloat,S,DS,CS,P,IP,PS}
     sampling_freq::typeof(1.0Hz)
     dopplers::DS
     codes_freq_domain::CS
+    code_doppler_indices::Vector{Int}
+    code_doppler_step::Float64
+    code_doppler_offset_idx::Int
+    num_code_dopplers::Int
     signal_baseband::Vector{Complex{T}}
     signal_baseband_freq_domain::Vector{Complex{T}}
     code_freq_baseband_freq_domain::Vector{ComplexF32}
@@ -91,16 +95,25 @@ function AcquisitionPlan(
     doppler_step_factor = 1//3,
     doppler_step = doppler_step_factor * sampling_freq / num_samples_to_integrate_coherently,
     dopplers = min_doppler:doppler_step:max_doppler,
+    code_doppler_tolerance = 0.01,
     prns = 1:34,
     fft_flag = FFTW.MEASURE,
 ) where {T<:AbstractFloat}
+    # Code Doppler step: tolerance (cycles of phase error) / integration time (s) = Hz
+    T_coh = num_samples_to_integrate_coherently / sampling_freq
+    code_doppler_step = code_doppler_tolerance / ustrip(T_coh)
+    code_dopplers, n_neg = compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step)
+    code_doppler_offset_idx = n_neg + 1
+    num_code_dopplers = length(code_dopplers)
+    code_doppler_indices = compute_code_doppler_indices(dopplers, system, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
+
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,
     code_baseband,
     codes_freq_domain,
     fft_plan,
-    ifft_plan = common_buffers(T, system, num_samples_to_integrate_coherently, sampling_freq, prns, fft_flag)
+    ifft_plan = common_buffers(T, system, num_samples_to_integrate_coherently, sampling_freq, prns, fft_flag, code_dopplers)
     chunk_duration = num_samples_to_integrate_coherently / sampling_freq
     code_interval = get_code_length(system) / get_code_frequency(system)
     signal_powers = [
@@ -132,6 +145,10 @@ function AcquisitionPlan(
         sampling_freq,
         dopplers,
         codes_freq_domain,
+        code_doppler_indices,
+        code_doppler_step,
+        code_doppler_offset_idx,
+        num_code_dopplers,
         signal_baseband,
         signal_baseband_freq_domain,
         code_freq_baseband_freq_domain,
@@ -233,17 +250,27 @@ function CoarseFineAcquisitionPlan(
     doppler_step_factor = 1//3,
     coarse_step = doppler_step_factor * sampling_freq / num_samples_to_integrate_coherently,
     fine_step = coarse_step / 10,
+    code_doppler_tolerance = 0.01,
     prns = 1:34,
     fft_flag = FFTW.MEASURE,
 ) where {T<:AbstractFloat}
+    # Code Doppler step: tolerance (cycles of phase error) / integration time (s) = Hz
+    T_coh = num_samples_to_integrate_coherently / sampling_freq
+    code_doppler_step = code_doppler_tolerance / ustrip(T_coh)
+    code_dopplers, n_neg = compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step)
+    code_doppler_offset_idx = n_neg + 1
+    num_code_dopplers = length(code_dopplers)
+
     coarse_dopplers = min_doppler:coarse_step:max_doppler
+    coarse_code_doppler_indices = compute_code_doppler_indices(coarse_dopplers, system, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
+
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,
     code_baseband,
     codes_freq_domain,
     fft_plan,
-    ifft_plan = common_buffers(T, system, num_samples_to_integrate_coherently, sampling_freq, prns, fft_flag)
+    ifft_plan = common_buffers(T, system, num_samples_to_integrate_coherently, sampling_freq, prns, fft_flag, code_dopplers)
     Δt = num_samples_to_integrate_coherently / sampling_freq
     code_interval = get_code_length(system) / get_code_frequency(system)
     coarse_signal_powers = [
@@ -253,7 +280,13 @@ function CoarseFineAcquisitionPlan(
             length(coarse_dopplers),
         ) for _ in prns
     ]
+
     fine_doppler_range = -2*coarse_step:fine_step:2*coarse_step
+    # Fine plan indices are precomputed assuming offset=0, but the fine search always
+    # uses a non-zero doppler_offset (the coarse estimate), so cd_idx is recomputed
+    # inline in acquire!. These indices satisfy the struct field requirement.
+    fine_code_doppler_indices = compute_code_doppler_indices(fine_doppler_range, system, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
+
     fine_signal_powers = [
         Matrix{Float32}(
             undef,
@@ -262,72 +295,28 @@ function CoarseFineAcquisitionPlan(
         ) for _ in prns
     ]
     coarse_results = [
-        AcquisitionResults(
-            system,
-            prn,
-            sampling_freq,
-            0.0Hz,
-            0.0,
-            0.0,
-            Float32(0),
-            coarse_signal_powers[i],
-            coarse_dopplers,
-        )
+        AcquisitionResults(system, prn, sampling_freq, 0.0Hz, 0.0, 0.0, Float32(0), coarse_signal_powers[i], coarse_dopplers)
         for (i, prn) in enumerate(prns)
     ]
     coarse_prn_indices = Vector{Int}(undef, length(prns))
     coarse_output_results = Vector{Base.eltype(coarse_results)}(undef, length(prns))
     coarse_plan = AcquisitionPlan(
-        system,
-        num_samples_to_integrate_coherently,
-        sampling_freq,
-        coarse_dopplers,
-        codes_freq_domain,
-        signal_baseband,
-        signal_baseband_freq_domain,
-        code_freq_baseband_freq_domain,
-        code_baseband,
-        coarse_signal_powers,
-        fft_plan,
-        ifft_plan,
-        prns,
-        coarse_results,
-        coarse_prn_indices,
-        coarse_output_results,
+        system, num_samples_to_integrate_coherently, sampling_freq, coarse_dopplers,
+        codes_freq_domain, coarse_code_doppler_indices, code_doppler_step, code_doppler_offset_idx, num_code_dopplers,
+        signal_baseband, signal_baseband_freq_domain, code_freq_baseband_freq_domain, code_baseband,
+        coarse_signal_powers, fft_plan, ifft_plan, prns, coarse_results, coarse_prn_indices, coarse_output_results,
     )
     fine_results = [
-        AcquisitionResults(
-            system,
-            prn,
-            sampling_freq,
-            0.0Hz,
-            0.0,
-            0.0,
-            Float32(0),
-            fine_signal_powers[i],
-            fine_doppler_range,
-        )
+        AcquisitionResults(system, prn, sampling_freq, 0.0Hz, 0.0, 0.0, Float32(0), fine_signal_powers[i], fine_doppler_range)
         for (i, prn) in enumerate(prns)
     ]
     fine_prn_indices = Vector{Int}(undef, length(prns))
     fine_output_results = Vector{Base.eltype(fine_results)}(undef, length(prns))
     fine_plan = AcquisitionPlan(
-        system,
-        num_samples_to_integrate_coherently,
-        sampling_freq,
-        fine_doppler_range,
-        codes_freq_domain,
-        signal_baseband,
-        signal_baseband_freq_domain,
-        code_freq_baseband_freq_domain,
-        code_baseband,
-        fine_signal_powers,
-        fft_plan,
-        ifft_plan,
-        prns,
-        fine_results,
-        fine_prn_indices,
-        fine_output_results,
+        system, num_samples_to_integrate_coherently, sampling_freq, fine_doppler_range,
+        codes_freq_domain, fine_code_doppler_indices, code_doppler_step, code_doppler_offset_idx, num_code_dopplers,
+        signal_baseband, signal_baseband_freq_domain, code_freq_baseband_freq_domain, code_baseband,
+        fine_signal_powers, fft_plan, ifft_plan, prns, fine_results, fine_prn_indices, fine_output_results,
     )
     CoarseFineAcquisitionPlan(coarse_plan, fine_plan)
 end
@@ -342,6 +331,35 @@ function CoarseFineAcquisitionPlan(
     data_frequency = get_data_frequency(system)
     num_samples_to_integrate_coherently = ceil(Int, sampling_freq / data_frequency)
     CoarseFineAcquisitionPlan(system, num_samples_to_integrate_coherently, sampling_freq; kwargs...)
+end
+
+"""
+    compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step)
+
+Compute a grid of code Doppler offsets centered at 0 Hz that covers the code Doppler
+range implied by the carrier Doppler search range.
+
+Returns `(code_dopplers, n_neg)` where `code_dopplers` is a range of code Doppler values
+in Hz (without Unitful units) and `n_neg` is the number of negative steps.
+"""
+function compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step)
+    ratio = get_code_center_frequency_ratio(system)
+    min_code_doppler = ustrip(min_doppler) * ratio
+    max_code_doppler = ustrip(max_doppler) * ratio
+    n_neg = ceil(Int, -min_code_doppler / code_doppler_step)
+    n_pos = ceil(Int, max_code_doppler / code_doppler_step)
+    code_dopplers = (-n_neg:n_pos) .* code_doppler_step
+    return code_dopplers, n_neg
+end
+
+"""
+    compute_code_doppler_indices(dopplers, system, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
+
+Map each carrier Doppler bin to the index of the nearest pre-computed code Doppler replica.
+"""
+function compute_code_doppler_indices(dopplers, system, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
+    ratio = get_code_center_frequency_ratio(system)
+    [clamp(round(Int, ustrip(doppler) * ratio / code_doppler_step) + code_doppler_offset_idx, 1, num_code_dopplers) for doppler in dopplers]
 end
 
 const FFTW_WISDOM_DIR = @get_scratch!("fftw_wisdom")
@@ -361,8 +379,14 @@ function common_buffers(
     sampling_freq,
     prns,
     fft_flag,
+    code_dopplers,
 ) where {T}
-    codes = [gen_code(num_samples_to_integrate_coherently, system, sat_prn, sampling_freq) for sat_prn in prns]
+    codes = [
+        [gen_code(num_samples_to_integrate_coherently, system, sat_prn, sampling_freq,
+                  get_code_frequency(system) + code_doppler * 1.0Hz)
+         for code_doppler in code_dopplers]
+        for sat_prn in prns
+    ]
     signal_baseband = Vector{Complex{T}}(undef, num_samples_to_integrate_coherently)
     signal_baseband_freq_domain = similar(signal_baseband)
     code_freq_baseband_freq_domain = Vector{ComplexF32}(undef, num_samples_to_integrate_coherently)
@@ -376,7 +400,10 @@ function common_buffers(
         plan_fft(signal_baseband; flags = fft_flag),
         plan_ifft(code_freq_baseband_freq_domain; flags = fft_flag)
     end
-    codes_freq_domain = map(code -> fft_plan * code, codes)
+    codes_freq_domain = [
+        [fft_plan * code for code in prn_codes]
+        for prn_codes in codes
+    ]
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -10,6 +10,7 @@ multiple signals with the same length and sampling frequency.
 
   - `system`: GNSS system (e.g., `GPSL1()`)
   - `num_samples_to_integrate_coherently`: Number of samples per coherent integration chunk
+  - `linear_fft_size`: FFT size for linear correlation (2 × num_samples_to_integrate_coherently)
   - `sampling_freq`: Sampling frequency
   - `dopplers`: Range of Doppler frequencies to search
   - `avail_prn_channels`: PRN channels available in this plan
@@ -21,6 +22,7 @@ multiple signals with the same length and sampling frequency.
 struct AcquisitionPlan{T<:AbstractFloat,S,DS,CS,P,BP,PS}
     system::S
     num_samples_to_integrate_coherently::Int
+    linear_fft_size::Int
     bfft_size::Int
     sampling_freq::typeof(1.0Hz)
     dopplers::DS
@@ -122,10 +124,16 @@ function AcquisitionPlan(
         num_code_dopplers,
     )
 
+    # Double Block Zero Padding (DBZP): zero-pad signal and code to >= 2N before FFT to
+    # convert circular correlation into linear correlation, eliminating boundary artifacts
+    # when code_length * sampling_freq / code_freq is non-integer.
+    # See: D.J.R. van Nee and A.J.R.M. Coenen, "New Fast GPS Code-Acquisition Technique
+    # Using FFT," Electronics Letters, vol. 27, no. 2, pp. 158-160, Jan. 1991.
+    linear_fft_size = fftw_friendly_size(2 * num_samples_to_integrate_coherently)
     bfft_size =
         zero_pad_power > 0 ?
-        fftw_friendly_size(num_samples_to_integrate_coherently) << (zero_pad_power - 1) :
-        num_samples_to_integrate_coherently
+        nextpow(2, linear_fft_size) << (zero_pad_power - 1) :
+        linear_fft_size
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,
@@ -136,6 +144,7 @@ function AcquisitionPlan(
         T,
         system,
         num_samples_to_integrate_coherently,
+        linear_fft_size,
         bfft_size,
         sampling_freq,
         prns,
@@ -144,8 +153,7 @@ function AcquisitionPlan(
     )
     chunk_duration = num_samples_to_integrate_coherently / sampling_freq
     code_interval = get_code_length(system) / get_code_frequency(system)
-    effective_sampling_freq =
-        sampling_freq * bfft_size / num_samples_to_integrate_coherently
+    effective_sampling_freq = sampling_freq * bfft_size / linear_fft_size
     signal_powers = [
         Matrix{Float32}(
             undef,
@@ -171,6 +179,7 @@ function AcquisitionPlan(
     AcquisitionPlan(
         system,
         num_samples_to_integrate_coherently,
+        linear_fft_size,
         bfft_size,
         sampling_freq,
         dopplers,
@@ -303,10 +312,12 @@ function CoarseFineAcquisitionPlan(
         num_code_dopplers,
     )
 
+    # DBZP: see comment in AcquisitionPlan constructor
+    linear_fft_size = fftw_friendly_size(2 * num_samples_to_integrate_coherently)
     bfft_size =
         zero_pad_power > 0 ?
-        fftw_friendly_size(num_samples_to_integrate_coherently) << (zero_pad_power - 1) :
-        num_samples_to_integrate_coherently
+        nextpow(2, linear_fft_size) << (zero_pad_power - 1) :
+        linear_fft_size
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,
@@ -317,6 +328,7 @@ function CoarseFineAcquisitionPlan(
         T,
         system,
         num_samples_to_integrate_coherently,
+        linear_fft_size,
         bfft_size,
         sampling_freq,
         prns,
@@ -325,8 +337,7 @@ function CoarseFineAcquisitionPlan(
     )
     Δt = num_samples_to_integrate_coherently / sampling_freq
     code_interval = get_code_length(system) / get_code_frequency(system)
-    effective_sampling_freq =
-        sampling_freq * bfft_size / num_samples_to_integrate_coherently
+    effective_sampling_freq = sampling_freq * bfft_size / linear_fft_size
     coarse_signal_powers = [
         Matrix{Float32}(
             undef,
@@ -372,6 +383,7 @@ function CoarseFineAcquisitionPlan(
     coarse_plan = AcquisitionPlan(
         system,
         num_samples_to_integrate_coherently,
+        linear_fft_size,
         bfft_size,
         sampling_freq,
         coarse_dopplers,
@@ -410,6 +422,7 @@ function CoarseFineAcquisitionPlan(
     fine_plan = AcquisitionPlan(
         system,
         num_samples_to_integrate_coherently,
+        linear_fft_size,
         bfft_size,
         sampling_freq,
         fine_doppler_range,
@@ -563,6 +576,7 @@ function common_buffers(
     ::Type{T},
     system,
     num_samples_to_integrate_coherently,
+    linear_fft_size,
     bfft_size,
     sampling_freq,
     prns,
@@ -571,16 +585,21 @@ function common_buffers(
 ) where {T}
     codes = [
         [
-            gen_code(
-                num_samples_to_integrate_coherently,
-                system,
-                sat_prn,
-                sampling_freq,
-                get_code_frequency(system) + code_doppler * 1.0Hz,
-            ) for code_doppler in code_dopplers
+            begin
+                code = gen_code(
+                    num_samples_to_integrate_coherently,
+                    system,
+                    sat_prn,
+                    sampling_freq,
+                    get_code_frequency(system) + code_doppler * 1.0Hz,
+                )
+                padded = zeros(eltype(code), linear_fft_size)
+                padded[1:num_samples_to_integrate_coherently] .= code
+                padded
+            end for code_doppler in code_dopplers
         ] for sat_prn in prns
     ]
-    signal_baseband = Vector{Complex{T}}(undef, num_samples_to_integrate_coherently)
+    signal_baseband = Vector{Complex{T}}(undef, linear_fft_size)
     signal_baseband_freq_domain = similar(signal_baseband)
     code_freq_baseband_freq_domain = Vector{ComplexF32}(undef, bfft_size)
     code_baseband = similar(code_freq_baseband_freq_domain)

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -497,6 +497,26 @@ function compute_code_doppler_grid(system, min_doppler, max_doppler, code_dopple
 end
 
 """
+    code_doppler_index(doppler_hz, ratio, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
+
+Map a single carrier Doppler value (in Hz, unitless) to the index of the nearest
+pre-computed code Doppler replica.
+"""
+@inline function code_doppler_index(
+    doppler_hz,
+    ratio,
+    code_doppler_step,
+    code_doppler_offset_idx,
+    num_code_dopplers,
+)
+    clamp(
+        round(Int, doppler_hz * ratio / code_doppler_step) + code_doppler_offset_idx,
+        1,
+        num_code_dopplers,
+    )
+end
+
+"""
     compute_code_doppler_indices(dopplers, system, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
 
 Map each carrier Doppler bin to the index of the nearest pre-computed code Doppler replica.
@@ -510,10 +530,11 @@ function compute_code_doppler_indices(
 )
     ratio = get_code_center_frequency_ratio(system)
     [
-        clamp(
-            round(Int, ustrip(doppler) * ratio / code_doppler_step) +
+        code_doppler_index(
+            ustrip(doppler),
+            ratio,
+            code_doppler_step,
             code_doppler_offset_idx,
-            1,
             num_code_dopplers,
         ) for doppler in dopplers
     ]

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -18,9 +18,10 @@ multiple signals with the same length and sampling frequency.
 
 [`acquire!`](@ref), [`CoarseFineAcquisitionPlan`](@ref)
 """
-struct AcquisitionPlan{T<:AbstractFloat,S,DS,CS,P,IP,PS}
+struct AcquisitionPlan{T<:AbstractFloat,S,DS,CS,P,BP,PS}
     system::S
     num_samples_to_integrate_coherently::Int
+    bfft_size::Int
     sampling_freq::typeof(1.0Hz)
     dopplers::DS
     codes_freq_domain::CS
@@ -34,7 +35,7 @@ struct AcquisitionPlan{T<:AbstractFloat,S,DS,CS,P,IP,PS}
     code_baseband::Vector{ComplexF32}
     signal_powers::Vector{Matrix{Float32}}
     fft_plan::P
-    ifft_plan::IP
+    bfft_plan::BP
     avail_prn_channels::PS
     results::Vector{AcquisitionResults{S,Float32,DS}}
     prn_indices::Vector{Int}
@@ -97,33 +98,57 @@ function AcquisitionPlan(
     max_doppler = 7000Hz,
     min_doppler = -max_doppler,
     doppler_step_factor = 1//3,
-    doppler_step = doppler_step_factor * sampling_freq / num_samples_to_integrate_coherently,
+    doppler_step = doppler_step_factor * sampling_freq /
+                   num_samples_to_integrate_coherently,
     dopplers = min_doppler:doppler_step:max_doppler,
     code_doppler_tolerance = 0.01,
     prns = 1:34,
     fft_flag = FFTW.MEASURE,
+    zero_pad_power::Int = 1,
 ) where {T<:AbstractFloat}
     # Code Doppler step: tolerance (cycles of phase error) / integration time (s) = Hz
     T_coh = num_samples_to_integrate_coherently / sampling_freq
     code_doppler_step = code_doppler_tolerance / ustrip(T_coh)
-    code_dopplers, n_neg = compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step)
+    code_dopplers, n_neg =
+        compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step)
     code_doppler_offset_idx = n_neg + 1
     num_code_dopplers = length(code_dopplers)
-    code_doppler_indices = compute_code_doppler_indices(dopplers, system, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
+    code_doppler_indices = compute_code_doppler_indices(
+        dopplers,
+        system,
+        code_doppler_step,
+        code_doppler_offset_idx,
+        num_code_dopplers,
+    )
 
+    bfft_size =
+        zero_pad_power > 0 ?
+        fftw_friendly_size(num_samples_to_integrate_coherently) << (zero_pad_power - 1) :
+        num_samples_to_integrate_coherently
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,
     code_baseband,
     codes_freq_domain,
     fft_plan,
-    ifft_plan = common_buffers(T, system, num_samples_to_integrate_coherently, sampling_freq, prns, fft_flag, code_dopplers)
+    bfft_plan = common_buffers(
+        T,
+        system,
+        num_samples_to_integrate_coherently,
+        bfft_size,
+        sampling_freq,
+        prns,
+        fft_flag,
+        code_dopplers,
+    )
     chunk_duration = num_samples_to_integrate_coherently / sampling_freq
     code_interval = get_code_length(system) / get_code_frequency(system)
+    effective_sampling_freq =
+        sampling_freq * bfft_size / num_samples_to_integrate_coherently
     signal_powers = [
         Matrix{Float32}(
             undef,
-            ceil(Int, sampling_freq * min(chunk_duration, code_interval)),
+            ceil(Int, effective_sampling_freq * min(chunk_duration, code_interval)),
             length(dopplers),
         ) for _ in prns
     ]
@@ -138,14 +163,14 @@ function AcquisitionPlan(
             Float32(0),
             signal_powers[i],
             dopplers,
-        )
-        for (i, prn) in enumerate(prns)
+        ) for (i, prn) in enumerate(prns)
     ]
     prn_indices = Vector{Int}(undef, length(prns))
     output_results = Vector{Base.eltype(results)}(undef, length(prns))
     AcquisitionPlan(
         system,
         num_samples_to_integrate_coherently,
+        bfft_size,
         sampling_freq,
         dopplers,
         codes_freq_domain,
@@ -159,7 +184,7 @@ function AcquisitionPlan(
         code_baseband,
         signal_powers,
         fft_plan,
-        ifft_plan,
+        bfft_plan,
         prns,
         results,
         prn_indices,
@@ -168,11 +193,7 @@ function AcquisitionPlan(
 end
 
 # Convenience constructor that defaults num_samples_to_integrate_coherently to one bit period
-function AcquisitionPlan(
-    system,
-    sampling_freq;
-    kwargs...
-)
+function AcquisitionPlan(system, sampling_freq; kwargs...)
     # Default to one bit period worth of samples for optimal non-coherent integration
     data_frequency = get_data_frequency(system)
     num_samples_to_integrate_coherently = ceil(Int, sampling_freq / data_frequency)
@@ -261,84 +282,166 @@ function CoarseFineAcquisitionPlan(
     code_doppler_tolerance = 0.01,
     prns = 1:34,
     fft_flag = FFTW.MEASURE,
+    zero_pad_power::Int = 1,
 ) where {T<:AbstractFloat}
     # Code Doppler step: tolerance (cycles of phase error) / integration time (s) = Hz
     T_coh = num_samples_to_integrate_coherently / sampling_freq
     code_doppler_step = code_doppler_tolerance / ustrip(T_coh)
-    code_dopplers, n_neg = compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step)
+    code_dopplers, n_neg =
+        compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step)
     code_doppler_offset_idx = n_neg + 1
     num_code_dopplers = length(code_dopplers)
 
     coarse_dopplers = min_doppler:coarse_step:max_doppler
-    coarse_code_doppler_indices = compute_code_doppler_indices(coarse_dopplers, system, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
+    coarse_code_doppler_indices = compute_code_doppler_indices(
+        coarse_dopplers,
+        system,
+        code_doppler_step,
+        code_doppler_offset_idx,
+        num_code_dopplers,
+    )
 
+    bfft_size =
+        zero_pad_power > 0 ?
+        fftw_friendly_size(num_samples_to_integrate_coherently) << (zero_pad_power - 1) :
+        num_samples_to_integrate_coherently
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,
     code_baseband,
     codes_freq_domain,
     fft_plan,
-    ifft_plan = common_buffers(T, system, num_samples_to_integrate_coherently, sampling_freq, prns, fft_flag, code_dopplers)
+    bfft_plan = common_buffers(
+        T,
+        system,
+        num_samples_to_integrate_coherently,
+        bfft_size,
+        sampling_freq,
+        prns,
+        fft_flag,
+        code_dopplers,
+    )
     Δt = num_samples_to_integrate_coherently / sampling_freq
     code_interval = get_code_length(system) / get_code_frequency(system)
+    effective_sampling_freq =
+        sampling_freq * bfft_size / num_samples_to_integrate_coherently
     coarse_signal_powers = [
         Matrix{Float32}(
             undef,
-            ceil(Int, sampling_freq * min(Δt, code_interval)),
+            ceil(Int, effective_sampling_freq * min(Δt, code_interval)),
             length(coarse_dopplers),
         ) for _ in prns
     ]
 
-    fine_doppler_range = -2*coarse_step:fine_step:2*coarse_step
+    fine_doppler_range = (-2*coarse_step):fine_step:(2*coarse_step)
     # Fine plan indices are precomputed assuming offset=0, but the fine search always
     # uses a non-zero doppler_offset (the coarse estimate), so cd_idx is recomputed
     # inline in acquire!. These indices satisfy the struct field requirement.
-    fine_code_doppler_indices = compute_code_doppler_indices(fine_doppler_range, system, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
+    fine_code_doppler_indices = compute_code_doppler_indices(
+        fine_doppler_range,
+        system,
+        code_doppler_step,
+        code_doppler_offset_idx,
+        num_code_dopplers,
+    )
 
     fine_signal_powers = [
         Matrix{Float32}(
             undef,
-            ceil(Int, sampling_freq * min(Δt, code_interval)),
+            ceil(Int, effective_sampling_freq * min(Δt, code_interval)),
             length(fine_doppler_range),
         ) for _ in prns
     ]
     coarse_results = [
-        AcquisitionResults(system, prn, sampling_freq, 0.0Hz, 0.0, 0.0, Float32(0), coarse_signal_powers[i], coarse_dopplers)
-        for (i, prn) in enumerate(prns)
+        AcquisitionResults(
+            system,
+            prn,
+            sampling_freq,
+            0.0Hz,
+            0.0,
+            0.0,
+            Float32(0),
+            coarse_signal_powers[i],
+            coarse_dopplers,
+        ) for (i, prn) in enumerate(prns)
     ]
     coarse_prn_indices = Vector{Int}(undef, length(prns))
     coarse_output_results = Vector{Base.eltype(coarse_results)}(undef, length(prns))
     coarse_plan = AcquisitionPlan(
-        system, num_samples_to_integrate_coherently, sampling_freq, coarse_dopplers,
-        codes_freq_domain, coarse_code_doppler_indices, code_doppler_step, code_doppler_offset_idx, num_code_dopplers,
-        signal_baseband, signal_baseband_freq_domain, code_freq_baseband_freq_domain, code_baseband,
-        coarse_signal_powers, fft_plan, ifft_plan, prns, coarse_results, coarse_prn_indices, coarse_output_results,
+        system,
+        num_samples_to_integrate_coherently,
+        bfft_size,
+        sampling_freq,
+        coarse_dopplers,
+        codes_freq_domain,
+        coarse_code_doppler_indices,
+        code_doppler_step,
+        code_doppler_offset_idx,
+        num_code_dopplers,
+        signal_baseband,
+        signal_baseband_freq_domain,
+        code_freq_baseband_freq_domain,
+        code_baseband,
+        coarse_signal_powers,
+        fft_plan,
+        bfft_plan,
+        prns,
+        coarse_results,
+        coarse_prn_indices,
+        coarse_output_results,
     )
     fine_results = [
-        AcquisitionResults(system, prn, sampling_freq, 0.0Hz, 0.0, 0.0, Float32(0), fine_signal_powers[i], fine_doppler_range)
-        for (i, prn) in enumerate(prns)
+        AcquisitionResults(
+            system,
+            prn,
+            sampling_freq,
+            0.0Hz,
+            0.0,
+            0.0,
+            Float32(0),
+            fine_signal_powers[i],
+            fine_doppler_range,
+        ) for (i, prn) in enumerate(prns)
     ]
     fine_prn_indices = Vector{Int}(undef, length(prns))
     fine_output_results = Vector{Base.eltype(fine_results)}(undef, length(prns))
     fine_plan = AcquisitionPlan(
-        system, num_samples_to_integrate_coherently, sampling_freq, fine_doppler_range,
-        codes_freq_domain, fine_code_doppler_indices, code_doppler_step, code_doppler_offset_idx, num_code_dopplers,
-        signal_baseband, signal_baseband_freq_domain, code_freq_baseband_freq_domain, code_baseband,
-        fine_signal_powers, fft_plan, ifft_plan, prns, fine_results, fine_prn_indices, fine_output_results,
+        system,
+        num_samples_to_integrate_coherently,
+        bfft_size,
+        sampling_freq,
+        fine_doppler_range,
+        codes_freq_domain,
+        fine_code_doppler_indices,
+        code_doppler_step,
+        code_doppler_offset_idx,
+        num_code_dopplers,
+        signal_baseband,
+        signal_baseband_freq_domain,
+        code_freq_baseband_freq_domain,
+        code_baseband,
+        fine_signal_powers,
+        fft_plan,
+        bfft_plan,
+        prns,
+        fine_results,
+        fine_prn_indices,
+        fine_output_results,
     )
     CoarseFineAcquisitionPlan(coarse_plan, fine_plan)
 end
 
 # Convenience constructor that defaults num_samples_to_integrate_coherently to one bit period
-function CoarseFineAcquisitionPlan(
-    system,
-    sampling_freq;
-    kwargs...
-)
+function CoarseFineAcquisitionPlan(system, sampling_freq; kwargs...)
     # Default to one bit period worth of samples for optimal non-coherent integration
     data_frequency = get_data_frequency(system)
     num_samples_to_integrate_coherently = ceil(Int, sampling_freq / data_frequency)
-    CoarseFineAcquisitionPlan(system, num_samples_to_integrate_coherently, sampling_freq; kwargs...)
+    CoarseFineAcquisitionPlan(
+        system,
+        num_samples_to_integrate_coherently,
+        sampling_freq;
+        kwargs...,
+    )
 end
 
 """
@@ -356,7 +459,7 @@ function compute_code_doppler_grid(system, min_doppler, max_doppler, code_dopple
     max_code_doppler = ustrip(max_doppler) * ratio
     n_neg = ceil(Int, -min_code_doppler / code_doppler_step)
     n_pos = ceil(Int, max_code_doppler / code_doppler_step)
-    code_dopplers = (-n_neg:n_pos) .* code_doppler_step
+    code_dopplers = ((-n_neg):n_pos) .* code_doppler_step
     return code_dopplers, n_neg
 end
 
@@ -365,10 +468,32 @@ end
 
 Map each carrier Doppler bin to the index of the nearest pre-computed code Doppler replica.
 """
-function compute_code_doppler_indices(dopplers, system, code_doppler_step, code_doppler_offset_idx, num_code_dopplers)
+function compute_code_doppler_indices(
+    dopplers,
+    system,
+    code_doppler_step,
+    code_doppler_offset_idx,
+    num_code_dopplers,
+)
     ratio = get_code_center_frequency_ratio(system)
-    [clamp(round(Int, ustrip(doppler) * ratio / code_doppler_step) + code_doppler_offset_idx, 1, num_code_dopplers) for doppler in dopplers]
+    [
+        clamp(
+            round(Int, ustrip(doppler) * ratio / code_doppler_step) +
+            code_doppler_offset_idx,
+            1,
+            num_code_dopplers,
+        ) for doppler in dopplers
+    ]
 end
+
+"""
+    fftw_friendly_size(n)
+
+Return the smallest integer `≥ n` whose prime factors are all in {2, 3, 5, 7}.
+FFTW is efficient for these "smooth" sizes; padding to the next power of 2 can be
+much larger than necessary (e.g. 20000 → 32768) and hurt performance.
+"""
+fftw_friendly_size(n::Integer) = nextprod((2, 3, 5, 7), n)
 
 const FFTW_WISDOM_DIR = @get_scratch!("fftw_wisdom")
 
@@ -384,39 +509,42 @@ function common_buffers(
     ::Type{T},
     system,
     num_samples_to_integrate_coherently,
+    bfft_size,
     sampling_freq,
     prns,
     fft_flag,
     code_dopplers,
 ) where {T}
     codes = [
-        [gen_code(num_samples_to_integrate_coherently, system, sat_prn, sampling_freq,
-                  get_code_frequency(system) + code_doppler * 1.0Hz)
-         for code_doppler in code_dopplers]
-        for sat_prn in prns
+        [
+            gen_code(
+                num_samples_to_integrate_coherently,
+                system,
+                sat_prn,
+                sampling_freq,
+                get_code_frequency(system) + code_doppler * 1.0Hz,
+            ) for code_doppler in code_dopplers
+        ] for sat_prn in prns
     ]
     signal_baseband = Vector{Complex{T}}(undef, num_samples_to_integrate_coherently)
     signal_baseband_freq_domain = similar(signal_baseband)
-    code_freq_baseband_freq_domain = Vector{ComplexF32}(undef, num_samples_to_integrate_coherently)
+    code_freq_baseband_freq_domain = Vector{ComplexF32}(undef, bfft_size)
     code_baseband = similar(code_freq_baseband_freq_domain)
-    fft_plan, ifft_plan = if fft_flag != FFTW.ESTIMATE
+    fft_plan, bfft_plan = if fft_flag != FFTW.ESTIMATE
         with_fftw_wisdom() do
             plan_fft(signal_baseband; flags = fft_flag),
-            plan_ifft(code_freq_baseband_freq_domain; flags = fft_flag)
+            plan_bfft(code_freq_baseband_freq_domain; flags = fft_flag)
         end
     else
         plan_fft(signal_baseband; flags = fft_flag),
-        plan_ifft(code_freq_baseband_freq_domain; flags = fft_flag)
+        plan_bfft(code_freq_baseband_freq_domain; flags = fft_flag)
     end
-    codes_freq_domain = [
-        [fft_plan * code for code in prn_codes]
-        for prn_codes in codes
-    ]
+    codes_freq_domain = [[fft_plan * code for code in prn_codes] for prn_codes in codes]
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,
     code_baseband,
     codes_freq_domain,
     fft_plan,
-    ifft_plan
+    bfft_plan
 end

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -106,7 +106,7 @@ function AcquisitionPlan(
     max_code_doppler_loss = 0.5dB,
     prns = 1:34,
     fft_flag = FFTW.MEASURE,
-    zero_pad_power::Int = 1,
+    zero_pad_power::Int = 0,
 ) where {T<:AbstractFloat}
     # Convert dB loss to max phase error (cycles), then to code Doppler step (Hz)
     T_coh = num_samples_to_integrate_coherently / sampling_freq
@@ -130,10 +130,7 @@ function AcquisitionPlan(
     # See: D.J.R. van Nee and A.J.R.M. Coenen, "New Fast GPS Code-Acquisition Technique
     # Using FFT," Electronics Letters, vol. 27, no. 2, pp. 158-160, Jan. 1991.
     linear_fft_size = fftw_friendly_size(2 * num_samples_to_integrate_coherently)
-    bfft_size =
-        zero_pad_power > 0 ?
-        nextpow(2, linear_fft_size) << (zero_pad_power - 1) :
-        linear_fft_size
+    bfft_size = fftw_friendly_size(linear_fft_size << zero_pad_power)
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,
@@ -292,7 +289,7 @@ function CoarseFineAcquisitionPlan(
     max_code_doppler_loss = 0.5dB,
     prns = 1:34,
     fft_flag = FFTW.MEASURE,
-    zero_pad_power::Int = 1,
+    zero_pad_power::Int = 0,
 ) where {T<:AbstractFloat}
     # Convert dB loss to max phase error (cycles), then to code Doppler step (Hz)
     T_coh = num_samples_to_integrate_coherently / sampling_freq
@@ -314,10 +311,7 @@ function CoarseFineAcquisitionPlan(
 
     # DBZP: see comment in AcquisitionPlan constructor
     linear_fft_size = fftw_friendly_size(2 * num_samples_to_integrate_coherently)
-    bfft_size =
-        zero_pad_power > 0 ?
-        nextpow(2, linear_fft_size) << (zero_pad_power - 1) :
-        linear_fft_size
+    bfft_size = fftw_friendly_size(linear_fft_size << zero_pad_power)
     signal_baseband,
     signal_baseband_freq_domain,
     code_freq_baseband_freq_domain,

--- a/src/plan_acquire.jl
+++ b/src/plan_acquire.jl
@@ -68,10 +68,10 @@ Create an acquisition plan for efficient repeated acquisition.
   - `doppler_step_factor`: Factor for computing Doppler step from integration time (default: `1//3`)
   - `prns`: PRN channels to prepare (default: `1:34`)
   - `fft_flag`: FFTW planning flag (default: `FFTW.MEASURE`)
-  - `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
-    Controls how many code replicas are pre-computed at different code Doppler offsets.
-    Smaller values improve accuracy at high Dopplers with long integration times, at the
-    cost of more memory.
+  - `max_code_doppler_loss`: Maximum acceptable correlation loss in dB from code Doppler
+    mismatch (default: `0.5`). Controls how many code replicas are pre-computed at different
+    code Doppler offsets. This parameter works uniformly across all GNSS systems regardless
+    of chip rate. Typical values: `0.5` (negligible loss), `1.0` (mild loss), `3.0` (aggressive).
 
 # Example
 
@@ -101,14 +101,15 @@ function AcquisitionPlan(
     doppler_step = doppler_step_factor * sampling_freq /
                    num_samples_to_integrate_coherently,
     dopplers = min_doppler:doppler_step:max_doppler,
-    code_doppler_tolerance = 0.01,
+    max_code_doppler_loss = 0.5dB,
     prns = 1:34,
     fft_flag = FFTW.MEASURE,
     zero_pad_power::Int = 1,
 ) where {T<:AbstractFloat}
-    # Code Doppler step: tolerance (cycles of phase error) / integration time (s) = Hz
+    # Convert dB loss to max phase error (cycles), then to code Doppler step (Hz)
     T_coh = num_samples_to_integrate_coherently / sampling_freq
-    code_doppler_step = code_doppler_tolerance / ustrip(T_coh)
+    max_phase_err = max_phase_error_from_loss(max_code_doppler_loss)
+    code_doppler_step = max_phase_err > 0 ? max_phase_err / ustrip(T_coh) : Inf
     code_dopplers, n_neg =
         compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step)
     code_doppler_offset_idx = n_neg + 1
@@ -247,10 +248,10 @@ Create a two-stage coarse-fine acquisition plan.
   - `doppler_step_factor`: Factor for computing coarse step from integration time (default: `1//3`)
   - `prns`: PRN channels to prepare (default: `1:34`)
   - `fft_flag`: FFTW planning flag (default: `FFTW.MEASURE`)
-  - `code_doppler_tolerance`: Maximum allowed code Doppler mismatch × integration time (default: `0.01`).
-    Controls how many code replicas are pre-computed at different code Doppler offsets.
-    Smaller values improve accuracy at high Dopplers with long integration times, at the
-    cost of more memory.
+  - `max_code_doppler_loss`: Maximum acceptable correlation loss in dB from code Doppler
+    mismatch (default: `0.5`). Controls how many code replicas are pre-computed at different
+    code Doppler offsets. This parameter works uniformly across all GNSS systems regardless
+    of chip rate. Typical values: `0.5` (negligible loss), `1.0` (mild loss), `3.0` (aggressive).
 
 # Example
 
@@ -279,14 +280,15 @@ function CoarseFineAcquisitionPlan(
     doppler_step_factor = 1//3,
     coarse_step = doppler_step_factor * sampling_freq / num_samples_to_integrate_coherently,
     fine_step = coarse_step / 10,
-    code_doppler_tolerance = 0.01,
+    max_code_doppler_loss = 0.5dB,
     prns = 1:34,
     fft_flag = FFTW.MEASURE,
     zero_pad_power::Int = 1,
 ) where {T<:AbstractFloat}
-    # Code Doppler step: tolerance (cycles of phase error) / integration time (s) = Hz
+    # Convert dB loss to max phase error (cycles), then to code Doppler step (Hz)
     T_coh = num_samples_to_integrate_coherently / sampling_freq
-    code_doppler_step = code_doppler_tolerance / ustrip(T_coh)
+    max_phase_err = max_phase_error_from_loss(max_code_doppler_loss)
+    code_doppler_step = max_phase_err > 0 ? max_phase_err / ustrip(T_coh) : Inf
     code_dopplers, n_neg =
         compute_code_doppler_grid(system, min_doppler, max_doppler, code_doppler_step)
     code_doppler_offset_idx = n_neg + 1
@@ -442,6 +444,37 @@ function CoarseFineAcquisitionPlan(system, sampling_freq; kwargs...)
         sampling_freq;
         kwargs...,
     )
+end
+
+"""
+    max_phase_error_from_loss(loss_dB)
+
+Compute the maximum code phase error (in cycles) that produces at most `loss_dB` of
+correlation loss. The correlation loss from a linear code frequency mismatch over the
+integration interval is `sinc²(ε)` where `ε` is the accumulated phase error in cycles.
+
+Accepts a Unitful `Gain` value (e.g. `0.5u"dB"`).
+
+Uses Newton's method to invert `sinc(ε) = 10^(-loss_dB/20)` for `ε ∈ [0, 0.5]`.
+"""
+function max_phase_error_from_loss(loss::Gain)
+    loss_dB = loss.val
+    loss_dB <= 0 && return 0.0
+    target = 10^(-loss_dB / 20)  # sinc(ε) threshold
+    target >= 1 && return 0.0
+    # Initial guess from small-angle approximation: sinc(ε) ≈ 1 - π²ε²/6
+    ε = sqrt(6 * (1 - target)) / π
+    # Newton iterations on f(ε) = sinc(ε) - target = sin(πε)/(πε) - target
+    for _ = 1:10
+        πε = π * ε
+        s, c = sincos(πε)
+        sinc_val = s / πε
+        # d/dε sinc(ε) = (cos(πε) - sinc(ε)) / ε
+        sinc_deriv = (c - sinc_val) / ε
+        ε -= (sinc_val - target) / sinc_deriv
+        ε = clamp(ε, 0.0, 0.5)
+    end
+    return ε
 end
 
 """

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -2,31 +2,8 @@
                                                             [GPSL1(), GalileoE1B()],
     type in [Float64, Float32, Int16, Int32]
 
-    Random.seed!(2345)
-    num_samples = 60000
-    doppler = 1234Hz
-    code_phase = 110.613261
-    prn = 1
-    sampling_freq = 15e6Hz - 1Hz # Allow num_samples * sampling_freq to be non integer of ms
-    interm_freq = 243.0Hz
-    CN0 = 45
-
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
-    )
-
-    carrier =
-        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
-
-    noise_power = 10 * log10(sampling_freq / 1.0Hz)
-    signal_power = CN0
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    (; signal, doppler, code_phase, prn, sampling_freq, interm_freq, CN0, num_samples) =
+        generate_test_signal(system, 1)
     if type <: Integer
         signal_typed = complex.(floor.(type, real.(signal)), floor.(type, imag.(signal)))
     else
@@ -124,32 +101,9 @@ end
 end
 
 @testset "Acquire with asymmetric Doppler range" begin
-    Random.seed!(2345)
     system = GPSL1()
-    num_samples = 60000
-    doppler = 1234Hz
-    code_phase = 110.613261
-    prn = 1
-    sampling_freq = 15e6Hz - 1Hz
-    interm_freq = 243.0Hz
-    CN0 = 45
-
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
-    )
-
-    carrier =
-        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
-
-    noise_power = 10 * log10(sampling_freq / 1.0Hz)
-    signal_power = CN0
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    (; signal, doppler, code_phase, prn, sampling_freq, interm_freq, CN0) =
+        generate_test_signal(system, 1)
     signal_typed = Complex{Float64}.(signal)
 
     # Test asymmetric Doppler range: 0Hz to 7000Hz (positive only)
@@ -352,13 +306,8 @@ end
 end
 
 @testset "Non-coherent integration for signals longer than bit period" begin
-    Random.seed!(4567)
     system = GPSL1()
     sampling_freq = 5e6Hz
-    doppler = 500Hz
-    code_phase = 50.5
-    prn = 1
-    CN0 = 45
 
     # Calculate bit period samples (20ms for GPS L1 at 50Hz data rate)
     bit_period_samples = ceil(Int, sampling_freq / get_data_frequency(system))
@@ -366,21 +315,11 @@ end
     # Create signal spanning 2.5 bit periods (50ms)
     num_samples = ceil(Int, 2.5 * bit_period_samples)
 
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
+    (; signal, doppler, code_phase, prn, CN0) = generate_test_signal(
+        system, 1;
+        seed = 4567, num_samples, doppler = 500Hz, code_phase = 50.5,
+        sampling_freq, interm_freq = 0.0Hz, phase_offset = 0.0,
     )
-
-    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
-
-    noise_power = 10 * log10(sampling_freq / 1.0Hz)
-    signal_power = CN0
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
     signal_typed = ComplexF32.(signal)
 
     # Test with plan using default bit period chunk size
@@ -461,35 +400,18 @@ end
 end
 
 @testset "Code Doppler compensation with long coherent integration" begin
-    Random.seed!(7890)
     system = GPSL1()
     sampling_freq = 5e6Hz
-    doppler = 5000Hz
-    code_phase = 50.5
-    prn = 1
-    CN0 = 55  # High CN0 for clean detection
 
     # Long coherent integration: 10ms (10x the default 1ms code period)
     T_coh_ms = 10
     num_samples = ceil(Int, T_coh_ms * 1e-3 * (sampling_freq / 1.0Hz))
 
-    # Generate signal with realistic code Doppler
-    code_doppler = doppler * get_code_center_frequency_ratio(system)
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + code_doppler,
-        code_phase,
+    (; signal, doppler, code_phase, prn, CN0) = generate_test_signal(
+        system, 1;
+        seed = 7890, num_samples, doppler = 5000Hz, code_phase = 50.5,
+        sampling_freq, interm_freq = 0.0Hz, CN0 = 55, phase_offset = 0.0,
     )
-
-    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
-
-    noise_power = 10 * log10(sampling_freq / 1.0Hz)
-    signal_power = CN0
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
     signal_typed = ComplexF32.(signal)
 
     # Acquire with code Doppler compensation (default tolerance)

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -49,12 +49,12 @@
 
     inplace_acq_res = @inferred acquire!(acq_plan, signal_typed, prn; interm_freq)
 
-    @test acq_res.code_phase ≈ code_phase atol = 0.08
+    @test acq_res.code_phase ≈ code_phase atol = 0.04
     @test abs(acq_res.carrier_doppler - doppler) < step(dopplers) / 2
     @test acq_res.prn == prn
     @test acq_res.CN0 ≈ CN0 atol = 7
 
-    @test inplace_acq_res.code_phase ≈ code_phase atol = 0.08
+    @test inplace_acq_res.code_phase ≈ code_phase atol = 0.04
     @test abs(inplace_acq_res.carrier_doppler - doppler) < step(dopplers) / 2
     @test inplace_acq_res.prn == prn
     @test inplace_acq_res.CN0 ≈ CN0 atol = 7
@@ -72,12 +72,12 @@
     inplace_inplace_acq_res =
         @inferred acquire!(coarse_fine_acq_plan, signal_typed, prn; interm_freq)
 
-    @test coarse_fine_acq_res.code_phase ≈ code_phase atol = 0.08
+    @test coarse_fine_acq_res.code_phase ≈ code_phase atol = 0.04
     @test abs(coarse_fine_acq_res.carrier_doppler - doppler) < step(dopplers) / 2
     @test coarse_fine_acq_res.prn == prn
     @test coarse_fine_acq_res.CN0 ≈ CN0 atol = 7
 
-    @test inplace_inplace_acq_res.code_phase ≈ code_phase atol = 0.08
+    @test inplace_inplace_acq_res.code_phase ≈ code_phase atol = 0.04
     @test abs(inplace_inplace_acq_res.carrier_doppler - doppler) < step(dopplers) / 2
     @test inplace_inplace_acq_res.prn == prn
     @test inplace_inplace_acq_res.CN0 ≈ CN0 atol = 7
@@ -168,7 +168,7 @@ end
         max_doppler,
     )
 
-    @test acq_res.code_phase ≈ code_phase atol = 0.08
+    @test acq_res.code_phase ≈ code_phase atol = 0.04
     @test abs(acq_res.carrier_doppler - doppler) < step(dopplers) / 2
     @test acq_res.prn == prn
     @test acq_res.CN0 ≈ CN0 atol = 7
@@ -188,7 +188,7 @@ end
 
     inplace_acq_res = @inferred acquire!(acq_plan, signal_typed, prn; interm_freq)
 
-    @test inplace_acq_res.code_phase ≈ code_phase atol = 0.08
+    @test inplace_acq_res.code_phase ≈ code_phase atol = 0.04
     @test abs(inplace_acq_res.carrier_doppler - doppler) < step(dopplers) / 2
     @test inplace_acq_res.prn == prn
     @test inplace_acq_res.CN0 ≈ CN0 atol = 7
@@ -204,7 +204,7 @@ end
         max_doppler,
     )
 
-    @test coarse_fine_acq_res.code_phase ≈ code_phase atol = 0.08
+    @test coarse_fine_acq_res.code_phase ≈ code_phase atol = 0.04
     @test abs(coarse_fine_acq_res.carrier_doppler - doppler) < step(dopplers) / 2
     @test coarse_fine_acq_res.prn == prn
     @test coarse_fine_acq_res.CN0 ≈ CN0 atol = 7
@@ -226,7 +226,7 @@ end
     inplace_coarse_fine_acq_res =
         @inferred acquire!(coarse_fine_acq_plan, signal_typed, prn; interm_freq)
 
-    @test inplace_coarse_fine_acq_res.code_phase ≈ code_phase atol = 0.08
+    @test inplace_coarse_fine_acq_res.code_phase ≈ code_phase atol = 0.04
     @test abs(inplace_coarse_fine_acq_res.carrier_doppler - doppler) < step(dopplers) / 2
     @test inplace_coarse_fine_acq_res.prn == prn
     @test inplace_coarse_fine_acq_res.CN0 ≈ CN0 atol = 7

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -21,7 +21,7 @@
     )
 
     carrier =
-        cis.(2π * (0:num_samples-1) * (interm_freq + doppler) / sampling_freq .+ π / 8)
+        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
 
     noise_power = 10 * log10(sampling_freq / 1.0Hz)
     signal_power = CN0
@@ -34,7 +34,7 @@
     end
 
     max_doppler = 7000Hz
-    dopplers = -max_doppler:250Hz:max_doppler
+    dopplers = (-max_doppler):250Hz:max_doppler
 
     acq_res =
         @inferred acquire(system, signal_typed, sampling_freq, prn; interm_freq, dopplers)
@@ -94,17 +94,25 @@ end
     @test eltype(plan_default.signal_baseband_freq_domain) == ComplexF32
 
     # Test explicit Float32
-    plan_f32 = AcquisitionPlan(system, num_samples, sampling_freq; prns = 1:1, eltype = Float32)
+    plan_f32 =
+        AcquisitionPlan(system, num_samples, sampling_freq; prns = 1:1, eltype = Float32)
     @test eltype(plan_f32.signal_baseband) == ComplexF32
     @test eltype(plan_f32.signal_baseband_freq_domain) == ComplexF32
 
     # Test Float64
-    plan_f64 = AcquisitionPlan(system, num_samples, sampling_freq; prns = 1:1, eltype = Float64)
+    plan_f64 =
+        AcquisitionPlan(system, num_samples, sampling_freq; prns = 1:1, eltype = Float64)
     @test eltype(plan_f64.signal_baseband) == ComplexF64
     @test eltype(plan_f64.signal_baseband_freq_domain) == ComplexF64
 
     # Test CoarseFineAcquisitionPlan with eltype
-    cf_plan_f64 = CoarseFineAcquisitionPlan(system, num_samples, sampling_freq; prns = 1:1, eltype = Float64)
+    cf_plan_f64 = CoarseFineAcquisitionPlan(
+        system,
+        num_samples,
+        sampling_freq;
+        prns = 1:1,
+        eltype = Float64,
+    )
     @test eltype(cf_plan_f64.coarse_plan.signal_baseband) == ComplexF64
     @test eltype(cf_plan_f64.fine_plan.signal_baseband) == ComplexF64
 
@@ -136,7 +144,7 @@ end
     )
 
     carrier =
-        cis.(2π * (0:num_samples-1) * (interm_freq + doppler) / sampling_freq .+ π / 8)
+        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
 
     noise_power = 10 * log10(sampling_freq / 1.0Hz)
     signal_power = CN0
@@ -247,7 +255,7 @@ end
     @test contains(output, "chips")
 
     # Test show for Vector{AcquisitionResults}
-    results = [acquire!(plan, signal, prn) for prn in 1:3]
+    results = [acquire!(plan, signal, prn) for prn = 1:3]
     io = IOBuffer()
     show(io, MIME"text/plain"(), results)
     output = String(take!(io))
@@ -258,10 +266,26 @@ end
 
     # Test CN0 highlighting (green for CN0 > 42, red for CN0 < 42)
     high_cn0_result = Acquisition.AcquisitionResults(
-        system, 1, sampling_freq, 0.0Hz, 0.0, 50.0, 0.0, zeros(1, 1), 0.0Hz:1.0Hz:0.0Hz
+        system,
+        1,
+        sampling_freq,
+        0.0Hz,
+        0.0,
+        50.0,
+        0.0,
+        zeros(1, 1),
+        0.0Hz:1.0Hz:0.0Hz,
     )
     low_cn0_result = Acquisition.AcquisitionResults(
-        system, 2, sampling_freq, 0.0Hz, 0.0, 30.0, 0.0, zeros(1, 1), 0.0Hz:1.0Hz:0.0Hz
+        system,
+        2,
+        sampling_freq,
+        0.0Hz,
+        0.0,
+        30.0,
+        0.0,
+        zeros(1, 1),
+        0.0Hz:1.0Hz:0.0Hz,
     )
     io = IOBuffer()
     ioc = IOContext(io, :color => true)
@@ -281,12 +305,7 @@ end
     # Use ComplexF32 signal to match default Float32 buffers (avoids type conversion allocations)
     signal = randn(ComplexF32, num_samples)
 
-    acq_plan = AcquisitionPlan(
-        system,
-        num_samples,
-        sampling_freq;
-        prns = 1:5,
-    )
+    acq_plan = AcquisitionPlan(system, num_samples, sampling_freq; prns = 1:5)
 
     # Verify plan.results field exists and is populated
     @test hasfield(typeof(acq_plan), :results)
@@ -316,12 +335,7 @@ end
     @test results[2].power_bins === acq_plan.signal_powers[3]
 
     # Test CoarseFineAcquisitionPlan is also allocation-free
-    cf_plan = CoarseFineAcquisitionPlan(
-        system,
-        num_samples,
-        sampling_freq;
-        prns = 1:5,
-    )
+    cf_plan = CoarseFineAcquisitionPlan(system, num_samples, sampling_freq; prns = 1:5)
 
     # Warmup
     acquire!(cf_plan, signal, prns)
@@ -361,7 +375,7 @@ end
         code_phase,
     )
 
-    carrier = cis.(2π * (0:num_samples-1) * doppler / sampling_freq)
+    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
 
     noise_power = 10 * log10(sampling_freq / 1.0Hz)
     signal_power = CN0
@@ -370,7 +384,8 @@ end
     signal_typed = ComplexF32.(signal)
 
     # Test with plan using default bit period chunk size
-    acq_plan = AcquisitionPlan(system, sampling_freq; prns = [prn], fft_flag = FFTW.ESTIMATE)
+    acq_plan =
+        AcquisitionPlan(system, sampling_freq; prns = [prn], fft_flag = FFTW.ESTIMATE)
     @test acq_plan.num_samples_to_integrate_coherently == bit_period_samples
 
     result = acquire!(acq_plan, signal_typed, prn)
@@ -390,7 +405,12 @@ end
     @test result.CN0 ≈ expected_CN0 atol = 5
 
     # Test CoarseFineAcquisitionPlan with long signal
-    cf_plan = CoarseFineAcquisitionPlan(system, sampling_freq; prns = [prn], fft_flag = FFTW.ESTIMATE)
+    cf_plan = CoarseFineAcquisitionPlan(
+        system,
+        sampling_freq;
+        prns = [prn],
+        fft_flag = FFTW.ESTIMATE,
+    )
     cf_result = acquire!(cf_plan, signal_typed, prn)
 
     @test cf_result.code_phase ≈ code_phase atol = 0.5
@@ -425,7 +445,12 @@ end
     @test allocs == 0
 
     # Also test CoarseFineAcquisitionPlan
-    cf_plan = CoarseFineAcquisitionPlan(system, sampling_freq; prns = 1:5, fft_flag = FFTW.ESTIMATE)
+    cf_plan = CoarseFineAcquisitionPlan(
+        system,
+        sampling_freq;
+        prns = 1:5,
+        fft_flag = FFTW.ESTIMATE,
+    )
 
     # Warmup
     acquire!(cf_plan, signal, prns)
@@ -459,7 +484,7 @@ end
         code_phase,
     )
 
-    carrier = cis.(2π * (0:num_samples-1) * doppler / sampling_freq)
+    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
 
     noise_power = 10 * log10(sampling_freq / 1.0Hz)
     signal_power = CN0
@@ -496,4 +521,26 @@ end
 
     @test cf_result.code_phase ≈ code_phase atol = 0.5
     @test abs(cf_result.carrier_doppler - doppler) < step(cf_plan.coarse_plan.dopplers)
+end
+
+@testset "max_phase_error_from_loss" begin
+    import Unitful: dB
+
+    # sinc(ε) = sin(πε)/(πε), loss = -20log10(sinc(ε))
+    # Verify round-trip: compute ε from loss, then verify sinc(ε) matches
+    for loss_dB in [0.1, 0.5, 1.0, 3.0]
+        ε = Acquisition.max_phase_error_from_loss(loss_dB * dB)
+        sinc_val = sin(π * ε) / (π * ε)
+        expected_sinc = 10^(-loss_dB / 20)
+        @test sinc_val ≈ expected_sinc atol = 1e-10
+    end
+
+    # Edge case: 0 dB loss → 0 phase error
+    @test Acquisition.max_phase_error_from_loss(0.0dB) == 0.0
+
+    # Phase error should increase with loss
+    ε1 = Acquisition.max_phase_error_from_loss(0.5dB)
+    ε2 = Acquisition.max_phase_error_from_loss(1.0dB)
+    ε3 = Acquisition.max_phase_error_from_loss(3.0dB)
+    @test 0 < ε1 < ε2 < ε3 <= 0.5
 end

--- a/test/calc_powers.jl
+++ b/test/calc_powers.jl
@@ -1,29 +1,8 @@
 @testset "Power over code for $system" for system in [GPSL1(), GalileoE1B()]
-    Random.seed!(2345)
-    num_samples = 60000
-    doppler = 1234Hz
-    code_phase = 110.613261
-    prn = 1
-    sampling_freq = 15e6Hz - 1Hz # Allow num_samples * sampling_freq to be non integer of ms
-    interm_freq = 0.0Hz
-    CN0 = 45
-
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
-    )
-
-    carrier =
-        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
-
-    noise_power = 1
-    signal_power = CN0 - 10 * log10(sampling_freq / 1.0Hz)
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    (; signal, doppler, code_phase, prn, sampling_freq, interm_freq, num_samples) =
+        generate_test_signal(
+            system, 1; interm_freq = 0.0Hz, unit_noise_power = true,
+        )
 
     code_freq_domain = fft(
         get_code.(
@@ -66,32 +45,13 @@
 end
 
 @testset "Power over code with zero-padding for $system" for system in [GPSL1(), GalileoE1B()]
-    Random.seed!(2345)
     # 16368 = 2^4 × 3 × 11 × 31 — not FFTW-friendly, pads to 16384
-    num_samples = 16368
-    doppler = 1234Hz
-    code_phase = 50.5
-    prn = 1
-    sampling_freq = 16.368e6Hz
-    interm_freq = 0.0Hz
-    CN0 = 45
-
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
-    )
-
-    carrier =
-        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
-
-    noise_power = 1
-    signal_power = CN0 - 10 * log10(sampling_freq / 1.0Hz)
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    (; signal, doppler, code_phase, prn, sampling_freq, interm_freq, num_samples) =
+        generate_test_signal(
+            system, 1;
+            num_samples = 16368, code_phase = 50.5, sampling_freq = 16.368e6Hz,
+            interm_freq = 0.0Hz, unit_noise_power = true,
+        )
 
     bfft_size = Acquisition.fftw_friendly_size(num_samples)
     @test bfft_size > num_samples  # Verify padding actually occurs
@@ -141,31 +101,8 @@ end
 end
 
 @testset "Power over code and Doppler for $system" for system in [GPSL1(), GalileoE1B()]
-    Random.seed!(2345)
-    num_samples = 60000
-    doppler = 1234Hz
-    code_phase = 110.613261
-    prn = 1
-    sampling_freq = 15e6Hz - 1Hz # Allow num_samples * sampling_freq to be non integer of ms
-    interm_freq = 243.0Hz
-    CN0 = 45
-
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
-    )
-
-    carrier =
-        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
-
-    noise_power = 1
-    signal_power = CN0 - 10 * log10(sampling_freq / 1.0Hz)
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    (; signal, doppler, code_phase, prn, sampling_freq, interm_freq, num_samples) =
+        generate_test_signal(system, 1; unit_noise_power = true)
 
     max_doppler = 7000Hz
     dopplers = (-max_doppler):250Hz:max_doppler

--- a/test/calc_powers.jl
+++ b/test/calc_powers.jl
@@ -64,6 +64,81 @@
     @test (maxidx - 1) * get_code_frequency(system) / sampling_freq ≈ code_phase atol = 0.15
 end
 
+@testset "Power over code with zero-padding for $system" for system in [GPSL1(), GalileoE1B()]
+    Random.seed!(2345)
+    # 16368 = 2^4 × 3 × 11 × 31 — not FFTW-friendly, pads to 16384
+    num_samples = 16368
+    doppler = 1234Hz
+    code_phase = 50.5
+    prn = 1
+    sampling_freq = 16.368e6Hz
+    interm_freq = 0.0Hz
+    CN0 = 45
+
+    code = gen_code(
+        num_samples,
+        system,
+        prn,
+        sampling_freq,
+        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
+        code_phase,
+    )
+
+    carrier =
+        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
+
+    noise_power = 1
+    signal_power = CN0 - 10 * log10(sampling_freq / 1.0Hz)
+    noise = randn(ComplexF64, num_samples)
+    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+
+    bfft_size = Acquisition.fftw_friendly_size(num_samples)
+    @test bfft_size > num_samples  # Verify padding actually occurs
+
+    code_freq_domain = fft(
+        get_code.(
+            system,
+            (0:(num_samples-1)) .* get_code_frequency(system) ./ sampling_freq,
+            prn,
+        ),
+    )
+    codes_freq_domain = [[code_freq_domain]]
+    effective_sampling_freq = sampling_freq * bfft_size / num_samples
+    code_interval = get_code_length(system) / get_code_frequency(system)
+    num_code_samples =
+        ceil(Int, effective_sampling_freq * min(num_samples / sampling_freq, code_interval))
+    signal_powers = [Matrix{Float32}(undef, num_code_samples, 1)]
+
+    signal_baseband = Vector{ComplexF32}(undef, num_samples)
+    signal_baseband_freq_domain = similar(signal_baseband)
+    code_freq_baseband_freq_domain = Vector{ComplexF32}(undef, bfft_size)
+    code_baseband = similar(code_freq_baseband_freq_domain)
+    fft_plan = plan_fft(signal_baseband)
+    bfft_plan = plan_bfft(code_freq_baseband_freq_domain)
+
+    Acquisition.power_over_code!(
+        signal_powers,
+        1,
+        signal_baseband,
+        signal_baseband_freq_domain,
+        code_freq_baseband_freq_domain,
+        code_baseband,
+        signal,
+        fft_plan,
+        bfft_plan,
+        codes_freq_domain,
+        1,
+        doppler,
+        sampling_freq,
+        interm_freq,
+    )
+
+    maxval, maxidx = findmax(signal_powers[1][:, 1])
+
+    @test (maxidx - 1) * get_code_frequency(system) / effective_sampling_freq ≈
+          code_phase atol = 0.15
+end
+
 @testset "Power over code and Doppler for $system" for system in [GPSL1(), GalileoE1B()]
     Random.seed!(2345)
     num_samples = 60000

--- a/test/calc_powers.jl
+++ b/test/calc_powers.jl
@@ -171,7 +171,7 @@ end
     dopplers = (-max_doppler):250Hz:max_doppler
 
     acq_plan = AcquisitionPlan(system, length(signal), sampling_freq; dopplers, prns = 1:1)
-    effective_sampling_freq = sampling_freq * acq_plan.bfft_size / length(signal)
+    effective_sampling_freq = sampling_freq * acq_plan.bfft_size / acq_plan.linear_fft_size
 
     powers_per_sats = @inferred Acquisition.power_over_doppler_and_codes!(
         acq_plan,
@@ -182,8 +182,9 @@ end
     )
 
     maxval, maxidx = findmax(powers_per_sats[1])
+    # Max quantization error is code_phase_step/2 ≈ 0.031 chips for these parameters
     @test (maxidx[1] - 1) * get_code_frequency(system) / effective_sampling_freq ≈
-          code_phase atol = 0.08
+          code_phase atol = 0.04
 
     est_doppler = (maxidx[2] - 1) * step(dopplers) + first(dopplers)
     @test abs(est_doppler - doppler) < step(dopplers) / 2

--- a/test/calc_powers.jl
+++ b/test/calc_powers.jl
@@ -25,15 +25,15 @@
     noise = randn(ComplexF64, num_samples)
     signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
 
-    codes_freq_domain = [
-        fft(
-            get_code.(
-                system,
-                (0:(num_samples-1)) .* get_code_frequency(system) ./ sampling_freq,
-                prn,
-            ),
+    code_freq_domain = fft(
+        get_code.(
+            system,
+            (0:(num_samples-1)) .* get_code_frequency(system) ./ sampling_freq,
+            prn,
         ),
-    ]
+    )
+    # Nested format: codes_freq_domain[prn][code_doppler_idx]
+    codes_freq_domain = [[code_freq_domain]]
     signal_powers = [Matrix{Float32}(undef, 5000, 1)]
 
     signal_baseband = Vector{ComplexF32}(undef, length(signal))
@@ -41,7 +41,7 @@
     code_freq_baseband_freq_domain = similar(signal_baseband)
     code_baseband = similar(signal_baseband)
     fft_plan = plan_fft(signal_baseband)
-    ifft_plan = plan_ifft(signal_baseband)
+    bfft_plan = plan_bfft(signal_baseband)
 
     @inferred Acquisition.power_over_code!(
         signal_powers,
@@ -52,8 +52,9 @@
         code_baseband,
         signal,
         fft_plan,
-        ifft_plan,
+        bfft_plan,
         codes_freq_domain,
+        1,
         doppler,
         sampling_freq,
         interm_freq,

--- a/test/calc_powers.jl
+++ b/test/calc_powers.jl
@@ -18,7 +18,7 @@
     )
 
     carrier =
-        cis.(2π * (0:num_samples-1) * (interm_freq + doppler) / sampling_freq .+ π / 8)
+        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
 
     noise_power = 1
     signal_power = CN0 - 10 * log10(sampling_freq / 1.0Hz)
@@ -29,7 +29,7 @@
         fft(
             get_code.(
                 system,
-                (0:num_samples-1) .* get_code_frequency(system) ./ sampling_freq,
+                (0:(num_samples-1)) .* get_code_frequency(system) ./ sampling_freq,
                 prn,
             ),
         ),
@@ -84,7 +84,7 @@ end
     )
 
     carrier =
-        cis.(2π * (0:num_samples-1) * (interm_freq + doppler) / sampling_freq .+ π / 8)
+        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
 
     noise_power = 1
     signal_power = CN0 - 10 * log10(sampling_freq / 1.0Hz)
@@ -92,9 +92,10 @@ end
     signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
 
     max_doppler = 7000Hz
-    dopplers = -max_doppler:250Hz:max_doppler
+    dopplers = (-max_doppler):250Hz:max_doppler
 
     acq_plan = AcquisitionPlan(system, length(signal), sampling_freq; dopplers, prns = 1:1)
+    effective_sampling_freq = sampling_freq * acq_plan.bfft_size / length(signal)
 
     powers_per_sats = @inferred Acquisition.power_over_doppler_and_codes!(
         acq_plan,
@@ -105,8 +106,8 @@ end
     )
 
     maxval, maxidx = findmax(powers_per_sats[1])
-    @test (maxidx[1] - 1) * get_code_frequency(system) / sampling_freq ≈ code_phase atol =
-        0.08
+    @test (maxidx[1] - 1) * get_code_frequency(system) / effective_sampling_freq ≈
+          code_phase atol = 0.08
 
     est_doppler = (maxidx[2] - 1) * step(dopplers) + first(dopplers)
     @test abs(est_doppler - doppler) < step(dopplers) / 2

--- a/test/ka_acquire.jl
+++ b/test/ka_acquire.jl
@@ -185,7 +185,7 @@ end
     result = acquire!(plan, signal, prn; doppler_offset = base_doppler)
 
     @test result.code_phase ≈ code_phase atol = 0.1
-    @test abs(result.carrier_doppler - doppler) < 250Hz
+    @test abs(result.carrier_doppler - doppler) < step(plan.dopplers) / 2 * 1.0Hz
 end
 
 @testset "KAAcquisitionPlan store_powers" begin
@@ -246,8 +246,8 @@ end
     result = acquire!(ka_plan, signal_typed, prn)
 
     # Verify acquisition still finds the signal correctly
-    @test result.code_phase ≈ code_phase atol = 0.5
-    @test abs(result.carrier_doppler - doppler) < 250Hz
+    @test result.code_phase ≈ code_phase atol = 0.08
+    @test abs(result.carrier_doppler - doppler) < step(ka_plan.dopplers) / 2 * 1.0Hz
     @test result.prn == prn
 
     # CN0 includes coherent integration gain only (no explicit non-coherent gain)
@@ -261,8 +261,8 @@ end
         AcquisitionPlan(system, sampling_freq; prns = [prn], fft_flag = FFTW.ESTIMATE)
     cpu_result = acquire!(cpu_plan, signal_typed, prn)
 
-    @test abs(result.carrier_doppler - cpu_result.carrier_doppler) < 250Hz
-    @test abs(result.code_phase - cpu_result.code_phase) < 0.5
+    @test abs(result.carrier_doppler - cpu_result.carrier_doppler) < step(ka_plan.dopplers) / 2 * 1.0Hz
+    @test abs(result.code_phase - cpu_result.code_phase) < 0.02
     @test abs(result.CN0 - cpu_result.CN0) < 3
 end
 
@@ -302,8 +302,8 @@ end
 
     result = acquire!(ka_plan, signal_typed, prn)
 
-    @test result.code_phase ≈ code_phase atol = 0.5
-    @test abs(result.carrier_doppler - doppler) < step(ka_plan.dopplers) * 1.0Hz
+    @test result.code_phase ≈ code_phase atol = 0.08
+    @test abs(result.carrier_doppler - doppler) < step(ka_plan.dopplers) / 2 * 1.0Hz
 end
 
 @testset "KAAcquisitionPlan zero_pad_power=0 (no padding)" begin
@@ -348,8 +348,55 @@ end
 
     result = acquire!(ka_plan, signal_f32, prn; interm_freq)
 
-    @test result.code_phase ≈ code_phase atol = 0.5
-    @test abs(result.carrier_doppler - doppler) < 250Hz
+    @test result.code_phase ≈ code_phase atol = 0.08
+    @test abs(result.carrier_doppler - doppler) < step(ka_plan.dopplers) / 2 * 1.0Hz
+    @test result.CN0 ≈ CN0 atol = 7
+end
+
+@testset "KAAcquisitionPlan zero_pad_power=1 (frequency-domain zero-padding)" begin
+    Random.seed!(2345)
+    system = GPSL1()
+    num_samples = 16368
+    doppler = 1234Hz
+    code_phase = 50.5
+    prn = 1
+    sampling_freq = 16.368e6Hz
+    CN0 = 50
+
+    code = gen_code(
+        num_samples,
+        system,
+        prn,
+        sampling_freq,
+        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
+        code_phase,
+    )
+
+    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
+
+    noise_power = 10 * log10(sampling_freq / 1.0Hz)
+    signal_power = CN0
+    noise = randn(ComplexF64, num_samples)
+    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    signal_f32 = ComplexF32.(signal)
+
+    ka_plan = KAAcquisitionPlan(
+        system,
+        num_samples,
+        sampling_freq,
+        Array;
+        prns = 1:34,
+        zero_pad_power = 1,
+    )
+
+    linear_fft_size = Acquisition.fftw_friendly_size(2 * num_samples)
+    @test ka_plan.bfft_size == Acquisition.fftw_friendly_size(linear_fft_size << 1)
+    @test ka_plan.bfft_size > ka_plan.linear_fft_size  # needs_padding == true
+
+    result = acquire!(ka_plan, signal_f32, prn)
+
+    @test result.code_phase ≈ code_phase atol = 0.001
+    @test abs(result.carrier_doppler - doppler) < step(ka_plan.dopplers) / 2 * 1.0Hz
     @test result.CN0 ≈ CN0 atol = 7
 end
 
@@ -393,7 +440,7 @@ end
 
     result = acquire!(ka_plan, signal_f32, prn)
 
-    @test result.code_phase ≈ code_phase atol = 0.5
-    @test abs(result.carrier_doppler - doppler) < 250Hz
+    @test result.code_phase ≈ code_phase atol = 0.08
+    @test abs(result.carrier_doppler - doppler) < step(ka_plan.dopplers) / 2 * 1.0Hz
     @test result.CN0 ≈ CN0 atol = 7
 end

--- a/test/ka_acquire.jl
+++ b/test/ka_acquire.jl
@@ -344,7 +344,7 @@ end
         zero_pad_power = 0,
     )
 
-    @test ka_plan.bfft_size == num_samples
+    @test ka_plan.bfft_size == Acquisition.fftw_friendly_size(2 * num_samples)
 
     result = acquire!(ka_plan, signal_f32, prn; interm_freq)
 

--- a/test/ka_acquire.jl
+++ b/test/ka_acquire.jl
@@ -21,8 +21,9 @@ using KernelAbstractions
             code_phase,
         )
 
-        carrier =
-            cis.(2π * (0:num_samples-1) * (interm_freq + doppler) / sampling_freq .+ π / 8)
+        carrier = cis.(
+            2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8,
+        )
 
         noise_power = 10 * log10(sampling_freq / 1.0Hz)
         signal_power = CN0
@@ -31,7 +32,7 @@ using KernelAbstractions
         signal_f32 = ComplexF32.(signal)
 
         max_doppler = 7000Hz
-        dopplers = -max_doppler:250Hz:max_doppler
+        dopplers = (-max_doppler):250Hz:max_doppler
 
         # Create KAAcquisitionPlan with Array (CPU backend)
         ka_plan = KAAcquisitionPlan(
@@ -40,7 +41,7 @@ using KernelAbstractions
             sampling_freq,
             Array;
             dopplers,
-            prns=1:34,
+            prns = 1:34,
         )
 
         # Test single PRN acquisition
@@ -59,13 +60,8 @@ using KernelAbstractions
         @test ka_res_multi[3].prn == 3
 
         # Compare with CPU AcquisitionPlan results
-        cpu_plan = AcquisitionPlan(
-            system,
-            num_samples,
-            sampling_freq;
-            dopplers,
-            prns=1:34,
-        )
+        cpu_plan =
+            AcquisitionPlan(system, num_samples, sampling_freq; dopplers, prns = 1:34)
         cpu_res = acquire!(cpu_plan, signal_f32, prn; interm_freq)
 
         # Results should be very similar (not identical due to different FFT implementations)
@@ -81,16 +77,30 @@ end
     sampling_freq = 5e6Hz
 
     # Test default eltype (Float32)
-    plan_default = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns=1:1)
+    plan_default = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns = 1:1)
     @test eltype(plan_default.signal_baseband) == ComplexF32
     @test eltype(plan_default.codes_freq_domain) == ComplexF32
 
     # Test explicit Float32
-    plan_f32 = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns=1:1, eltype=Float32)
+    plan_f32 = KAAcquisitionPlan(
+        system,
+        num_samples,
+        sampling_freq,
+        Array;
+        prns = 1:1,
+        eltype = Float32,
+    )
     @test eltype(plan_f32.signal_baseband) == ComplexF32
 
     # Test Float64
-    plan_f64 = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns=1:1, eltype=Float64)
+    plan_f64 = KAAcquisitionPlan(
+        system,
+        num_samples,
+        sampling_freq,
+        Array;
+        prns = 1:1,
+        eltype = Float64,
+    )
     @test eltype(plan_f64.signal_baseband) == ComplexF64
     @test eltype(plan_f64.codes_freq_domain) == ComplexF64
 
@@ -106,7 +116,7 @@ end
     num_samples = 10000
     sampling_freq = 5e6Hz
 
-    plan = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns=1:10)
+    plan = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns = 1:10)
 
     signal = randn(ComplexF32, num_samples)
 
@@ -123,7 +133,7 @@ end
     num_samples = 10000
     sampling_freq = 5e6Hz
 
-    plan = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns=1:10)
+    plan = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns = 1:10)
     signal = randn(ComplexF32, num_samples)
 
     # Empty PRNs should return empty vector
@@ -151,12 +161,14 @@ end
         code_phase,
     )
 
-    carrier = cis.(2π * (0:num_samples-1) * doppler / sampling_freq)
+    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
 
     noise_power = 10 * log10(sampling_freq / 1.0Hz)
     signal_power = CN0
     noise = randn(ComplexF64, num_samples)
-    signal = ComplexF32.((carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20))
+    signal = ComplexF32.(
+        (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20),
+    )
 
     # Use a narrow Doppler range with offset
     base_doppler = 1000Hz
@@ -165,12 +177,12 @@ end
         num_samples,
         sampling_freq,
         Array;
-        min_doppler=-500Hz,
-        max_doppler=500Hz,
-        prns=1:10,
+        min_doppler = -500Hz,
+        max_doppler = 500Hz,
+        prns = 1:10,
     )
 
-    result = acquire!(plan, signal, prn; doppler_offset=base_doppler)
+    result = acquire!(plan, signal, prn; doppler_offset = base_doppler)
 
     @test result.code_phase ≈ code_phase atol = 0.1
     @test abs(result.carrier_doppler - doppler) < 250Hz
@@ -183,15 +195,15 @@ end
     prn = 1
 
     signal = randn(ComplexF32, num_samples)
-    plan = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns=1:5)
+    plan = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns = 1:5)
 
     # Test with store_powers=true
-    result = acquire!(plan, signal, prn; store_powers=true)
+    result = acquire!(plan, signal, prn; store_powers = true)
     @test size(result.power_bins, 1) > 0
     @test size(result.power_bins, 2) > 0
 
     # Test with store_powers=false (default)
-    result_no_powers = acquire!(plan, signal, prn; store_powers=false)
+    result_no_powers = acquire!(plan, signal, prn; store_powers = false)
     @test size(result_no_powers.power_bins) == (0, 0)
 end
 
@@ -219,7 +231,7 @@ end
         code_phase,
     )
 
-    carrier = cis.(2π * (0:num_samples-1) * doppler / sampling_freq)
+    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
 
     noise_power = 10 * log10(sampling_freq / 1.0Hz)
     signal_power = CN0
@@ -228,7 +240,7 @@ end
     signal_typed = ComplexF32.(signal)
 
     # Test with plan using default bit period chunk size (uses convenience constructor)
-    ka_plan = KAAcquisitionPlan(system, sampling_freq, Array; prns=[prn])
+    ka_plan = KAAcquisitionPlan(system, sampling_freq, Array; prns = [prn])
     @test ka_plan.num_samples_to_integrate_coherently == bit_period_samples
 
     result = acquire!(ka_plan, signal_typed, prn)
@@ -245,7 +257,8 @@ end
     @test result.CN0 ≈ expected_CN0 atol = 5
 
     # Compare with CPU AcquisitionPlan - results should be similar
-    cpu_plan = AcquisitionPlan(system, sampling_freq; prns=[prn], fft_flag=FFTW.ESTIMATE)
+    cpu_plan =
+        AcquisitionPlan(system, sampling_freq; prns = [prn], fft_flag = FFTW.ESTIMATE)
     cpu_result = acquire!(cpu_plan, signal_typed, prn)
 
     @test abs(result.carrier_doppler - cpu_result.carrier_doppler) < 250Hz
@@ -275,7 +288,7 @@ end
         code_phase,
     )
 
-    carrier = cis.(2π * (0:num_samples-1) * doppler / sampling_freq)
+    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
 
     noise_power = 10 * log10(sampling_freq / 1.0Hz)
     signal_power = CN0
@@ -283,13 +296,7 @@ end
     signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
     signal_typed = ComplexF32.(signal)
 
-    ka_plan = KAAcquisitionPlan(
-        system,
-        num_samples,
-        sampling_freq,
-        Array;
-        prns = [prn],
-    )
+    ka_plan = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns = [prn])
 
     @test ka_plan.num_code_dopplers > 1
 
@@ -297,4 +304,96 @@ end
 
     @test result.code_phase ≈ code_phase atol = 0.5
     @test abs(result.carrier_doppler - doppler) < step(ka_plan.dopplers) * 1.0Hz
+end
+
+@testset "KAAcquisitionPlan zero_pad_power=0 (no padding)" begin
+    Random.seed!(2345)
+    system = GPSL1()
+    num_samples = 60000
+    doppler = 1234Hz
+    code_phase = 110.613261
+    prn = 1
+    sampling_freq = 15e6Hz - 1Hz
+    interm_freq = 243.0Hz
+    CN0 = 45
+
+    code = gen_code(
+        num_samples,
+        system,
+        prn,
+        sampling_freq,
+        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
+        code_phase,
+    )
+
+    carrier =
+        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
+
+    noise_power = 10 * log10(sampling_freq / 1.0Hz)
+    signal_power = CN0
+    noise = randn(ComplexF64, num_samples)
+    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    signal_f32 = ComplexF32.(signal)
+
+    ka_plan = KAAcquisitionPlan(
+        system,
+        num_samples,
+        sampling_freq,
+        Array;
+        prns = 1:34,
+        zero_pad_power = 0,
+    )
+
+    @test ka_plan.bfft_size == num_samples
+
+    result = acquire!(ka_plan, signal_f32, prn; interm_freq)
+
+    @test result.code_phase ≈ code_phase atol = 0.5
+    @test abs(result.carrier_doppler - doppler) < 250Hz
+    @test result.CN0 ≈ CN0 atol = 7
+end
+
+@testset "KAAcquisitionPlan with zero-padding (non-smooth sample count)" begin
+    Random.seed!(2345)
+    system = GPSL1()
+    # 16368 = 2^4 × 3 × 11 × 31 — not FFTW-friendly, pads to 16384
+    num_samples = 16368
+    doppler = 1234Hz
+    code_phase = 50.5
+    prn = 1
+    sampling_freq = 16.368e6Hz
+    CN0 = 45
+
+    code = gen_code(
+        num_samples,
+        system,
+        prn,
+        sampling_freq,
+        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
+        code_phase,
+    )
+
+    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
+
+    noise_power = 10 * log10(sampling_freq / 1.0Hz)
+    signal_power = CN0
+    noise = randn(ComplexF64, num_samples)
+    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    signal_f32 = ComplexF32.(signal)
+
+    ka_plan = KAAcquisitionPlan(
+        system,
+        num_samples,
+        sampling_freq,
+        Array;
+        prns = 1:34,
+    )
+
+    @test ka_plan.bfft_size > num_samples
+
+    result = acquire!(ka_plan, signal_f32, prn)
+
+    @test result.code_phase ≈ code_phase atol = 0.5
+    @test abs(result.carrier_doppler - doppler) < 250Hz
+    @test result.CN0 ≈ CN0 atol = 7
 end

--- a/test/ka_acquire.jl
+++ b/test/ka_acquire.jl
@@ -3,32 +3,8 @@ using KernelAbstractions
 # Test with CPU backend (KernelAbstractions works on regular Arrays)
 @testset "KAAcquisitionPlan CPU backend" begin
     @testset "Acquire signal $system" for system in [GPSL1(), GalileoE1B()]
-        Random.seed!(2345)
-        num_samples = 60000
-        doppler = 1234Hz
-        code_phase = 110.613261
-        prn = 1
-        sampling_freq = 15e6Hz - 1Hz
-        interm_freq = 243.0Hz
-        CN0 = 45
-
-        code = gen_code(
-            num_samples,
-            system,
-            prn,
-            sampling_freq,
-            get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-            code_phase,
-        )
-
-        carrier = cis.(
-            2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8,
-        )
-
-        noise_power = 10 * log10(sampling_freq / 1.0Hz)
-        signal_power = CN0
-        noise = randn(ComplexF64, num_samples)
-        signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+        (; signal, doppler, code_phase, prn, sampling_freq, interm_freq, CN0, num_samples) =
+            generate_test_signal(system, 1)
         signal_f32 = ComplexF32.(signal)
 
         max_doppler = 7000Hz
@@ -143,32 +119,14 @@ end
 end
 
 @testset "KAAcquisitionPlan with doppler_offset" begin
-    Random.seed!(4567)
     system = GPSL1()
-    num_samples = 60000
-    doppler = 1234Hz
-    code_phase = 50.0
-    prn = 1
-    sampling_freq = 15e6Hz
-    CN0 = 45
-
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
-    )
-
-    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
-
-    noise_power = 10 * log10(sampling_freq / 1.0Hz)
-    signal_power = CN0
-    noise = randn(ComplexF64, num_samples)
-    signal = ComplexF32.(
-        (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20),
-    )
+    (; signal, doppler, code_phase, prn, sampling_freq, num_samples) =
+        generate_test_signal(
+            system, 1;
+            seed = 4567, code_phase = 50.0, sampling_freq = 15e6Hz,
+            interm_freq = 0.0Hz, phase_offset = 0.0,
+        )
+    signal = ComplexF32.(signal)
 
     # Use a narrow Doppler range with offset
     base_doppler = 1000Hz
@@ -208,13 +166,8 @@ end
 end
 
 @testset "KAAcquisitionPlan non-coherent integration" begin
-    Random.seed!(4567)
     system = GPSL1()
     sampling_freq = 5e6Hz
-    doppler = 500Hz
-    code_phase = 50.5
-    prn = 1
-    CN0 = 45
 
     # Calculate bit period samples (20ms for GPS L1 at 50Hz data rate)
     bit_period_samples = ceil(Int, sampling_freq / get_data_frequency(system))
@@ -222,21 +175,11 @@ end
     # Create signal spanning 2.5 bit periods (50ms)
     num_samples = ceil(Int, 2.5 * bit_period_samples)
 
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
+    (; signal, doppler, code_phase, prn, CN0) = generate_test_signal(
+        system, 1;
+        seed = 4567, num_samples, doppler = 500Hz, code_phase = 50.5,
+        sampling_freq, interm_freq = 0.0Hz, phase_offset = 0.0,
     )
-
-    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
-
-    noise_power = 10 * log10(sampling_freq / 1.0Hz)
-    signal_power = CN0
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
     signal_typed = ComplexF32.(signal)
 
     # Test with plan using default bit period chunk size (uses convenience constructor)
@@ -267,33 +210,17 @@ end
 end
 
 @testset "KAAcquisitionPlan code Doppler compensation" begin
-    Random.seed!(7890)
     system = GPSL1()
     sampling_freq = 5e6Hz
-    doppler = 5000Hz
-    code_phase = 50.5
-    prn = 1
-    CN0 = 55
 
     T_coh_ms = 10
     num_samples = ceil(Int, T_coh_ms * 1e-3 * (sampling_freq / 1.0Hz))
 
-    code_doppler = doppler * get_code_center_frequency_ratio(system)
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + code_doppler,
-        code_phase,
+    (; signal, doppler, code_phase, prn) = generate_test_signal(
+        system, 1;
+        seed = 7890, num_samples, doppler = 5000Hz, code_phase = 50.5,
+        sampling_freq, interm_freq = 0.0Hz, CN0 = 55, phase_offset = 0.0,
     )
-
-    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
-
-    noise_power = 10 * log10(sampling_freq / 1.0Hz)
-    signal_power = CN0
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
     signal_typed = ComplexF32.(signal)
 
     ka_plan = KAAcquisitionPlan(system, num_samples, sampling_freq, Array; prns = [prn])
@@ -307,32 +234,9 @@ end
 end
 
 @testset "KAAcquisitionPlan zero_pad_power=0 (no padding)" begin
-    Random.seed!(2345)
     system = GPSL1()
-    num_samples = 60000
-    doppler = 1234Hz
-    code_phase = 110.613261
-    prn = 1
-    sampling_freq = 15e6Hz - 1Hz
-    interm_freq = 243.0Hz
-    CN0 = 45
-
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
-    )
-
-    carrier =
-        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ π / 8)
-
-    noise_power = 10 * log10(sampling_freq / 1.0Hz)
-    signal_power = CN0
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    (; signal, doppler, code_phase, prn, sampling_freq, interm_freq, CN0, num_samples) =
+        generate_test_signal(system, 1)
     signal_f32 = ComplexF32.(signal)
 
     ka_plan = KAAcquisitionPlan(
@@ -354,30 +258,13 @@ end
 end
 
 @testset "KAAcquisitionPlan zero_pad_power=1 (frequency-domain zero-padding)" begin
-    Random.seed!(2345)
     system = GPSL1()
-    num_samples = 16368
-    doppler = 1234Hz
-    code_phase = 50.5
-    prn = 1
-    sampling_freq = 16.368e6Hz
-    CN0 = 50
-
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
-    )
-
-    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
-
-    noise_power = 10 * log10(sampling_freq / 1.0Hz)
-    signal_power = CN0
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    (; signal, doppler, code_phase, prn, sampling_freq, num_samples, CN0) =
+        generate_test_signal(
+            system, 1;
+            num_samples = 16368, code_phase = 50.5, sampling_freq = 16.368e6Hz,
+            CN0 = 50, interm_freq = 0.0Hz, phase_offset = 0.0,
+        )
     signal_f32 = ComplexF32.(signal)
 
     ka_plan = KAAcquisitionPlan(
@@ -401,31 +288,14 @@ end
 end
 
 @testset "KAAcquisitionPlan with zero-padding (non-smooth sample count)" begin
-    Random.seed!(2345)
     system = GPSL1()
     # 16368 = 2^4 × 3 × 11 × 31 — not FFTW-friendly, pads to 16384
-    num_samples = 16368
-    doppler = 1234Hz
-    code_phase = 50.5
-    prn = 1
-    sampling_freq = 16.368e6Hz
-    CN0 = 45
-
-    code = gen_code(
-        num_samples,
-        system,
-        prn,
-        sampling_freq,
-        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
-        code_phase,
-    )
-
-    carrier = cis.(2π * (0:(num_samples-1)) * doppler / sampling_freq)
-
-    noise_power = 10 * log10(sampling_freq / 1.0Hz)
-    signal_power = CN0
-    noise = randn(ComplexF64, num_samples)
-    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+    (; signal, doppler, code_phase, prn, sampling_freq, num_samples, CN0) =
+        generate_test_signal(
+            system, 1;
+            num_samples = 16368, code_phase = 50.5, sampling_freq = 16.368e6Hz,
+            interm_freq = 0.0Hz, phase_offset = 0.0,
+        )
     signal_f32 = ComplexF32.(signal)
 
     ka_plan = KAAcquisitionPlan(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Test, FFTW, Acquisition, GNSSSignals, Random, Aqua
 import Unitful: Hz
 
+include("test_utils.jl")
+
 @testset "Aqua" begin
     Aqua.test_all(Acquisition; ambiguities=false)
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,69 @@
+"""
+    generate_test_signal(system, prn; kwargs...) -> NamedTuple
+
+Generate a noisy GNSS signal for testing. Returns a NamedTuple with all signal
+components and parameters, so call sites can destructure what they need.
+
+# Keywords
+- `seed=2345`: Random seed for reproducibility
+- `num_samples=60000`: Number of signal samples
+- `doppler=1234Hz`: Carrier Doppler frequency
+- `code_phase=110.613261`: True code phase in chips
+- `sampling_freq=15e6Hz - 1Hz`: Sampling frequency
+- `interm_freq=243.0Hz`: Intermediate frequency
+- `CN0=45`: Carrier-to-noise density ratio (dB-Hz)
+- `phase_offset=π/8`: Carrier phase offset
+- `unit_noise_power=false`: When true, scale so noise power ≈ 1 (used by calc_powers tests);
+  when false, scale so signal power corresponds directly to CN0
+"""
+function generate_test_signal(
+    system,
+    prn;
+    seed = 2345,
+    num_samples = 60000,
+    doppler = 1234Hz,
+    code_phase = 110.613261,
+    sampling_freq = 15e6Hz - 1Hz,
+    interm_freq = 243.0Hz,
+    CN0 = 45,
+    phase_offset = π / 8,
+    unit_noise_power = false,
+)
+    Random.seed!(seed)
+
+    code = gen_code(
+        num_samples,
+        system,
+        prn,
+        sampling_freq,
+        get_code_frequency(system) + doppler * get_code_center_frequency_ratio(system),
+        code_phase,
+    )
+
+    carrier =
+        cis.(2π * (0:(num_samples-1)) * (interm_freq + doppler) / sampling_freq .+ phase_offset)
+
+    if unit_noise_power
+        noise_power = 1
+        signal_power = CN0 - 10 * log10(sampling_freq / 1.0Hz)
+    else
+        noise_power = 10 * log10(sampling_freq / 1.0Hz)
+        signal_power = CN0
+    end
+
+    noise = randn(ComplexF64, num_samples)
+    signal = (carrier .* code) * 10^(signal_power / 20) + noise * 10^(noise_power / 20)
+
+    return (;
+        signal,
+        code,
+        carrier,
+        num_samples,
+        doppler,
+        code_phase,
+        sampling_freq,
+        interm_freq,
+        CN0,
+        prn,
+    )
+end


### PR DESCRIPTION
## Summary
- Pre-compute multiple code replicas at different code Doppler offsets to maintain acquisition accuracy when coherent integration time is long and carrier Doppler is large
- Each carrier Doppler bin automatically selects the nearest pre-computed code replica, with step size controlled by `max_code_doppler_loss` (in dB, using Unitful `Gain` type)
- Optional frequency-domain zero-padding via `zero_pad_power` kwarg for sinc-interpolated finer code phase resolution
- Switch from `plan_ifft` to `plan_bfft` (unnormalized backward FFT) — matches GPU path, avoids scaling surprises with zero-padding, and only relative magnitudes matter for peak detection/CN0
- **Double Block Zero Padding (DBZP)**: zero-pad both signal and code from N to 2N before FFT, converting circular correlation to linear correlation. Eliminates boundary artifacts when `code_length * sampling_freq / code_freq` is non-integer. Reference: van Nee & Coenen, Electronics Letters, 1991.
- **Fix `acquire()` code Doppler grid bug**: the convenience function was not passing `min_doppler`/`max_doppler` to `AcquisitionPlan`, causing the code Doppler compensation grid to default to ±7000 Hz even when the actual search range was wider. At large Doppler offsets, the wrong code replica was selected, shifting the correlation peak.
- Implemented for all three plan types: `AcquisitionPlan`, `CoarseFineAcquisitionPlan`, and `KAAcquisitionPlan` (GPU)
- Fully backward compatible: new `zero_pad_power` kwarg defaults to `0` (DBZP only, no additional interpolation padding); set to `1` or higher for sinc-interpolated finer code phase resolution

## Changes

### DBZP linear correlation
- **`src/plan_acquire.jl`**: Added `linear_fft_size` field to `AcquisitionPlan`; computed as `fftw_friendly_size(2 * num_samples_to_integrate_coherently)`; code replicas zero-padded from N to `linear_fft_size` in `common_buffers()`; `effective_sampling_freq` now uses `bfft_size / linear_fft_size` instead of `bfft_size / N`; `bfft_size` computed via `fftw_friendly_size(linear_fft_size << zero_pad_power)` for consistent FFTW-efficient sizing
- **`src/calc_powers.jl`**: Removed dead `if signal_samples < buffer_length` guard (with DBZP, buffer is always 2N > signal ≤ N, so zero-padding is unconditional)
- **`src/acquire.jl`**: Updated `effective_sampling_freq` to use `acq_plan.linear_fft_size`; fixed `acquire()` to pass `min_doppler`/`max_doppler` through to `AcquisitionPlan`
- **`src/ka_acquire.jl`**: Added `linear_fft_size` field to `KAAcquisitionPlan`; codes zero-padded from N to `linear_fft_size`; signal buffers sized at `linear_fft_size` with DBZP zero-padding after downconversion; downconvert phases extended to `linear_fft_size` with zeros beyond N; `effective_sampling_freq` uses `bfft_size / linear_fft_size`; cross-spectrum padding uses `linear_fft_size` as FFT output size
- **`test/acquire.jl`**: Tightened code_phase tolerance from `atol=0.08` to `atol=0.04` (grid quantization limit ~0.031 chips)
- **`test/calc_powers.jl`**: Updated `effective_sampling_freq` formula; tightened tolerance to `atol=0.04`

### Code Doppler compensation
- **`src/plan_acquire.jl`**: Added `compute_code_doppler_grid()` / `compute_code_doppler_indices()` helpers; added `max_phase_error_from_loss()` to convert dB loss to max phase error via Newton's method on sinc; extended `AcquisitionPlan` and `CoarseFineAcquisitionPlan` with code Doppler fields; `common_buffers` now generates nested `codes[prn][code_doppler_idx]`; extracted `code_doppler_index()` helper to deduplicate the repeated `clamp(round(Int, ...))` pattern across 4 call sites
- **`src/calc_powers.jl`**: `power_over_code!` accepts `code_doppler_idx`; `power_over_doppler_and_codes!` selects the correct code replica per Doppler bin using `code_doppler_index()`; removed backward-compatible `power_over_code!` method
- **`src/acquire.jl`**: Added `max_code_doppler_loss` kwarg (default `0.5dB`); code phase formula includes code Doppler correction; uses `code_doppler_index()` helper
- **`src/ka_acquire.jl`**: Extended with 3D codes array `(samples × prns × code_dopplers)`; groups consecutive Doppler columns by code Doppler index using `code_doppler_index()` helper

### Frequency-domain zero-padding
- **`src/plan_acquire.jl`**: Added `bfft_size` field to `AcquisitionPlan`; renamed `ifft_plan` → `bfft_plan`; `common_buffers` sizes BFFT buffers at `bfft_size` and uses `plan_bfft`; `effective_sampling_freq` used for signal_powers row count; added `fftw_friendly_size()` helper using `nextprod((2,3,5,7), n)` — pads to the nearest size whose prime factors are all in {2,3,5,7}, which avoids the large overhead of `nextpow(2, n)` for already-smooth inputs (e.g. 20000 → 32768 = +64%); `bfft_size` now computed via `fftw_friendly_size(linear_fft_size << zero_pad_power)` instead of `nextpow(2, linear_fft_size)` to avoid inconsistent padding waste
- **`src/calc_powers.jl`**: `power_over_code!` zero-pads cross-spectrum with `@inbounds` scalar loops (zero allocations on hot path); gap zeroed once before PRN loop
- **`src/acquire.jl`**: Uses `effective_sampling_freq = sampling_freq * bfft_size / linear_fft_size` for code phase conversion, CN0 estimation, and `AcquisitionResults`; `zero_pad_power` kwarg on all public functions (default `0`)
- **`src/ka_acquire.jl`**: Same zero-padding for GPU path with positive/negative frequency splitting
- **`test/calc_powers.jl`**: Updated to use `effective_sampling_freq` for code phase assertion

### Benchmarks
- **`benchmark/cpu_benchmarks.jl`**: Changed from `FFTW.ESTIMATE` to `FFTW.MEASURE` for realistic benchmark timings. ESTIMATE produces suboptimal plans for padded sizes, making zero-padding appear slower than it is in production.
- **`benchmark/cpu_benchmarks.jl`** and **`benchmark/ka_benchmarks.jl`**: Reduced benchmark count from 51 to 22 to speed up CI.
- **`benchmark/benchmarks.jl`**: KA benchmark labels now reflect the actual backend (`ROCm`, `CUDA`, or `KA-CPU`) instead of always saying `GPU`.

### Benchmark regression fix
- **`src/plan_acquire.jl`**, **`src/ka_acquire.jl`**: Replaced `nextpow(2, linear_fft_size) << (zpp-1)` with `fftw_friendly_size(linear_fft_size << zpp)` for `bfft_size`. The old formula used `nextpow(2, ...)` which created inconsistent zero-pad waste: 1.0x for lucky power-of-2 `linear_fft_size` values (16368, 32736 samples) vs 1.6x for others (20000, 327360 samples), causing 1.7–2.5x slowdowns. Changed default `zero_pad_power` from `1` to `0` since DBZP alone provides sufficient accuracy.
- **`src/ka_acquire.jl`**: Added DBZP to the KA (GPU) path — was previously missing, doing circular correlation instead of linear. Added `linear_fft_size` field, zero-padded codes and signal buffers, corrected `effective_sampling_freq`.

### KA (GPU) performance optimization
- **Single-chunk fast path**: For signals that fit in one coherent integration chunk (the common case for acquisition), process each PRN inline using `plan.power_buffer` instead of allocating per-PRN power matrices. Reduces allocations from 6380 / 308 MiB to 875 / 23 KiB per call (~99.99% reduction).
- **Targeted zero-fill**: Only zero the DBZP pad region once instead of the full `linear_fft_size × num_dopplers` buffer every chunk. The signal region (1:N) is overwritten by the downconvert anyway.
- **`fft_flag` parameter**: Added `fft_flag` kwarg (default `FFTW.MEASURE`) to `KAAcquisitionPlan`. For CPU Arrays, FFTW.MEASURE finds the optimal FFT algorithm for the specific transform size and caches it via FFTW wisdom, giving ~25–40% faster FFTs. Ignored for GPU arrays (rocFFT/cuFFT handle planning internally).
- **Extracted helpers**: `_ka_correlate_prn!` (code multiplication + backward FFT) and `_ka_make_result` (findmax + CN0 + result construction) reduce duplication between single-chunk and multi-chunk paths.
- **KA test tolerances tightened**: Code phase from `atol=0.5` to `atol=0.08` (non-coherent, code Doppler, zero_pad_power=0, non-smooth) and `atol=0.001` (zero_pad_power=1); KA-vs-CPU from `0.5` to `0.02` chips; Doppler from `250Hz` to `step/2`.

## Expected benchmark impact
DBZP doubles the FFT size from N to `fftw_friendly_size(2N)`, which is an inherent ~2x per-doppler cost for correctness (linear vs circular correlation). The forward and backward FFTs account for ~92% of the regression; code multiplication and zero-padding account for the rest. For benchmarks where N is already a power of 2 (16368, 32736), the DBZP overhead is recovered by FFTW.MEASURE and other optimizations, resulting in net speedups. For non-power-of-2 sizes (20000, 60000), the DBZP cost is partially offset but a regression remains.

Note that on master, FFTs operated directly on N-sized buffers without any smooth-number padding — FFTW handled whatever size N happened to be. This PR introduces `fftw_friendly_size(n) = nextprod((2,3,5,7), n)` to round up to the nearest FFTW-efficient size. For DBZP, `fftw_friendly_size(2N)` is often exactly 2N when 2N is already smooth (e.g. 2×16368 = 32736 → 32768, 2×60000 = 120000 → 120000), so the overhead is purely the DBZP doubling, not additional padding waste.

An alternative to DBZP would be a Hanning window applied before the FFT to suppress circular correlation boundary artifacts. However, windowing attenuates the signal energy by ~1.76 dB (the coherent processing loss of a Hanning window), which degrades acquisition sensitivity — unacceptable for weak-signal scenarios. DBZP achieves the same linear correlation result with zero SNR loss, at the cost of doubling the FFT size.

The KA performance optimizations (single-chunk fast path, targeted zero-fill, FFTW.MEASURE) recover ~25–50% of the DBZP regression on the CPU Array backend.

## Motivation
When the sampling rate is close to the chip rate, the correlation output has few samples per chip. Neighbors of the peak sit near the triangle autocorrelation's edge where noise dominates signal. Zero-padding to the next FFTW-friendly size increases the effective resolution, and the smooth-number FFT runs faster with FFTW.MEASURE.

DBZP eliminates circular correlation bias that occurs when `code_length * sampling_freq / code_freq` is non-integer. Without DBZP, the FFT-based circular cross-correlation wraps at N samples, causing a boundary discontinuity that shifts the correlation peak. DBZP converts this to linear cross-correlation with zero SNR loss.

The `max_code_doppler_loss` parameter (default 0.5 dB) provides a system-independent way to control code Doppler compensation. It works uniformly across all GNSS systems: GPS L5 (which needs many code Doppler replicas at high Doppler due to its 10.23 MHz chip rate) benefits the most, while GPS L1 and Galileo E1B need few or no replicas due to their lower chip rates.

## Test plan
- [x] All 32 test sets pass
- [x] New CPU test verifies acquisition at 5kHz Doppler with 10ms integration
- [x] New KA test verifies GPU path at 5kHz Doppler with 10ms integration
- [x] New KA test with `zero_pad_power=0` covers the no-padding code path
- [x] New KA test with `zero_pad_power=1` covers frequency-domain zero-padding path
- [x] New unit tests for `max_phase_error_from_loss` verify sinc inversion round-trip
- [x] Real signal validation: acquisition code_phase within 0.09 chips of hand-tuned truth, tracking converges
- [x] Code_phase test tolerances tightened from 0.5 to 0.08 chips (KA), 0.08 to 0.04 (CPU)
- [x] KA path verified on AMD Vega iGPU via ROCArray: correctness confirmed, 2x faster than CPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)