### PR TITLE
perf: hoist signal-block FFTs out of per-PRN loop and drop dead fill!

### DIFF
--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -16,17 +16,17 @@ function _acquire_prn!(plan::AcquisitionPlan, scratch, prn::Int, accumulation_st
     prn_idx = findfirst(==(prn), plan.avail_prns)
     prn_fft_matrix = plan.prn_conj_ffts[prn]
 
+    # plan.signal_block_ffts is filled by _precompute_signal_block_ffts! in acquire!
+    # before this loop fires; we read from it here.
     _build_coherent_integration_matrix!(
         scratch.coherent_integration_matrix,
-        plan.sig_buf,
+        plan.signal_block_ffts,
         prn_fft_matrix,
         plan.samples_per_code,
         plan.num_blocks,
         plan.block_size,
         plan.num_coherently_integrated_code_periods,
-        scratch.double_block_buf,
         scratch.corr_buf,
-        plan.double_block_fft_plan,
         plan.double_block_bfft_plan,
     )
 
@@ -133,6 +133,20 @@ function acquire!(
                 plan.sig_buf[sample_idx] = ComplexF32(signal[seg_start + sample_idx - 1]) * Complex(c, s)
             end
         end
+
+        # Precompute signal-block FFTs once per dwell. They do not depend on
+        # PRN, so the per-PRN inner loop reads from `plan.signal_block_ffts`
+        # instead of redoing this O(num_coh*num_blocks) FFT batch per PRN.
+        _precompute_signal_block_ffts!(
+            plan.signal_block_ffts,
+            plan.sig_buf,
+            plan.samples_per_code,
+            plan.num_blocks,
+            plan.block_size,
+            plan.num_coherently_integrated_code_periods,
+            plan.double_block_buf,
+            plan.double_block_fft_plan,
+        )
 
         _acquire_step!(plan, prns, step_idx - 1)
     end

--- a/src/coherent_integration.jl
+++ b/src/coherent_integration.jl
@@ -1,9 +1,57 @@
 # src/coherent_integration.jl
 
 """
-    _build_coherent_integration_matrix!(coherent_integration_matrix, signal_f32, prn_fft_matrix, samples_per_code, num_blocks, block_size, num_coherently_integrated_code_periods, double_block_buf, fft_plan, bfft_plan)
+    _precompute_signal_block_ffts!(signal_block_ffts, signal_f32, samples_per_code, num_blocks, block_size, num_coherently_integrated_code_periods, double_block_buf, fft_plan)
 
-Fill `coherent_integration_matrix` (size `(num_coherently_integrated_code_periods*num_blocks, samples_per_code)`) with double-block correlation results.
+Precompute the FFT of every signal double-block once per `acquire!` call.
+Each column `global_block_idx + 1` of `signal_block_ffts` (size
+`(double_block_size, num_coh*num_blocks)`) holds the FFT of the
+`global_block_idx`-th double-block of `signal_f32`. Hoisting this out of the
+PRN loop avoids redoing the same FFT for each of the (typically 32) PRNs.
+"""
+function _precompute_signal_block_ffts!(
+    signal_block_ffts::Matrix{ComplexF32},  # (double_block_size, num_coh * num_blocks)
+    signal_f32::Vector{ComplexF32},
+    samples_per_code::Int,
+    num_blocks::Int,
+    block_size::Int,
+    num_coherently_integrated_code_periods::Int,
+    double_block_buf::Vector{ComplexF32},
+    fft_plan,
+)
+    double_block_size = 2 * block_size
+    segment_length = num_coherently_integrated_code_periods * samples_per_code
+    length(signal_f32) >= segment_length || throw(ArgumentError(
+        "signal_f32 length $(length(signal_f32)) < num_coherently_integrated_code_periods*samples_per_code = $segment_length"))
+
+    @inbounds for global_block_idx in 0:num_coherently_integrated_code_periods*num_blocks-1
+        block_start = global_block_idx * block_size + 1
+        next_start  = (global_block_idx + 1) * block_size + 1
+        if next_start + block_size - 1 <= segment_length
+            copyto!(double_block_buf, 1,             signal_f32, block_start, block_size)
+            copyto!(double_block_buf, block_size+1,  signal_f32, next_start,  block_size)
+        else
+            # last double-block of segment wraps to the start
+            remaining = segment_length - (next_start - 1)
+            copyto!(double_block_buf, 1,                       signal_f32, block_start, block_size)
+            copyto!(double_block_buf, block_size+1,            signal_f32, next_start,  remaining)
+            copyto!(double_block_buf, block_size+remaining+1,  signal_f32, 1,           block_size - remaining)
+        end
+        mul!(double_block_buf, fft_plan, double_block_buf)
+        copyto!(signal_block_ffts, global_block_idx * double_block_size + 1,
+                double_block_buf, 1, double_block_size)
+    end
+    return signal_block_ffts
+end
+
+"""
+    _build_coherent_integration_matrix!(coherent_integration_matrix, signal_block_ffts, prn_conj_fft_matrix, samples_per_code, num_blocks, block_size, num_coherently_integrated_code_periods, corr_buf, bfft_plan)
+
+Fill `coherent_integration_matrix` (size `(num_coherently_integrated_code_periods*num_blocks, samples_per_code)`) with double-block correlation results, given precomputed signal-block FFTs.
+
+This is the per-PRN inner kernel. Signal FFTs do not depend on PRN, so they
+are computed once per `acquire!` call by [`_precompute_signal_block_ffts!`](@ref)
+and reused across all PRNs.
 
 ## Structure
 
@@ -12,7 +60,7 @@ Column block `r` (columns `r*block_size+1 .. (r+1)*block_size`) is filled by cor
 signal double-block `k` with PRN sub-block `(k + r) mod num_blocks`:
 
     coherent_integration_matrix[p*num_blocks + k + 1, r*block_size+1 : (r+1)*block_size] =
-        IFFT( FFT(signal_double_block_{p*num_blocks+k}) * conj(FFT(prn_sub_block_{(k+r) mod num_blocks})) )[1:block_size]
+        IFFT( signal_block_ffts[:, p*num_blocks+k+1] * conj(FFT(prn_sub_block_{(k+r) mod num_blocks})) )[1:block_size]
 
 This ensures that for the true code delay `tau_samples = k_true*block_size + fine`:
 - Every signal block `k` has exactly one column block `r = (num_blocks - k_true) mod num_blocks` where
@@ -28,54 +76,36 @@ column index `pc` (0-indexed) satisfies:
 """
 function _build_coherent_integration_matrix!(
     coherent_integration_matrix::Matrix{ComplexF32},
-    signal_f32::Vector{ComplexF32},
+    signal_block_ffts::Matrix{ComplexF32},  # (double_block_size, num_coh*num_blocks) — precomputed
     prn_conj_fft_matrix::Matrix{ComplexF32},  # (double_block_size, num_blocks), already conjugated
     samples_per_code::Int,
     num_blocks::Int,
     block_size::Int,
     num_coherently_integrated_code_periods::Int,
-    double_block_buf::Vector{ComplexF32},
     corr_buf::Vector{ComplexF32},
-    fft_plan,
     bfft_plan,
 )
     double_block_size = 2 * block_size
     inverse_double_block_size = 1f0 / double_block_size
 
-    fill!(coherent_integration_matrix, zero(ComplexF32))
-    length(signal_f32) >= num_coherently_integrated_code_periods * samples_per_code || throw(ArgumentError(
-        "signal_f32 length $(length(signal_f32)) < num_coherently_integrated_code_periods*samples_per_code = $(num_coherently_integrated_code_periods * samples_per_code)"))
+    # No fill!: every cell of `coherent_integration_matrix` is written exactly
+    # once. Outer loops cover all `num_coh × num_blocks` rows, the column loop
+    # tiles all `num_blocks × block_size = samples_per_code` columns.
 
     for code_period_idx in 0:num_coherently_integrated_code_periods-1
         for block_idx in 0:num_blocks-1
-            global_block_idx = code_period_idx * num_blocks + block_idx   # global block index (0-based)
+            global_block_idx = code_period_idx * num_blocks + block_idx   # 0-based
+            sig_fft_col = view(signal_block_ffts, :, global_block_idx + 1)
 
-            # Signal double-block: two consecutive block_size blocks
-            block_start  = global_block_idx * block_size + 1
-            next_start = (global_block_idx + 1) * block_size + 1  # consecutive, no modular wrap needed
-            # (signal_f32 has length num_coherently_integrated_code_periods*samples_per_code, last block wraps to start of segment)
-            if next_start + block_size - 1 <= num_coherently_integrated_code_periods * samples_per_code
-                copyto!(double_block_buf, 1,             signal_f32, block_start,  block_size)
-                copyto!(double_block_buf, block_size+1,  signal_f32, next_start, block_size)
-            else
-                # last double-block of segment wraps
-                remaining = num_coherently_integrated_code_periods * samples_per_code - (next_start - 1)
-                copyto!(double_block_buf, 1,                    signal_f32, block_start,  block_size)
-                copyto!(double_block_buf, block_size+1,          signal_f32, next_start, remaining)
-                copyto!(double_block_buf, block_size+remaining+1, signal_f32, 1,         block_size-remaining)
-            end
-
-            # Forward FFT of double-block (in-place)
-            mul!(double_block_buf, fft_plan, double_block_buf)
-
-            # For each column block: multiply with conj(PRN sub-block (block_idx+col_block_idx) mod num_blocks)
+            # For each column block: multiply precomputed signal FFT with
+            # conj(PRN sub-block (block_idx+col_block_idx) mod num_blocks).
             for col_block_idx in 0:num_blocks-1
                 prn_block = mod(block_idx + col_block_idx, num_blocks)
 
-                # Multiply double_block_buf with precomputed conj(PRN FFT) into corr_buf
-                corr_buf .= double_block_buf .* view(prn_conj_fft_matrix, :, prn_block + 1)
+                # Multiply precomputed signal FFT with the conjugated PRN FFT.
+                corr_buf .= sig_fft_col .* view(prn_conj_fft_matrix, :, prn_block + 1)
 
-                # Inverse FFT (unnormalised), normalise, keep first block_size
+                # Inverse FFT (unnormalised), normalise, keep first block_size.
                 mul!(corr_buf, bfft_plan, corr_buf)
                 col_start = col_block_idx * block_size + 1
                 row = global_block_idx + 1

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -62,6 +62,7 @@ struct AcquisitionPlan{S<:AbstractGNSS,DS,P1,P2,P3,P4,R}
     noncoherent_integration_max_buf::Matrix{Float32}              # (num_doppler_bins, samples_per_code) — running max over bit edges per step
     noncoherent_integration_buf::Matrix{Float32}          # (num_doppler_bins, samples_per_code) — per-edge accumulator
     sub_block_ffts::Matrix{ComplexF32}    # (num_doppler_bins, num_data_bits) — scratch for _accumulate_noncoherent_integration_data_bits!
+    signal_block_ffts::Matrix{ComplexF32} # (double_block_size, num_coh*num_blocks) — precomputed once per acquire!, shared across PRNs
     noncoherent_integration_matrices::Vector{Matrix{Float32}}  # per PRN, (num_doppler_bins, samples_per_code); index i corresponds to avail_prns[i]
     fftshift_perm::Vector{Int}               # length num_doppler_bins — pre-computed fftshift row permutation
     result_buffers::Vector{Matrix{Float32}}  # per PRN, pre-allocated copy of power_bins for AcquisitionResults
@@ -277,6 +278,10 @@ function plan_acquire(
     noncoherent_integration_max_buf = zeros(Float32, num_doppler_bins, samples_per_code)
     noncoherent_integration_buf = zeros(Float32, num_doppler_bins, samples_per_code)
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, num_data_bits)
+    # Pre-allocated signal-block FFT cache: holds FFT(signal double-block k) for
+    # k ∈ 0..num_coh*num_blocks-1. Filled once per acquire! call before the PRN
+    # loop and reused across all PRNs.
+    signal_block_ffts = zeros(ComplexF32, double_block_size, num_coherently_integrated_code_periods * num_blocks)
     noncoherent_integration_matrices = [zeros(Float32, num_doppler_bins, samples_per_code) for _ in prns]
     fftshift_perm = [mod(r - 1 + num_doppler_bins ÷ 2, num_doppler_bins) + 1 for r in 1:num_doppler_bins]
     result_buffers = [zeros(Float32, num_doppler_bins, samples_per_code) for _ in prns]
@@ -317,6 +322,7 @@ function plan_acquire(
         doppler_freqs,
         double_block_buf, corr_buf, sig_buf, col_buf, col_fftshift_buf, row_buf, row_shift_buf,
         coherent_integration_matrix, noncoherent_integration_max_buf, noncoherent_integration_buf, sub_block_ffts,
+        signal_block_ffts,
         noncoherent_integration_matrices, fftshift_perm,
         result_buffers,
         avail_prns_vec,

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -144,6 +144,10 @@ end
     for prn_idx in eachindex(plan.avail_prns)
         fill!(plan.noncoherent_integration_matrices[prn_idx], 0f0)
     end
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, plan.sig_buf,
+        plan.samples_per_code, plan.num_blocks, plan.block_size,
+        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.double_block_fft_plan)
     Acquisition._acquire_step_threaded!(plan, collect(plan.avail_prns), 0)
     # PRN 1 should have a peak; just verify noncoherent matrix was filled
     @test maximum(plan.noncoherent_integration_matrices[1]) > 0

--- a/test/coherent_integration.jl
+++ b/test/coherent_integration.jl
@@ -22,10 +22,13 @@
         sampling_freq = sampling_freq, interm_freq = 0.0Hz, CN0 = 100)
 
     signal_f32 = ComplexF32.(signal)
-    fill!(plan.coherent_integration_matrix, zero(ComplexF32))
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, signal_f32, plan.prn_conj_ffts[prn],
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32,
+        plan.samples_per_code, plan.num_blocks, plan.block_size,
+        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.double_block_fft_plan)
+    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-        plan.double_block_buf, plan.corr_buf, plan.double_block_fft_plan, plan.double_block_bfft_plan)
+        plan.corr_buf, plan.double_block_bfft_plan)
 
     # In the full coherent integration matrix structure ALL rows peak at the same column:
     #   pc (0-indexed) = mod(num_blocks - tau÷block_size, num_blocks) * block_size + (tau%block_size)
