### PR TITLE
ci(docs): serialize gh-pages deploys with concurrency group

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -7,6 +7,10 @@ on:
     tags: '*'
   pull_request:
 
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
 jobs:
   build:
     permissions:


### PR DESCRIPTION
## Summary
- A tag push and a master push that land back-to-back both trigger the Documentation workflow. Both jobs build successfully, then race on `git push upstream HEAD:gh-pages` — the second one is rejected as non-fast-forward and the workflow fails. Example: [run 25011310597](https://github.com/JuliaGNSS/Acquisition.jl/actions/runs/25011310597/job/73247490780) failed this way against the parallel `v2.0.0` tag deploy.
- Adds a `concurrency: docs-deploy` group with `cancel-in-progress: false` so doc deploys serialize instead of racing. PR builds also share the group, but they don't deploy, so the cost is at most a short queue wait.

## Test plan
- [ ] Merge and confirm the next master/tag back-to-back doesn't reproduce the gh-pages push rejection.
- [ ] Confirm PR doc previews still build (they're gated on the same workflow but don't push to gh-pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)