### PR TITLE
ci: pass --threads=auto to benchmark runner

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -14,3 +14,4 @@ jobs:
           julia-version: '1'
           extra-pkgs: GNSSSignals,Unitful,FFTW
           bench-on: ${{github.event.pull_request.head.sha}}
+          exeflags: '--threads=auto'


### PR DESCRIPTION
## Summary
- The `AirspeedVelocity.jl` action hardcodes `export JULIA_NUM_THREADS=2` in its install step, so a workflow-level `env: JULIA_NUM_THREADS: auto` on the action step is silently overridden — benchmarks always ran on 2 threads.
- Route thread count through the action's `exeflags` input instead, which forwards to `benchpkg --exeflags='--threads=auto'` and is inherited by the benchmark runner subprocess.
- On `ubuntu-latest` (4 vCPUs) this gives benchmarks 4 threads instead of 2 and properly exercises the `@batch` multi-PRN path.

Merging this to master first so that subsequent PRs (e.g. #45) pick up the change via `pull_request_target`, which loads the workflow from the base branch.

## Test plan
- [ ] Merge to master
- [ ] Rebase #45; confirm the next `bench` run logs `--exeflags='--threads=auto'` in the `benchpkg` invocation and the runner reports 4 threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)