@@ -49,10 +52,13 @@
         doppler = 0Hz, code_phase = code_phase_2,
         sampling_freq = sampling_freq, interm_freq = 0.0Hz, CN0 = 100)
     signal_f32_2 = ComplexF32.(result_2.signal)
-    fill!(plan.coherent_integration_matrix, zero(ComplexF32))
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, signal_f32_2, plan.prn_conj_ffts[prn],
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32_2,
+        plan.samples_per_code, plan.num_blocks, plan.block_size,
+        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.double_block_fft_plan)
+    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-        plan.double_block_buf, plan.corr_buf, plan.double_block_fft_plan, plan.double_block_bfft_plan)
+        plan.corr_buf, plan.double_block_bfft_plan)
     block_row_2 = tau_samples_2 ÷ plan.block_size
     @test block_row_2 == 1  # Verify we're testing block_row > 0 (non-trivial column block)
     scrambled_block_2    = mod(plan.num_blocks - block_row_2, plan.num_blocks)  # = 15

--- a/test/noncoherent_integration.jl
+++ b/test/noncoherent_integration.jl
@@ -21,10 +21,13 @@
         sampling_freq = sampling_freq, interm_freq = 0.0Hz, CN0 = 45)
 
     signal_f32 = ComplexF32.(signal)
-    fill!(plan.coherent_integration_matrix, zero(ComplexF32))
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, signal_f32, plan.prn_conj_ffts[prn],
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32,
+        plan.samples_per_code, plan.num_blocks, plan.block_size,
+        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.double_block_fft_plan)
+    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-        plan.double_block_buf, plan.corr_buf, plan.double_block_fft_plan, plan.double_block_bfft_plan)
+        plan.corr_buf, plan.double_block_bfft_plan)
 
     noncoherent_integration_matrix = zeros(Float32, plan.num_coherently_integrated_code_periods * plan.num_blocks, plan.samples_per_code)
     Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_matrix, plan.coherent_integration_matrix, plan.col_buf,
@@ -79,10 +82,13 @@ end
         sampling_freq = sampling_freq, interm_freq = 0.0Hz, CN0 = 60)
 
     signal_f32 = ComplexF32.(signal)
-    fill!(plan.coherent_integration_matrix, zero(ComplexF32))
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, signal_f32, plan.prn_conj_ffts[prn],
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32,
+        plan.samples_per_code, plan.num_blocks, plan.block_size,
+        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.double_block_fft_plan)
+    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-        plan.double_block_buf, plan.corr_buf, plan.double_block_fft_plan, plan.double_block_bfft_plan)
+        plan.corr_buf, plan.double_block_bfft_plan)
 
     noncoherent_integration_matrix = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     noncoherent_integration_buf = zeros(Float32, num_doppler_bins, plan.samples_per_code)
@@ -132,10 +138,13 @@ end
     half = (plan.num_coherently_integrated_code_periods ÷ plan.num_data_bits) * plan.samples_per_code  # = 20 * 2048 = 40960
     signal_flipped[half+1:end] .*= -1
 
-    fill!(plan.coherent_integration_matrix, zero(ComplexF32))
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, signal_flipped, plan.prn_conj_ffts[prn],
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_flipped,
+        plan.samples_per_code, plan.num_blocks, plan.block_size,
+        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.double_block_fft_plan)
+    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-        plan.double_block_buf, plan.corr_buf, plan.double_block_fft_plan, plan.double_block_bfft_plan)
+        plan.corr_buf, plan.double_block_bfft_plan)
 
     noncoherent_integration_data = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
@@ -182,10 +191,13 @@ end
 
     for plan in (plan_no_search, plan_with_search)
         num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks
-        fill!(plan.coherent_integration_matrix, zero(ComplexF32))
-        Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, signal_f32, plan.prn_conj_ffts[prn],
+        Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32,
+            plan.samples_per_code, plan.num_blocks, plan.block_size,
+            plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+            plan.double_block_fft_plan)
+        Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
             plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-            plan.double_block_buf, plan.corr_buf, plan.double_block_fft_plan, plan.double_block_bfft_plan)
+            plan.corr_buf, plan.double_block_bfft_plan)
         noncoherent_integration_matrix = zeros(Float32, num_doppler_bins, plan.samples_per_code)
         Acquisition._accumulate_noncoherent_integration_step!(noncoherent_integration_matrix, plan.coherent_integration_matrix, plan, 0)
 
@@ -320,21 +332,27 @@ end
 
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
 
-    fill!(plan.coherent_integration_matrix, zero(ComplexF32))
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, ComplexF32.(signal_no_transition),
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, ComplexF32.(signal_no_transition),
+        plan.samples_per_code, plan.num_blocks, plan.block_size,
+        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.double_block_fft_plan)
+    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf, plan.corr_buf,
-        plan.double_block_fft_plan, plan.double_block_bfft_plan)
+        plan.num_coherently_integrated_code_periods, plan.corr_buf,
+        plan.double_block_bfft_plan)
     noncoherent_integration_no_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_no_transition, plan.coherent_integration_matrix, plan.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
     peak_no_transition = maximum(noncoherent_integration_no_transition)
 
-    fill!(plan.coherent_integration_matrix, zero(ComplexF32))
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, ComplexF32.(signal_with_transition),
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, ComplexF32.(signal_with_transition),
+        plan.samples_per_code, plan.num_blocks, plan.block_size,
+        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.double_block_fft_plan)
+    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf, plan.corr_buf,
-        plan.double_block_fft_plan, plan.double_block_bfft_plan)
+        plan.num_coherently_integrated_code_periods, plan.corr_buf,
+        plan.double_block_bfft_plan)
     noncoherent_integration_with_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     Acquisition._accumulate_noncoherent_integration_data_bits!(noncoherent_integration_with_transition, plan.coherent_integration_matrix, plan.col_buf,
         plan.col_fftshift_buf, plan.col_fft_plan, plan.samples_per_code, num_doppler_bins,
@@ -362,21 +380,27 @@ end
 
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
 
-    fill!(plan.coherent_integration_matrix, zero(ComplexF32))
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, ComplexF32.(signal_no_transition),
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, ComplexF32.(signal_no_transition),
+        plan.samples_per_code, plan.num_blocks, plan.block_size,
+        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.double_block_fft_plan)
+    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf, plan.corr_buf,
-        plan.double_block_fft_plan, plan.double_block_bfft_plan)
+        plan.num_coherently_integrated_code_periods, plan.corr_buf,
+        plan.double_block_bfft_plan)
     noncoherent_integration_no_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_no_transition, plan.coherent_integration_matrix, plan.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
     peak_no_transition = maximum(noncoherent_integration_no_transition)
 
-    fill!(plan.coherent_integration_matrix, zero(ComplexF32))
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, ComplexF32.(signal_with_transition),
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, ComplexF32.(signal_with_transition),
+        plan.samples_per_code, plan.num_blocks, plan.block_size,
+        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.double_block_fft_plan)
+    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf, plan.corr_buf,
-        plan.double_block_fft_plan, plan.double_block_bfft_plan)
+        plan.num_coherently_integrated_code_periods, plan.corr_buf,
+        plan.double_block_bfft_plan)
     noncoherent_integration_with_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     Acquisition._accumulate_noncoherent_integration_data_bits!(noncoherent_integration_with_transition, plan.coherent_integration_matrix, plan.col_buf,
         plan.col_fftshift_buf, plan.col_fft_plan, plan.samples_per_code, num_doppler_bins,


### PR DESCRIPTION
## Summary

Two profile-driven optimisations to `acquire!`:

1. **Remove dead `fill!`** in `_build_coherent_integration_matrix!`. The loops write every cell of `coherent_integration_matrix` exactly once (outer loops cover all `num_coh*num_blocks` rows; inner loop tiles all `samples_per_code` columns), so the zero-fill before them was pure waste — a `(num_doppler_bins × samples_per_code)` complex-fill executed `num_PRNs × num_dwells` times per `acquire!` call.
2. **Hoist signal-block FFTs out of the per-PRN loop**. The FFT of the signal double-blocks doesn't depend on PRN, but the previous code recomputed it inside `_build_coherent_integration_matrix!` for each of the (typically 32) PRNs. Now precomputed once per dwell into a new shared `plan.signal_block_ffts` cache; the per-PRN kernel reads from it. Forward-FFT count drops from `num_PRNs * num_coh * num_blocks` to `num_coh * num_blocks` per dwell.

## API

`_build_coherent_integration_matrix!` now takes the precomputed FFT matrix instead of the raw signal + forward FFT plan. It's a private helper (leading underscore) so no public API impact. All test callsites are updated.

`AcquisitionPlan` gains one new field: `signal_block_ffts::Matrix{ComplexF32}` of shape `(double_block_size, num_coh*num_blocks)`. Filled by the new internal helper `_precompute_signal_block_ffts!`.

## Performance

GNSSReceiver microbench (RTL-SDR signal, 20 ms coherent, 32 PRNs, single-thread `acquire!`):

| Metric              | Baseline | After  | Δ      |
|---------------------|---------:|-------:|-------:|
| `acquire!` p50      | 145 ms   | 125 ms | **−14%** |
| `acquire!` min      | 143 ms   | 121 ms | **−15%** |
| `acquire!` allocs   | 4        | 4      | unchanged |
| `acquire!` bytes    | 1056     | 1056   | unchanged |

Tracking-side `process` p50 unchanged (this PR doesn't touch that path).

The remaining hot spot is the per-PRN inverse FFT in the column-block loop (one IFFT per `(PRN × col_block × global_block)` triple); that work cannot be shared across PRNs since each PRN has a different `prn_conj_fft_matrix`. Potential future avenue: FFTW batched IFFT plan along `col_block` to amortise plan-dispatch overhead.

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` — all suites pass (140 tests, 0 failed)
- [x] GNSSReceiver end-to-end RTL-SDR integration test passes — same 11 healthy PRNs, same PVT fix at the published Oegstgeest location

🤖 Generated with [Claude Code](https://claude.com/claude-code)