### PR TITLE
perf: reduce plan_acquire RAM footprint (#60 slices 1-5)

### DIFF
--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -112,7 +112,38 @@ function acquire!(
     interm_freq_hz = ustrip(Hz, interm_freq)
     sampling_freq_hz = ustrip(Hz, plan.sampling_freq)
 
-    # Reset per-PRN noncoherent accumulators for the requested PRNs
+    # The N_nc==1 case fuses build → accumulate → extract per PRN against a
+    # single per-thread accumulator, dropping the 32-PRN-wide noncoherent matrix
+    # vector. The multistep path (N_nc>1) still needs that vector because the
+    # accumulator carries state across signal segments shared between PRNs.
+    if plan.num_noncoherent_accumulations == 1
+        _acquire_sequential!(plan, signal, prns, segment_length, interm_freq_hz,
+            sampling_freq_hz, subsample_interpolation, store_power_bins)
+    else
+        _acquire_multistep!(plan, signal, prns, segment_length, interm_freq_hz,
+            sampling_freq_hz, subsample_interpolation, store_power_bins)
+    end
+end
+
+# Fill `sig_buf` with one downconverted code segment starting at `seg_start`.
+function _downconvert!(sig_buf, signal, seg_start, segment_length, interm_freq_hz, sampling_freq_hz)
+    if iszero(interm_freq_hz)
+        sig_buf .= ComplexF32.(view(signal, seg_start:seg_start + segment_length - 1))
+    else
+        phase_step = Float32(-2π * interm_freq_hz / sampling_freq_hz)
+        phase_offset = Float32((seg_start - 1) * phase_step)
+        @inbounds for sample_idx in 1:segment_length
+            phase = phase_offset + (sample_idx - 1) * phase_step
+            s, c = sincos(phase)
+            sig_buf[sample_idx] = ComplexF32(signal[seg_start + sample_idx - 1]) * Complex(c, s)
+        end
+    end
+end
+
+# Multistep path (current pre-slice-4 behaviour, factored out unchanged).
+function _acquire_multistep!(plan, signal, prns, segment_length, interm_freq_hz,
+                              sampling_freq_hz, subsample_interpolation, store_power_bins)
+    # Reset per-PRN noncoherent accumulators for the requested PRNs.
     for prn in prns
         prn_idx = findfirst(==(prn), plan.avail_prns)
         fill!(plan.noncoherent_integration_matrices[prn_idx], 0f0)
@@ -125,20 +156,7 @@ function acquire!(
 
     for step_idx in 1:plan.num_noncoherent_accumulations
         seg_start = (step_idx - 1) * segment_length + 1
-
-        # Downconvert: apply intermediate frequency rotation into sig_buf
-        if iszero(interm_freq_hz)
-            sig_buf .= ComplexF32.(view(signal, seg_start:seg_start + segment_length - 1))
-        else
-            phase_step = Float32(-2π * interm_freq_hz / sampling_freq_hz)
-            phase_offset = Float32((seg_start - 1) * phase_step)
-            @inbounds for sample_idx in 1:segment_length
-                phase = phase_offset + (sample_idx - 1) * phase_step
-                s, c = sincos(phase)
-                sig_buf[sample_idx] = ComplexF32(signal[seg_start + sample_idx - 1]) * Complex(c, s)
-            end
-        end
-
+        _downconvert!(sig_buf, signal, seg_start, segment_length, interm_freq_hz, sampling_freq_hz)
         # Precompute signal-block FFTs once per dwell. They do not depend on
         # PRN, so the per-PRN inner loop reads from `plan.signal_block_ffts`
         # instead of redoing this O(num_coh*num_blocks) FFT batch per PRN.
@@ -152,12 +170,9 @@ function acquire!(
             main_scratch.double_block_buf,
             plan.double_block_fft_plan,
         )
-
         _acquire_step!(plan, prns, step_idx - 1)
     end
 
-    # Build results into pre-allocated buffer (concrete-typed to avoid boxing).
-    # resize! to the requested PRN count is non-allocating when shrinking.
     results = resize!(plan.acq_results_buf, length(prns))
     code_freq_hz = ustrip(Hz, get_code_frequency(plan.system))
     code_length = get_code_length(plan.system)
@@ -168,74 +183,141 @@ function acquire!(
         prn = @inbounds prns[result_idx]
         prn_idx = findfirst(==(prn), plan.avail_prns)
         power_bins = plan.noncoherent_integration_matrices[prn_idx]
-        col_sums_buf = plan.thread_scratch[Threads.threadid()].col_sums_buf
-
-        signal_power, noise_power, code_bin_idx, doppler_bin_idx = est_signal_noise_power(
-            power_bins,
-            sampling_freq_hz,
-            code_freq_hz,
-            col_sums_buf,
-            plan.noise_estimator,
-        )
-
-        peak_to_noise = (signal_power + noise_power) / noise_power
-        CN0 = 10 * log10(signal_power / noise_power / code_period / 1.0Hz)
-
-        # Decode code phase from column index (0-indexed column → delay in samples)
-        scrambled_col = code_bin_idx - 1  # convert to 0-indexed
-        delay_samples = _fmdbzp_column_to_tau(scrambled_col, plan.num_blocks, plan.block_size)
-        code_phase = mod(-delay_samples * code_freq_hz / sampling_freq_hz, code_length)
-
-        if subsample_interpolation
-            num_code_bins = plan.samples_per_code
-            col_left  = mod(scrambled_col - 1, num_code_bins)
-            col_right = mod(scrambled_col + 1, num_code_bins)
-            power_left  = power_bins[doppler_bin_idx, col_left + 1]
-            power_peak  = power_bins[doppler_bin_idx, scrambled_col + 1]
-            power_right = power_bins[doppler_bin_idx, col_right + 1]
-            if max(power_left, power_right) > sqrt(noise_power)
-                fractional_col_offset = _parabolic_interp(power_left, power_peak, power_right)
-                delay_samples_interp = delay_samples + fractional_col_offset
-                code_phase = mod(-delay_samples_interp * code_freq_hz / sampling_freq_hz, code_length)
-            end
-        end
-
-        doppler = plan.doppler_freqs[doppler_bin_idx]
-        if subsample_interpolation
-            dop_left  = power_bins[doppler_bin_idx == 1 ? num_doppler_bins : doppler_bin_idx - 1, code_bin_idx]
-            dop_peak  = power_bins[doppler_bin_idx, code_bin_idx]
-            dop_right = power_bins[doppler_bin_idx == num_doppler_bins ? 1 : doppler_bin_idx + 1, code_bin_idx]
-            if max(dop_left, dop_right) > sqrt(noise_power)
-                fractional_doppler_offset = _parabolic_interp(dop_left, dop_peak, dop_right)
-                doppler = doppler + fractional_doppler_offset * doppler_step
-            end
-        end
-
-        result_buf = if store_power_bins
-            cached = plan.result_buffers[prn_idx]
-            buf = cached === nothing ? similar(power_bins) : cached
-            plan.result_buffers[prn_idx] = buf
-            copyto!(buf, power_bins)
-        else
-            nothing
-        end
-        results[result_idx] = AcquisitionResults(
-            plan.system,
-            prn,
-            plan.sampling_freq,
-            doppler,
-            code_phase,
-            CN0,
-            Float32(noise_power),
-            Float32(peak_to_noise),
-            plan.num_noncoherent_accumulations,
-            result_buf,
-            plan.doppler_freqs,
-            plan.num_blocks,
-            plan.block_size,
-        )
+        scratch = plan.thread_scratch[Threads.threadid()]
+        results[result_idx] = _extract_result!(plan, scratch, prn, prn_idx, power_bins,
+            sampling_freq_hz, code_freq_hz, code_length, code_period,
+            num_doppler_bins, doppler_step, subsample_interpolation, store_power_bins)
     end
     return results
+end
+
+# Sequential path used when num_noncoherent_accumulations == 1: one segment,
+# per-PRN fused build → accumulate → extract against a per-thread accumulator.
+function _acquire_sequential!(plan, signal, prns, segment_length, interm_freq_hz,
+                               sampling_freq_hz, subsample_interpolation, store_power_bins)
+    main_scratch = _default_scratch(plan)
+    sig_buf = main_scratch.sig_buf
+
+    _downconvert!(sig_buf, signal, 1, segment_length, interm_freq_hz, sampling_freq_hz)
+    _precompute_signal_block_ffts!(
+        plan.signal_block_ffts,
+        sig_buf,
+        plan.samples_per_code,
+        plan.num_blocks,
+        plan.block_size,
+        plan.num_coherently_integrated_code_periods,
+        main_scratch.double_block_buf,
+        plan.double_block_fft_plan,
+    )
+
+    results = resize!(plan.acq_results_buf, length(prns))
+    code_freq_hz = ustrip(Hz, get_code_frequency(plan.system))
+    code_length = get_code_length(plan.system)
+    code_period = code_length / get_code_frequency(plan.system)
+    num_doppler_bins = length(plan.doppler_freqs)
+    doppler_step = step(plan.doppler_freqs)
+
+    @batch per=core for result_idx in eachindex(prns)
+        prn = @inbounds prns[result_idx]
+        prn_idx = findfirst(==(prn), plan.avail_prns)
+        scratch = plan.thread_scratch[Threads.threadid()]
+        accumulator = scratch.noncoherent_integration_accumulator
+        fill!(accumulator, 0f0)
+
+        _build_coherent_integration_matrix!(
+            scratch.coherent_integration_matrix,
+            plan.signal_block_ffts,
+            plan.prn_conj_ffts[prn],
+            plan.samples_per_code,
+            plan.num_blocks,
+            plan.block_size,
+            plan.num_coherently_integrated_code_periods,
+            scratch.corr_buf,
+            plan.double_block_bfft_plan,
+        )
+        _accumulate_noncoherent_integration_step!(accumulator, scratch.coherent_integration_matrix,
+            plan, scratch, 0)
+
+        results[result_idx] = _extract_result!(plan, scratch, prn, prn_idx, accumulator,
+            sampling_freq_hz, code_freq_hz, code_length, code_period,
+            num_doppler_bins, doppler_step, subsample_interpolation, store_power_bins)
+    end
+    return results
+end
+
+# Read the peak out of `power_bins` and assemble an AcquisitionResults. Used by
+# both the sequential and multistep paths; in the sequential path `power_bins`
+# is the per-thread accumulator (and is reused by the next PRN), so the
+# store_power_bins copy must happen here before this function returns.
+function _extract_result!(plan, scratch, prn, prn_idx, power_bins,
+                          sampling_freq_hz, code_freq_hz, code_length, code_period,
+                          num_doppler_bins, doppler_step, subsample_interpolation, store_power_bins)
+    col_sums_buf = scratch.col_sums_buf
+
+    signal_power, noise_power, code_bin_idx, doppler_bin_idx = est_signal_noise_power(
+        power_bins,
+        sampling_freq_hz,
+        code_freq_hz,
+        col_sums_buf,
+        plan.noise_estimator,
+    )
+
+    peak_to_noise = (signal_power + noise_power) / noise_power
+    CN0 = 10 * log10(signal_power / noise_power / code_period / 1.0Hz)
+
+    scrambled_col = code_bin_idx - 1
+    delay_samples = _fmdbzp_column_to_tau(scrambled_col, plan.num_blocks, plan.block_size)
+    code_phase = mod(-delay_samples * code_freq_hz / sampling_freq_hz, code_length)
+
+    if subsample_interpolation
+        num_code_bins = plan.samples_per_code
+        col_left  = mod(scrambled_col - 1, num_code_bins)
+        col_right = mod(scrambled_col + 1, num_code_bins)
+        power_left  = power_bins[doppler_bin_idx, col_left + 1]
+        power_peak  = power_bins[doppler_bin_idx, scrambled_col + 1]
+        power_right = power_bins[doppler_bin_idx, col_right + 1]
+        if max(power_left, power_right) > sqrt(noise_power)
+            fractional_col_offset = _parabolic_interp(power_left, power_peak, power_right)
+            delay_samples_interp = delay_samples + fractional_col_offset
+            code_phase = mod(-delay_samples_interp * code_freq_hz / sampling_freq_hz, code_length)
+        end
+    end
+
+    doppler = plan.doppler_freqs[doppler_bin_idx]
+    if subsample_interpolation
+        dop_left  = power_bins[doppler_bin_idx == 1 ? num_doppler_bins : doppler_bin_idx - 1, code_bin_idx]
+        dop_peak  = power_bins[doppler_bin_idx, code_bin_idx]
+        dop_right = power_bins[doppler_bin_idx == num_doppler_bins ? 1 : doppler_bin_idx + 1, code_bin_idx]
+        if max(dop_left, dop_right) > sqrt(noise_power)
+            fractional_doppler_offset = _parabolic_interp(dop_left, dop_peak, dop_right)
+            doppler = doppler + fractional_doppler_offset * doppler_step
+        end
+    end
+
+    result_buf = if store_power_bins
+        cached = plan.result_buffers[prn_idx]
+        buf = cached === nothing ? similar(power_bins) : cached
+        plan.result_buffers[prn_idx] = buf
+        copyto!(buf, power_bins)
+    else
+        nothing
+    end
+
+    return AcquisitionResults(
+        plan.system,
+        prn,
+        plan.sampling_freq,
+        doppler,
+        code_phase,
+        CN0,
+        Float32(noise_power),
+        Float32(peak_to_noise),
+        plan.num_noncoherent_accumulations,
+        result_buf,
+        plan.doppler_freqs,
+        plan.num_blocks,
+        plan.block_size,
+    )
 end
 
 """

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -118,19 +118,24 @@ function acquire!(
         fill!(plan.noncoherent_integration_matrices[prn_idx], 0f0)
     end
 
+    # The dwell-level scratch (downconverted segment + per-FFT temp) lives in
+    # thread 1's slot — `_default_scratch(plan)` names that convention.
+    main_scratch = _default_scratch(plan)
+    sig_buf = main_scratch.sig_buf
+
     for step_idx in 1:plan.num_noncoherent_accumulations
         seg_start = (step_idx - 1) * segment_length + 1
 
         # Downconvert: apply intermediate frequency rotation into sig_buf
         if iszero(interm_freq_hz)
-            plan.sig_buf .= ComplexF32.(view(signal, seg_start:seg_start + segment_length - 1))
+            sig_buf .= ComplexF32.(view(signal, seg_start:seg_start + segment_length - 1))
         else
             phase_step = Float32(-2π * interm_freq_hz / sampling_freq_hz)
             phase_offset = Float32((seg_start - 1) * phase_step)
             @inbounds for sample_idx in 1:segment_length
                 phase = phase_offset + (sample_idx - 1) * phase_step
                 s, c = sincos(phase)
-                plan.sig_buf[sample_idx] = ComplexF32(signal[seg_start + sample_idx - 1]) * Complex(c, s)
+                sig_buf[sample_idx] = ComplexF32(signal[seg_start + sample_idx - 1]) * Complex(c, s)
             end
         end
 
@@ -139,12 +144,12 @@ function acquire!(
         # instead of redoing this O(num_coh*num_blocks) FFT batch per PRN.
         _precompute_signal_block_ffts!(
             plan.signal_block_ffts,
-            plan.sig_buf,
+            sig_buf,
             plan.samples_per_code,
             plan.num_blocks,
             plan.block_size,
             plan.num_coherently_integrated_code_periods,
-            plan.double_block_buf,
+            main_scratch.double_block_buf,
             plan.double_block_fft_plan,
         )
 

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -212,7 +212,10 @@ function acquire!(
         end
 
         result_buf = if store_power_bins
-            copyto!(plan.result_buffers[prn_idx], power_bins)
+            cached = plan.result_buffers[prn_idx]
+            buf = cached === nothing ? similar(power_bins) : cached
+            plan.result_buffers[prn_idx] = buf
+            copyto!(buf, power_bins)
         else
             nothing
         end

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -217,6 +217,11 @@ function _acquire_sequential!(plan, signal, prns, segment_length, interm_freq_hz
     num_doppler_bins = length(plan.doppler_freqs)
     doppler_step = step(plan.doppler_freqs)
 
+    # When the simple/pilot routing applies, fuse the column FFT + |x|² + fftshift
+    # row permutation into one pass directly into the accumulator — see
+    # `_accumulate_fftshifted_power_pilot!`. Otherwise (bit edge / data bit
+    # search) fall back to the unfused `_accumulate_noncoherent_integration_step!`.
+    simple_path = plan.num_data_bits == 1 && plan.bit_edge_search_steps == 1
     @batch per=core for result_idx in eachindex(prns)
         prn = @inbounds prns[result_idx]
         prn_idx = findfirst(==(prn), plan.avail_prns)
@@ -235,8 +240,21 @@ function _acquire_sequential!(plan, signal, prns, segment_length, interm_freq_hz
             scratch.corr_buf,
             plan.double_block_bfft_plan,
         )
-        _accumulate_noncoherent_integration_step!(accumulator, scratch.coherent_integration_matrix,
-            plan, scratch, 0)
+        if simple_path
+            if num_doppler_bins <= BATCH_FFT_THRESHOLD
+                _accumulate_fftshifted_power_pilot_batched!(
+                    accumulator, scratch.coherent_integration_matrix,
+                    plan.col_batch_fft_plan, plan.samples_per_code, num_doppler_bins)
+            else
+                _accumulate_fftshifted_power_pilot!(
+                    accumulator, scratch.coherent_integration_matrix,
+                    scratch.col_buf, plan.col_fft_plan,
+                    plan.samples_per_code, num_doppler_bins)
+            end
+        else
+            _accumulate_noncoherent_integration_step!(accumulator, scratch.coherent_integration_matrix,
+                plan, scratch, 0)
+        end
 
         results[result_idx] = _extract_result!(plan, scratch, prn, prn_idx, accumulator,
             sampling_freq_hz, code_freq_hz, code_length, code_period,

--- a/src/noncoherent_integration.jl
+++ b/src/noncoherent_integration.jl
@@ -109,7 +109,7 @@ function _apply_code_drift!(noncoherent_integration_buf::Matrix{Float32}, plan::
 end
 # Single-argument scratch convenience: used by tests and code-drift testset directly
 _apply_code_drift!(buf::Matrix{Float32}, plan::AcquisitionPlan, accumulation_step_index::Int) =
-    _apply_code_drift!(buf, plan, plan, accumulation_step_index)
+    _apply_code_drift!(buf, plan, _default_scratch(plan), accumulation_step_index)
 
 # Scatter `src` into `dst` applying fftshift row permutation (accumulating).
 # For even num_doppler_bins — the only case in practice — this is a top/bottom
@@ -204,6 +204,7 @@ function _accumulate_noncoherent_integration_step!(
         _scatter_fftshift_accumulate!(noncoherent_integration_matrix, noncoherent_integration_max_buf, plan.fftshift_perm, plan.samples_per_code)
     end
 end
-# Convenience wrapper for tests and single-threaded callers (scratch = plan itself)
+# Convenience wrapper for tests and single-threaded callers — routes through
+# thread 1's scratch (see `_default_scratch`).
 _accumulate_noncoherent_integration_step!(nim, cim, plan::AcquisitionPlan, accumulation_step_index::Int) =
-    _accumulate_noncoherent_integration_step!(nim, cim, plan, plan, accumulation_step_index)
+    _accumulate_noncoherent_integration_step!(nim, cim, plan, _default_scratch(plan), accumulation_step_index)

--- a/src/noncoherent_integration.jl
+++ b/src/noncoherent_integration.jl
@@ -111,6 +111,62 @@ end
 _apply_code_drift!(buf::Matrix{Float32}, plan::AcquisitionPlan, accumulation_step_index::Int) =
     _apply_code_drift!(buf, plan, _default_scratch(plan), accumulation_step_index)
 
+# Per-column FFT followed by `|x|²` accumulation into `accumulator`, with the
+# row written at its fftshift-permuted position. Folds two passes
+# (`_accumulate_noncoherent_integration_pilot!` + `_scatter_fftshift_accumulate!`)
+# into one, dropping the full-matrix-size `noncoherent_integration_buf`
+# intermediate. Valid only at num_noncoherent_accumulations == 1 simple/pilot
+# path: code-drift correction is a no-op at step 0 and there is no bit-edge max
+# search to reuse the buf across alignments.
+#
+# The fftshift permutation is a fixed rotation by `shift = N ÷ 2` rows:
+#   src rows 1..N-shift    → dst rows 1+shift..N      (advance)
+#   src rows N-shift+1..N  → dst rows 1..shift        (wrap)
+# Two contiguous loops express both halves so the compiler can SIMD.
+function _accumulate_fftshifted_power_pilot!(
+    accumulator::Matrix{Float32},
+    coherent_integration_matrix::Matrix{ComplexF32},
+    col_buf::Vector{ComplexF32},
+    col_fft_plan,
+    samples_per_code::Int,
+    num_doppler_bins::Int,
+)
+    shift = num_doppler_bins ÷ 2
+    front = num_doppler_bins - shift
+    @inbounds for col_idx in 1:samples_per_code
+        copyto!(col_buf, 1, coherent_integration_matrix, (col_idx - 1) * num_doppler_bins + 1, num_doppler_bins)
+        mul!(col_buf, col_fft_plan, col_buf)
+        @simd for doppler_bin in 1:front
+            accumulator[doppler_bin + shift, col_idx] += abs2(col_buf[doppler_bin])
+        end
+        @simd for doppler_bin in 1:shift
+            accumulator[doppler_bin, col_idx] += abs2(col_buf[doppler_bin + front])
+        end
+    end
+end
+
+# Batched-FFT counterpart: FFT all columns at once in-place on the CIM, then
+# accumulate `|x|²` into `accumulator` with the fftshift row permutation.
+function _accumulate_fftshifted_power_pilot_batched!(
+    accumulator::Matrix{Float32},
+    coherent_integration_matrix::Matrix{ComplexF32},
+    col_batch_fft_plan,
+    samples_per_code::Int,
+    num_doppler_bins::Int,
+)
+    mul!(coherent_integration_matrix, col_batch_fft_plan, coherent_integration_matrix)
+    shift = num_doppler_bins ÷ 2
+    front = num_doppler_bins - shift
+    @inbounds for col_idx in 1:samples_per_code
+        @simd for doppler_bin in 1:front
+            accumulator[doppler_bin + shift, col_idx] += abs2(coherent_integration_matrix[doppler_bin, col_idx])
+        end
+        @simd for doppler_bin in 1:shift
+            accumulator[doppler_bin, col_idx] += abs2(coherent_integration_matrix[doppler_bin + front, col_idx])
+        end
+    end
+end
+
 # Scatter `src` into `dst` applying fftshift row permutation (accumulating).
 # For even num_doppler_bins — the only case in practice — this is a top/bottom
 # half swap, which SIMDs. For odd N, fall back to the indexed scatter (the

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -54,7 +54,10 @@ struct AcquisitionPlan{S<:AbstractGNSSSignal,DS,P1,P2,P3,P4,R,E<:AbstractNoiseEs
     signal_block_ffts::Matrix{ComplexF32} # (double_block_size, num_coh*num_blocks) — precomputed once per acquire!, shared across PRNs
     noncoherent_integration_matrices::Vector{Matrix{Float32}}  # per PRN, (num_doppler_bins, samples_per_code); index i corresponds to avail_prns[i]
     fftshift_perm::Vector{Int}               # length num_doppler_bins — pre-computed fftshift row permutation
-    result_buffers::Vector{Matrix{Float32}}  # per PRN, pre-allocated copy of power_bins for AcquisitionResults
+    # Per PRN: holds a copy of power_bins when the caller of `acquire!` passes
+    # store_power_bins=true. Initialised to `nothing` and allocated on the first
+    # opt-in call per PRN; subsequent calls reuse the same matrix in-place.
+    result_buffers::Vector{Union{Nothing,Matrix{Float32}}}
     avail_prns::Vector{Int}
     # Per-thread scratch, indexed by Threads.threadid() (length = nthreads at plan_acquire time).
     # Thread 1's entry doubles as the ambient single-threaded scratch — see `_default_scratch`.
@@ -280,7 +283,7 @@ function plan_acquire(
     signal_block_ffts = zeros(ComplexF32, double_block_size, num_coherently_integrated_code_periods * num_blocks)
     noncoherent_integration_matrices = [zeros(Float32, num_doppler_bins, samples_per_code) for _ in prns]
     fftshift_perm = [mod(r - 1 + num_doppler_bins ÷ 2, num_doppler_bins) + 1 for r in 1:num_doppler_bins]
-    result_buffers = [zeros(Float32, num_doppler_bins, samples_per_code) for _ in prns]
+    result_buffers = Union{Nothing,Matrix{Float32}}[nothing for _ in prns]
 
     # Per-thread scratch: one entry per thread, indexed by Threads.threadid().
     # Use maxthreadid() to cover Julia's internal task-switching threads (always >= nthreads()).

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -20,6 +20,11 @@ struct AcquisitionScratch
     coherent_integration_matrix::Matrix{ComplexF32}         # (num_doppler_bins, samples_per_code)
     noncoherent_integration_max_buf::Matrix{Float32}         # (num_doppler_bins, samples_per_code) — 0x0 when simple path is taken (see plan_acquire)
     noncoherent_integration_buf::Matrix{Float32}             # (num_doppler_bins, samples_per_code)
+    # At num_noncoherent_accumulations == 1 this matrix replaces the per-PRN
+    # `noncoherent_integration_matrices` vector: each PRN runs one build+accumulate
+    # into this per-thread buffer, then extracts its result before the next PRN
+    # overwrites it. 0x0 when N_nc > 1 (the per-PRN layout is required there).
+    noncoherent_integration_accumulator::Matrix{Float32}
     sub_block_ffts::Matrix{ComplexF32}              # (num_doppler_bins, num_data_bits) — 0x0 when simple path is taken (see plan_acquire)
     col_sums_buf::Vector{Float32}                   # length samples_per_code — scratch for est_signal_noise_power
 end
@@ -281,7 +286,17 @@ function plan_acquire(
     # k ∈ 0..num_coh*num_blocks-1. Filled once per acquire! call before the PRN
     # loop and reused across all PRNs.
     signal_block_ffts = zeros(ComplexF32, double_block_size, num_coherently_integrated_code_periods * num_blocks)
-    noncoherent_integration_matrices = [zeros(Float32, num_doppler_bins, samples_per_code) for _ in prns]
+    # At N_nc == 1 each PRN's noncoherent matrix is written once and consumed
+    # once for result extraction; we collapse the per-PRN vector into a
+    # per-thread accumulator (see `noncoherent_integration_accumulator` in
+    # AcquisitionScratch). The multistep path (N_nc > 1) still needs the
+    # per-PRN vector because it accumulates across steps.
+    sequential_prn_mode = num_noncoherent_accumulations == 1
+    noncoherent_integration_matrices = sequential_prn_mode ?
+        Matrix{Float32}[] :
+        [zeros(Float32, num_doppler_bins, samples_per_code) for _ in prns]
+    accumulator_rows = sequential_prn_mode ? num_doppler_bins : 0
+    accumulator_cols = sequential_prn_mode ? samples_per_code : 0
     fftshift_perm = [mod(r - 1 + num_doppler_bins ÷ 2, num_doppler_bins) + 1 for r in 1:num_doppler_bins]
     result_buffers = Union{Nothing,Matrix{Float32}}[nothing for _ in prns]
 
@@ -314,6 +329,7 @@ function plan_acquire(
             zeros(ComplexF32, num_doppler_bins, samples_per_code),
             zeros(Float32, sign_search_max_rows, sign_search_max_cols),
             zeros(Float32, num_doppler_bins, samples_per_code),
+            zeros(Float32, accumulator_rows, accumulator_cols),
             zeros(ComplexF32, sign_search_max_rows, sub_block_cols),
             zeros(Float32, samples_per_code),
         )

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -12,6 +12,7 @@ const BATCH_FFT_THRESHOLD = 320
 struct AcquisitionScratch
     double_block_buf::Vector{ComplexF32}            # length double_block_size
     corr_buf::Vector{ComplexF32}                    # length double_block_size
+    sig_buf::Vector{ComplexF32}                     # length segment_length — downconverted signal segment (thread 1 only)
     col_buf::Vector{ComplexF32}                     # length num_doppler_bins
     col_fftshift_buf::Vector{ComplexF32}            # length num_doppler_bins
     row_buf::Vector{Float32}                        # length samples_per_code
@@ -50,30 +51,26 @@ struct AcquisitionPlan{S<:AbstractGNSSSignal,DS,P1,P2,P3,P4,R,E<:AbstractNoiseEs
     col_batch_fft_plan::P4      # in-place forward FFT along dim 1 of (num_doppler_bins, samples_per_code) matrix; `nothing` when num_doppler_bins > BATCH_FFT_THRESHOLD
     # doppler_freqs: StepRangeLen of num_doppler_bins Hz values, sorted from -doppler_coverage_hz/2 to doppler_coverage_hz/2-doppler_bin_spacing_hz
     doppler_freqs::DS
-    # Pre-allocated buffers for thread 1 / single-threaded use (reused across calls)
-    double_block_buf::Vector{ComplexF32}            # length double_block_size
-    corr_buf::Vector{ComplexF32}          # length double_block_size — scratch for bfft in _build_coherent_integration_matrix!
-    sig_buf::Vector{ComplexF32}           # length segment_length — downconverted signal segment
-    col_buf::Vector{ComplexF32}           # length num_doppler_bins
-    col_fftshift_buf::Vector{ComplexF32}  # length num_doppler_bins
-    row_buf::Vector{Float32}              # length samples_per_code — source buffer for _apply_code_drift!
-    row_shift_buf::Vector{Float32}        # length samples_per_code — destination buffer for circshift! in _apply_code_drift!
-    coherent_integration_matrix::Matrix{ComplexF32}         # (num_doppler_bins, samples_per_code), filled per PRN per step
-    noncoherent_integration_max_buf::Matrix{Float32}              # (num_doppler_bins, samples_per_code) — running max over bit edges per step
-    noncoherent_integration_buf::Matrix{Float32}          # (num_doppler_bins, samples_per_code) — per-edge accumulator
-    sub_block_ffts::Matrix{ComplexF32}    # (num_doppler_bins, num_data_bits) — scratch for _accumulate_noncoherent_integration_data_bits!
     signal_block_ffts::Matrix{ComplexF32} # (double_block_size, num_coh*num_blocks) — precomputed once per acquire!, shared across PRNs
     noncoherent_integration_matrices::Vector{Matrix{Float32}}  # per PRN, (num_doppler_bins, samples_per_code); index i corresponds to avail_prns[i]
     fftshift_perm::Vector{Int}               # length num_doppler_bins — pre-computed fftshift row permutation
     result_buffers::Vector{Matrix{Float32}}  # per PRN, pre-allocated copy of power_bins for AcquisitionResults
     avail_prns::Vector{Int}
-    # Per-thread scratch, indexed by Threads.threadid() (length = nthreads at plan_acquire time)
+    # Per-thread scratch, indexed by Threads.threadid() (length = nthreads at plan_acquire time).
+    # Thread 1's entry doubles as the ambient single-threaded scratch — see `_default_scratch`.
     thread_scratch::Vector{AcquisitionScratch}
     # Pre-allocated results buffer, concrete-typed to avoid boxing allocations
     acq_results_buf::Vector{R}
     # Singleton selecting the noise-power estimator used by `est_signal_noise_power`.
     noise_estimator::E
 end
+
+# Thread 1's scratch is the ambient single-threaded scratch reused by `acquire!`
+# (downconversion + signal-block FFT precompute happen before the per-PRN parallel
+# loop) and by test/REPL call sites that drive the kernels directly. Naming this
+# convention here keeps it from being re-implemented as `plan.thread_scratch[1]`
+# across the codebase.
+_default_scratch(plan::AcquisitionPlan) = plan.thread_scratch[1]
 
 """
     _precompute_prn_ffts!(prn_ffts, system, prn, sampling_freq, samples_per_code, num_blocks, block_size, double_block_size, fft_plan)
@@ -276,19 +273,7 @@ function plan_acquire(
     doppler_bin_spacing_hz = doppler_coverage_hz / num_doppler_bins
     doppler_freqs = range(-doppler_coverage_hz / 2, step = doppler_bin_spacing_hz, length = num_doppler_bins) .* Hz
 
-    # Pre-allocated buffers (thread 1 / single-threaded use)
     segment_length = num_coherently_integrated_code_periods * samples_per_code
-    double_block_buf = zeros(ComplexF32, double_block_size)
-    corr_buf = zeros(ComplexF32, double_block_size)
-    sig_buf = zeros(ComplexF32, segment_length)
-    col_buf = zeros(ComplexF32, num_doppler_bins)
-    col_fftshift_buf = zeros(ComplexF32, num_doppler_bins)
-    row_buf = zeros(Float32, samples_per_code)
-    row_shift_buf = zeros(Float32, samples_per_code)
-    coherent_integration_matrix = zeros(ComplexF32, num_doppler_bins, samples_per_code)
-    noncoherent_integration_max_buf = zeros(Float32, num_doppler_bins, samples_per_code)
-    noncoherent_integration_buf = zeros(Float32, num_doppler_bins, samples_per_code)
-    sub_block_ffts = zeros(ComplexF32, num_doppler_bins, num_data_bits)
     # Pre-allocated signal-block FFT cache: holds FFT(signal double-block k) for
     # k ∈ 0..num_coh*num_blocks-1. Filled once per acquire! call before the PRN
     # loop and reused across all PRNs.
@@ -299,11 +284,16 @@ function plan_acquire(
 
     # Per-thread scratch: one entry per thread, indexed by Threads.threadid().
     # Use maxthreadid() to cover Julia's internal task-switching threads (always >= nthreads()).
+    # `sig_buf` lives here so that thread 1's scratch — the ambient single-threaded
+    # scratch — owns the downconverted-signal buffer used by `acquire!` before the
+    # per-PRN parallel loop. Other threads' sig_buf entries are unused (a few MB
+    # × nthreads, dwarfed by the matrices already sized per-thread).
     nthreads = Threads.maxthreadid()
     thread_scratch = [
         AcquisitionScratch(
             zeros(ComplexF32, double_block_size),
             zeros(ComplexF32, double_block_size),
+            zeros(ComplexF32, segment_length),
             zeros(ComplexF32, num_doppler_bins),
             zeros(ComplexF32, num_doppler_bins),
             zeros(Float32, samples_per_code),
@@ -331,8 +321,6 @@ function plan_acquire(
         prn_conj_ffts,
         double_block_fft_plan, double_block_bfft_plan, col_fft_plan, col_batch_fft_plan,
         doppler_freqs,
-        double_block_buf, corr_buf, sig_buf, col_buf, col_fftshift_buf, row_buf, row_shift_buf,
-        coherent_integration_matrix, noncoherent_integration_max_buf, noncoherent_integration_buf, sub_block_ffts,
         signal_block_ffts,
         noncoherent_integration_matrices, fftshift_perm,
         result_buffers,

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -310,6 +310,14 @@ function plan_acquire(
     sign_search_max_cols = sign_search_path_active ? samples_per_code  : 0
     sub_block_cols       = sign_search_path_active ? num_data_bits     : 0
 
+    # `noncoherent_integration_buf` (the |x|² intermediate) is bypassed when the
+    # fused FFT+|x|²+fftshift kernel runs (sequential N_nc==1 + simple path).
+    # Sign-search-at-N_nc==1 and any multistep path still consume the buf, so
+    # we only allocate it when at least one of those routes can fire.
+    integration_buf_needed = sign_search_path_active || !sequential_prn_mode
+    integration_buf_rows = integration_buf_needed ? num_doppler_bins : 0
+    integration_buf_cols = integration_buf_needed ? samples_per_code : 0
+
     # Per-thread scratch: one entry per thread, indexed by Threads.threadid().
     # Use maxthreadid() to cover Julia's internal task-switching threads (always >= nthreads()).
     # `sig_buf` lives here so that thread 1's scratch — the ambient single-threaded
@@ -328,7 +336,7 @@ function plan_acquire(
             zeros(Float32, samples_per_code),
             zeros(ComplexF32, num_doppler_bins, samples_per_code),
             zeros(Float32, sign_search_max_rows, sign_search_max_cols),
-            zeros(Float32, num_doppler_bins, samples_per_code),
+            zeros(Float32, integration_buf_rows, integration_buf_cols),
             zeros(Float32, accumulator_rows, accumulator_cols),
             zeros(ComplexF32, sign_search_max_rows, sub_block_cols),
             zeros(Float32, samples_per_code),

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -18,9 +18,9 @@ struct AcquisitionScratch
     row_buf::Vector{Float32}                        # length samples_per_code
     row_shift_buf::Vector{Float32}                  # length samples_per_code
     coherent_integration_matrix::Matrix{ComplexF32}         # (num_doppler_bins, samples_per_code)
-    noncoherent_integration_max_buf::Matrix{Float32}         # (num_doppler_bins, samples_per_code)
+    noncoherent_integration_max_buf::Matrix{Float32}         # (num_doppler_bins, samples_per_code) — 0x0 when simple path is taken (see plan_acquire)
     noncoherent_integration_buf::Matrix{Float32}             # (num_doppler_bins, samples_per_code)
-    sub_block_ffts::Matrix{ComplexF32}              # (num_doppler_bins, num_data_bits)
+    sub_block_ffts::Matrix{ComplexF32}              # (num_doppler_bins, num_data_bits) — 0x0 when simple path is taken (see plan_acquire)
     col_sums_buf::Vector{Float32}                   # length samples_per_code — scratch for est_signal_noise_power
 end
 
@@ -285,6 +285,16 @@ function plan_acquire(
     fftshift_perm = [mod(r - 1 + num_doppler_bins ÷ 2, num_doppler_bins) + 1 for r in 1:num_doppler_bins]
     result_buffers = Union{Nothing,Matrix{Float32}}[nothing for _ in prns]
 
+    # The sign-search path in `_accumulate_noncoherent_integration_step!` runs only
+    # when num_data_bits > 1 OR bit_edge_search_steps > 1. Otherwise the simple
+    # (pilot) path is taken, which never reads `noncoherent_integration_max_buf` or
+    # `sub_block_ffts`. Decide here at plan time so each thread can skip those
+    # buffers when they will provably never be read.
+    sign_search_path_active = num_data_bits > 1 || bit_edge_search_steps > 1
+    sign_search_max_rows = sign_search_path_active ? num_doppler_bins  : 0
+    sign_search_max_cols = sign_search_path_active ? samples_per_code  : 0
+    sub_block_cols       = sign_search_path_active ? num_data_bits     : 0
+
     # Per-thread scratch: one entry per thread, indexed by Threads.threadid().
     # Use maxthreadid() to cover Julia's internal task-switching threads (always >= nthreads()).
     # `sig_buf` lives here so that thread 1's scratch — the ambient single-threaded
@@ -302,9 +312,9 @@ function plan_acquire(
             zeros(Float32, samples_per_code),
             zeros(Float32, samples_per_code),
             zeros(ComplexF32, num_doppler_bins, samples_per_code),
+            zeros(Float32, sign_search_max_rows, sign_search_max_cols),
             zeros(Float32, num_doppler_bins, samples_per_code),
-            zeros(Float32, num_doppler_bins, samples_per_code),
-            zeros(ComplexF32, num_doppler_bins, num_data_bits),
+            zeros(ComplexF32, sign_search_max_rows, sub_block_cols),
             zeros(Float32, samples_per_code),
         )
         for _ in 1:nthreads

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -134,10 +134,14 @@ end
     @test r2.code_phase ≈ gen2.code_phase atol = 2.0
 end
 
-@testset "_acquire_step_threaded! — threaded path runs correctly" begin
+@testset "_acquire_step_threaded! — threaded path runs correctly (multistep)" begin
+    # _acquire_step_threaded! is the per-step fan-out used by the multistep
+    # (N_nc>1) path. Driven directly from the test, with a plan sized so the
+    # per-PRN noncoherent matrices exist.
     system = GPSL1CA()
     sampling_freq = 2.048e6Hz
-    plan = plan_acquire(system, sampling_freq, [1, 2]; fft_flag = FFTW.ESTIMATE)
+    plan = plan_acquire(system, sampling_freq, [1, 2];
+        num_noncoherent_accumulations = 2, fft_flag = FFTW.ESTIMATE)
     scratch = Acquisition._default_scratch(plan)
     (; signal, code_phase) = generate_test_signal(system, 1;
         num_samples = plan.samples_per_code, sampling_freq, interm_freq = 0.0Hz, CN0 = 45)
@@ -153,6 +157,45 @@ end
     # PRN 1 should have a peak; just verify noncoherent matrix was filled
     @test maximum(plan.noncoherent_integration_matrices[1]) > 0
     @test maximum(plan.noncoherent_integration_matrices[2]) > 0
+end
+
+@testset "acquire! N_nc=1 sequential vs N_nc=2 multistep parity" begin
+    # Concatenating the same coherent segment twice and running with N_nc=2
+    # should detect the same PRN at the same code phase as a single segment at
+    # N_nc=1. CN0 differs (more integration), but doppler / code_phase / detection
+    # outcome must match — confirms the new sequential path is semantically
+    # equivalent to the multistep path on shared work.
+    system = GPSL1CA()
+    sampling_freq = 2.048e6Hz
+    prn = 1
+    code_phase_true = 100.0
+    doppler_true = 1500Hz
+    CN0_dbhz = 45
+    seed = 123
+
+    (; signal) = generate_test_signal(system, prn;
+        num_samples = 2 * 2048,                  # two full code periods
+        doppler = doppler_true, code_phase = code_phase_true,
+        sampling_freq = sampling_freq, interm_freq = 0.0Hz, CN0 = CN0_dbhz, seed = seed)
+
+    plan_seq = plan_acquire(system, sampling_freq, [prn];
+        num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 1,
+        fft_flag = FFTW.ESTIMATE)
+    plan_multi = plan_acquire(system, sampling_freq, [prn];
+        num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 2,
+        fft_flag = FFTW.ESTIMATE)
+
+    # Sequential path consumes the first segment.
+    res_seq = only(acquire!(plan_seq, ComplexF32.(signal[1:2048]), [prn]; interm_freq = 0.0Hz))
+    # Multistep path consumes both segments.
+    res_multi = only(acquire!(plan_multi, ComplexF32.(signal), [prn]; interm_freq = 0.0Hz))
+
+    @test is_detected(res_seq)
+    @test is_detected(res_multi)
+    @test abs(res_seq.code_phase   - code_phase_true) < 1.0
+    @test abs(res_multi.code_phase - code_phase_true) < 1.0
+    @test abs(res_seq.carrier_doppler   / 1Hz - ustrip(Hz, doppler_true)) < ustrip(Hz, step(plan_seq.doppler_freqs))
+    @test abs(res_multi.carrier_doppler / 1Hz - ustrip(Hz, doppler_true)) < ustrip(Hz, step(plan_multi.doppler_freqs))
 end
 
 @testset "acquire! — PRN not in plan throws ArgumentError" begin

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -138,15 +138,16 @@ end
     system = GPSL1CA()
     sampling_freq = 2.048e6Hz
     plan = plan_acquire(system, sampling_freq, [1, 2]; fft_flag = FFTW.ESTIMATE)
+    scratch = Acquisition._default_scratch(plan)
     (; signal, code_phase) = generate_test_signal(system, 1;
         num_samples = plan.samples_per_code, sampling_freq, interm_freq = 0.0Hz, CN0 = 45)
-    plan.sig_buf .= ComplexF32.(signal)
+    scratch.sig_buf .= ComplexF32.(signal)
     for prn_idx in eachindex(plan.avail_prns)
         fill!(plan.noncoherent_integration_matrices[prn_idx], 0f0)
     end
-    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, plan.sig_buf,
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, scratch.sig_buf,
         plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
     Acquisition._acquire_step_threaded!(plan, collect(plan.avail_prns), 0)
     # PRN 1 should have a peak; just verify noncoherent matrix was filled

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -279,6 +279,36 @@ end
     @test is_detected(result)
 end
 
+@testset "acquire! — fused simple-path kernel above batch threshold (num_doppler_bins > 320)" begin
+    # Forces the per-column fused kernel `_accumulate_fftshifted_power_pilot!`
+    # (the only fused-kernel path no other test hits): simple/pilot routing +
+    # num_doppler_bins > BATCH_FFT_THRESHOLD. N_coh=10 keeps num_data_bits=1
+    # (GPS L1CA bit_period_codes=20), bit_edge_search_steps=1 keeps the simple
+    # path, and a 20 kHz doppler request inflates num_blocks past 32 →
+    # num_doppler_bins = 10 × num_blocks > 320.
+    system = GPSL1CA()
+    sampling_freq = 2.048e6Hz
+    prn = 1
+
+    plan = plan_acquire(system, sampling_freq, [prn];
+        min_doppler_coverage = 20_000Hz,
+        num_coherently_integrated_code_periods = 10,
+        bit_edge_search_steps = 1,
+        fft_flag = FFTW.ESTIMATE)
+    @test plan.num_data_bits == 1
+    @test plan.bit_edge_search_steps == 1
+    @test length(plan.doppler_freqs) > Acquisition.BATCH_FFT_THRESHOLD
+
+    (; signal) = generate_test_signal(system, prn;
+        num_samples = 10 * plan.samples_per_code,
+        doppler = 1500Hz, code_phase = 100.0,
+        sampling_freq, interm_freq = 0.0Hz, CN0 = 45)
+
+    result = only(acquire!(plan, ComplexF32.(signal), [prn]; interm_freq = 0.0Hz))
+    @test is_detected(result)
+    @test abs(result.code_phase - 100.0) < 1.0
+end
+
 @testset "generate_test_signal — unit_noise_power=true scales noise to ≈1" begin
     system = GPSL1CA()
 

--- a/test/coherent_integration.jl
+++ b/test/coherent_integration.jl
@@ -8,6 +8,7 @@
 
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 5_000Hz, num_coherently_integrated_code_periods = 1)
+    scratch = Acquisition._default_scratch(plan)
     # min_doppler_coverage=5000 → span 10000 Hz → num_blocks=16, block_size=128
 
     # code_phase=991 chips → tau_samples = round((1023-991)*2048/1023) = 64 samples
@@ -24,11 +25,11 @@
     signal_f32 = ComplexF32.(signal)
     Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32,
         plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-        plan.corr_buf, plan.double_block_bfft_plan)
+        scratch.corr_buf, plan.double_block_bfft_plan)
 
     # In the full coherent integration matrix structure ALL rows peak at the same column:
     #   pc (0-indexed) = mod(num_blocks - tau÷block_size, num_blocks) * block_size + (tau%block_size)
@@ -38,7 +39,7 @@
     expected_peak_col_1 = expected_pc_1 + 1
     for code_period in 0:plan.num_coherently_integrated_code_periods-1
         row = code_period * plan.num_blocks + 1  # check row 1 per code period
-        row_vals = abs.(plan.coherent_integration_matrix[row, :])
+        row_vals = abs.(scratch.coherent_integration_matrix[row, :])
         _, peak_col = findmax(row_vals)
         @test peak_col == expected_peak_col_1
     end
@@ -54,11 +55,11 @@
     signal_f32_2 = ComplexF32.(result_2.signal)
     Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32_2,
         plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-        plan.corr_buf, plan.double_block_bfft_plan)
+        scratch.corr_buf, plan.double_block_bfft_plan)
     block_row_2 = tau_samples_2 ÷ plan.block_size
     @test block_row_2 == 1  # Verify we're testing block_row > 0 (non-trivial column block)
     scrambled_block_2    = mod(plan.num_blocks - block_row_2, plan.num_blocks)  # = 15
@@ -66,7 +67,7 @@
     expected_peak_col_2  = scrambled_col_2 + 1
     for code_period_2 in 0:plan.num_coherently_integrated_code_periods-1
         row_2 = code_period_2 * plan.num_blocks + 1
-        row_vals_2 = abs.(plan.coherent_integration_matrix[row_2, :])
+        row_vals_2 = abs.(scratch.coherent_integration_matrix[row_2, :])
         _, peak_col_2 = findmax(row_vals_2)
         @test peak_col_2 == expected_peak_col_2
     end

--- a/test/noncoherent_integration.jl
+++ b/test/noncoherent_integration.jl
@@ -1,6 +1,58 @@
 # test/noncoherent_integration.jl
 # Tests for noncoherent integration: column FFT accumulation, data bit search, code drift correction
 
+@testset "Fused FFT+|x|²+fftshift kernel matches unfused pipeline" begin
+    # The slice-5 fused kernel must produce bit-identical output to the
+    # unfused `column FFT -> |x|² -> _scatter_fftshift_accumulate!` chain it
+    # replaces. Run both on the same synthetic CIM and assert equality. The
+    # `_accumulate_fftshifted_power_pilot!` (per-column) path is otherwise
+    # unreachable from the test suite because it only fires at
+    # num_doppler_bins > BATCH_FFT_THRESHOLD with simple-path + N_nc=1,
+    # which no acquire! test currently spans.
+    Random.seed!(20260526)
+    for (num_doppler_bins, samples_per_code) in [
+        (64, 256),      # batched-path size
+        (321, 128),     # per-column-path size (one above the threshold)
+        (55, 64),       # odd num_doppler_bins (16.368 MHz / N_coh=5 maps here)
+    ]
+        cim_template = randn(ComplexF32, num_doppler_bins, samples_per_code)
+        # Pre-build an FFTW plan matching how plan_acquire would
+        col_proto = zeros(ComplexF32, num_doppler_bins)
+        col_fft_plan = plan_fft!(col_proto)
+        col_batch_fft_plan = if num_doppler_bins <= Acquisition.BATCH_FFT_THRESHOLD
+            batch_proto = zeros(ComplexF32, num_doppler_bins, samples_per_code)
+            plan_fft!(batch_proto, 1)
+        else
+            nothing
+        end
+        fftshift_perm = [mod(r - 1 + num_doppler_bins ÷ 2, num_doppler_bins) + 1
+                         for r in 1:num_doppler_bins]
+
+        # Reference: unfused pipeline on a copy of the CIM.
+        ref_acc = zeros(Float32, num_doppler_bins, samples_per_code)
+        ref_buf = zeros(Float32, num_doppler_bins, samples_per_code)
+        col_buf = zeros(ComplexF32, num_doppler_bins)
+        Acquisition._accumulate_noncoherent_integration_pilot!(ref_buf, copy(cim_template),
+            col_buf, col_fft_plan, samples_per_code)
+        Acquisition._scatter_fftshift_accumulate!(ref_acc, ref_buf, fftshift_perm, samples_per_code)
+
+        # Fused: per-column path.
+        fused_acc = zeros(Float32, num_doppler_bins, samples_per_code)
+        Acquisition._accumulate_fftshifted_power_pilot!(fused_acc, copy(cim_template),
+            zeros(ComplexF32, num_doppler_bins), col_fft_plan,
+            samples_per_code, num_doppler_bins)
+        @test fused_acc ≈ ref_acc
+
+        # Fused: batched path (only valid below the threshold).
+        if col_batch_fft_plan !== nothing
+            fused_acc_batched = zeros(Float32, num_doppler_bins, samples_per_code)
+            Acquisition._accumulate_fftshifted_power_pilot_batched!(fused_acc_batched,
+                copy(cim_template), col_batch_fft_plan, samples_per_code, num_doppler_bins)
+            @test fused_acc_batched ≈ ref_acc
+        end
+    end
+end
+
 @testset "Column FFT accumulation — Tier 2: code delay and Doppler alias check" begin
     system = GPSL1CA()
     sampling_freq = 2.048e6Hz

--- a/test/noncoherent_integration.jl
+++ b/test/noncoherent_integration.jl
@@ -12,6 +12,7 @@
     # num_coherently_integrated_code_periods=20 = one GPS data bit period (num_data_bits=1, pilot path)
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 10_000Hz, num_coherently_integrated_code_periods = 20)
+    scratch = Acquisition._default_scratch(plan)
     doppler_bin_spacing = step(plan.doppler_freqs)
     tau_samples = round(Int, (get_code_length(system) - code_phase) * plan.samples_per_code / get_code_length(system))
 
@@ -23,14 +24,14 @@
     signal_f32 = ComplexF32.(signal)
     Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32,
         plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-        plan.corr_buf, plan.double_block_bfft_plan)
+        scratch.corr_buf, plan.double_block_bfft_plan)
 
     noncoherent_integration_matrix = zeros(Float32, plan.num_coherently_integrated_code_periods * plan.num_blocks, plan.samples_per_code)
-    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_matrix, plan.coherent_integration_matrix, plan.col_buf,
+    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_matrix, scratch.coherent_integration_matrix, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
 
     peak_row, peak_col = Tuple(argmax(noncoherent_integration_matrix))
@@ -57,7 +58,7 @@
 
     # 3. Verify += accumulation: a second call should double the peak value.
     peak_value_first = noncoherent_integration_matrix[peak_row, peak_col]
-    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_matrix, plan.coherent_integration_matrix, plan.col_buf,
+    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_matrix, scratch.coherent_integration_matrix, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
     @test noncoherent_integration_matrix[peak_row, peak_col] ≈ 2 * peak_value_first
 end
@@ -71,6 +72,7 @@ end
     # num_coherently_integrated_code_periods=40 → num_data_bits=2 (two GPS data bit periods)
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 10_000Hz, num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 1, num_noncoherent_accumulations = 1)
+    scratch = Acquisition._default_scratch(plan)
     num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks  # 640
 
     code_phase = 100.0
@@ -84,16 +86,16 @@ end
     signal_f32 = ComplexF32.(signal)
     Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32,
         plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-        plan.corr_buf, plan.double_block_bfft_plan)
+        scratch.corr_buf, plan.double_block_bfft_plan)
 
     noncoherent_integration_matrix = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     noncoherent_integration_buf = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
-    Acquisition._accumulate_noncoherent_integration_data_bits!(noncoherent_integration_buf, plan.coherent_integration_matrix, plan.col_buf, plan.col_fftshift_buf,
+    Acquisition._accumulate_noncoherent_integration_data_bits!(noncoherent_integration_buf, scratch.coherent_integration_matrix, scratch.col_buf, scratch.col_fftshift_buf,
         plan.col_fft_plan, plan.samples_per_code, num_doppler_bins, plan.num_data_bits, 0, sub_block_ffts)
     noncoherent_integration_matrix .+= noncoherent_integration_buf
 
@@ -124,6 +126,7 @@ end
 
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 10_000Hz, num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 1, num_noncoherent_accumulations = 1)
+    scratch = Acquisition._default_scratch(plan)
     num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks  # 640
 
     # Generate a clean signal, then negate the second half to simulate a bit
@@ -140,20 +143,20 @@ end
 
     Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_flipped,
         plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-        plan.corr_buf, plan.double_block_bfft_plan)
+        scratch.corr_buf, plan.double_block_bfft_plan)
 
     noncoherent_integration_data = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
-    Acquisition._accumulate_noncoherent_integration_data_bits!(noncoherent_integration_data, plan.coherent_integration_matrix, plan.col_buf, plan.col_fftshift_buf,
+    Acquisition._accumulate_noncoherent_integration_data_bits!(noncoherent_integration_data, scratch.coherent_integration_matrix, scratch.col_buf, scratch.col_fftshift_buf,
         plan.col_fft_plan, plan.samples_per_code, num_doppler_bins, plan.num_data_bits, 0, sub_block_ffts)
 
     # Pilot path: no bit search → the two halves cancel → weaker peak
     noncoherent_integration_pilot = zeros(Float32, num_doppler_bins, plan.samples_per_code)
-    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_pilot, plan.coherent_integration_matrix, plan.col_buf,
+    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_pilot, scratch.coherent_integration_matrix, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
 
     # Data bit search should recover a much stronger peak than naive pilot
@@ -190,16 +193,17 @@ end
     alias_period = plan_no_search.sampling_freq / plan_no_search.samples_per_code  # 1000 Hz
 
     for plan in (plan_no_search, plan_with_search)
+        scratch = Acquisition._default_scratch(plan)
         num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks
         Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32,
             plan.samples_per_code, plan.num_blocks, plan.block_size,
-            plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+            plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
             plan.double_block_fft_plan)
-        Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+        Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
             plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-            plan.corr_buf, plan.double_block_bfft_plan)
+            scratch.corr_buf, plan.double_block_bfft_plan)
         noncoherent_integration_matrix = zeros(Float32, num_doppler_bins, plan.samples_per_code)
-        Acquisition._accumulate_noncoherent_integration_step!(noncoherent_integration_matrix, plan.coherent_integration_matrix, plan, 0)
+        Acquisition._accumulate_noncoherent_integration_step!(noncoherent_integration_matrix, scratch.coherent_integration_matrix, plan, 0)
 
         peak_row, _ = Tuple(argmax(noncoherent_integration_matrix))
         detected_doppler = plan.doppler_freqs[peak_row]
@@ -328,34 +332,35 @@ end
 
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 10_000Hz, num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 1, num_noncoherent_accumulations = 1)
+    scratch = Acquisition._default_scratch(plan)
     num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks
 
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
 
     Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, ComplexF32.(signal_no_transition),
         plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts,
+    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.corr_buf,
+        plan.num_coherently_integrated_code_periods, scratch.corr_buf,
         plan.double_block_bfft_plan)
     noncoherent_integration_no_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
-    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_no_transition, plan.coherent_integration_matrix, plan.col_buf,
+    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_no_transition, scratch.coherent_integration_matrix, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
     peak_no_transition = maximum(noncoherent_integration_no_transition)
 
     Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, ComplexF32.(signal_with_transition),
         plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts,
+    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.corr_buf,
+        plan.num_coherently_integrated_code_periods, scratch.corr_buf,
         plan.double_block_bfft_plan)
     noncoherent_integration_with_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
-    Acquisition._accumulate_noncoherent_integration_data_bits!(noncoherent_integration_with_transition, plan.coherent_integration_matrix, plan.col_buf,
-        plan.col_fftshift_buf, plan.col_fft_plan, plan.samples_per_code, num_doppler_bins,
+    Acquisition._accumulate_noncoherent_integration_data_bits!(noncoherent_integration_with_transition, scratch.coherent_integration_matrix, scratch.col_buf,
+        scratch.col_fftshift_buf, plan.col_fft_plan, plan.samples_per_code, num_doppler_bins,
         plan.num_data_bits, 0, sub_block_ffts)
     peak_with_transition = maximum(noncoherent_integration_with_transition)
 
@@ -376,34 +381,35 @@ end
 
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 10_000Hz, num_coherently_integrated_code_periods = 60, bit_edge_search_steps = 1, num_noncoherent_accumulations = 1)
+    scratch = Acquisition._default_scratch(plan)
     num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks
 
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
 
     Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, ComplexF32.(signal_no_transition),
         plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts,
+    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.corr_buf,
+        plan.num_coherently_integrated_code_periods, scratch.corr_buf,
         plan.double_block_bfft_plan)
     noncoherent_integration_no_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
-    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_no_transition, plan.coherent_integration_matrix, plan.col_buf,
+    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_no_transition, scratch.coherent_integration_matrix, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
     peak_no_transition = maximum(noncoherent_integration_no_transition)
 
     Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, ComplexF32.(signal_with_transition),
         plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.double_block_buf,
+        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(plan.coherent_integration_matrix, plan.signal_block_ffts,
+    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, plan.corr_buf,
+        plan.num_coherently_integrated_code_periods, scratch.corr_buf,
         plan.double_block_bfft_plan)
     noncoherent_integration_with_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
-    Acquisition._accumulate_noncoherent_integration_data_bits!(noncoherent_integration_with_transition, plan.coherent_integration_matrix, plan.col_buf,
-        plan.col_fftshift_buf, plan.col_fft_plan, plan.samples_per_code, num_doppler_bins,
+    Acquisition._accumulate_noncoherent_integration_data_bits!(noncoherent_integration_with_transition, scratch.coherent_integration_matrix, scratch.col_buf,
+        scratch.col_fftshift_buf, plan.col_fft_plan, plan.samples_per_code, num_doppler_bins,
         plan.num_data_bits, 0, sub_block_ffts)
     peak_with_transition = maximum(noncoherent_integration_with_transition)
 

--- a/test/noncoherent_integration.jl
+++ b/test/noncoherent_integration.jl
@@ -192,21 +192,13 @@ end
 
     alias_period = plan_no_search.sampling_freq / plan_no_search.samples_per_code  # 1000 Hz
 
+    # Drive each plan end-to-end through acquire! and verify the detected
+    # Doppler is a valid alias of the true Doppler. The simple-path N_nc=1
+    # plan now goes through the fused FFT+|x|²+fftshift kernel, so we can't
+    # poke at the unfused noncoherent matrix directly the way we used to.
     for plan in (plan_no_search, plan_with_search)
-        scratch = Acquisition._default_scratch(plan)
-        num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks
-        Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, signal_f32,
-            plan.samples_per_code, plan.num_blocks, plan.block_size,
-            plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
-            plan.double_block_fft_plan)
-        Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
-            plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
-            scratch.corr_buf, plan.double_block_bfft_plan)
-        noncoherent_integration_matrix = zeros(Float32, num_doppler_bins, plan.samples_per_code)
-        Acquisition._accumulate_noncoherent_integration_step!(noncoherent_integration_matrix, scratch.coherent_integration_matrix, plan, 0)
-
-        peak_row, _ = Tuple(argmax(noncoherent_integration_matrix))
-        detected_doppler = plan.doppler_freqs[peak_row]
+        result = only(acquire!(plan, signal_f32, [prn]; interm_freq = 0.0Hz))
+        detected_doppler = result.carrier_doppler
         doppler_bin_spacing = step(plan.doppler_freqs)
         # FM-DBZP alias ambiguity: check detected Doppler is a valid alias
         diff = mod((detected_doppler - true_doppler) / (1Hz), alias_period / (1Hz))

--- a/test/plan.jl
+++ b/test/plan.jl
@@ -166,3 +166,32 @@ end
         @test hasfield(typeof(scratch), f)
     end
 end
+
+@testset "result_buffers are lazy — nothing unless store_power_bins=true" begin
+    # Default acquire! (store_power_bins=false) must not allocate any per-PRN
+    # result matrix. Only when the caller opts in does the slot fill in, and once
+    # filled it stays cached for the next call (reuse contract).
+    system = GPSL1CA()
+    sampling_freq = 2.048e6Hz
+    plan = plan_acquire(system, sampling_freq, [1, 2]; fft_flag = FFTW.ESTIMATE)
+    @test all(b -> b === nothing, plan.result_buffers)
+
+    (; signal) = generate_test_signal(system, 1;
+        num_samples = plan.samples_per_code, sampling_freq = sampling_freq,
+        interm_freq = 0.0Hz, CN0 = 45)
+    sig = ComplexF32.(signal)
+
+    # store_power_bins=false leaves the slots empty.
+    acquire!(plan, sig, [1, 2]; interm_freq = 0.0Hz, store_power_bins = false)
+    @test all(b -> b === nothing, plan.result_buffers)
+
+    # First store_power_bins=true call allocates and caches.
+    results = acquire!(plan, sig, [1, 2]; interm_freq = 0.0Hz, store_power_bins = true)
+    @test all(b -> b isa Matrix{Float32}, plan.result_buffers)
+    @test results[1].power_bins === plan.result_buffers[1]
+
+    # Reuse contract: the second call must reuse the same buffer object.
+    cached = plan.result_buffers[1]
+    acquire!(plan, sig, [1, 2]; interm_freq = 0.0Hz, store_power_bins = true)
+    @test plan.result_buffers[1] === cached
+end

--- a/test/plan.jl
+++ b/test/plan.jl
@@ -133,3 +133,36 @@ end
         end
     end
 end
+
+@testset "plan_acquire does not hold plan-level scratch duplicates" begin
+    # Regression-lock: AcquisitionScratch owns all per-thread scratch buffers.
+    # Any field re-added to AcquisitionPlan that duplicates an AcquisitionScratch
+    # field re-introduces the per-plan RAM waste #60 removed.
+    plan = plan_acquire(GPSL1CA(), 2.048e6Hz, [1];
+        num_coherently_integrated_code_periods = 1)
+    duplicated_fields = (
+        :coherent_integration_matrix,
+        :noncoherent_integration_max_buf,
+        :noncoherent_integration_buf,
+        :sub_block_ffts,
+        :col_buf,
+        :col_fftshift_buf,
+        :row_buf,
+        :row_shift_buf,
+        :double_block_buf,
+        :corr_buf,
+        :sig_buf,
+        :col_sums_buf,
+    )
+    for f in duplicated_fields
+        @test !hasfield(typeof(plan), f)
+    end
+
+    # _default_scratch names the "thread 1 is the ambient scratch" convention.
+    scratch = Acquisition._default_scratch(plan)
+    @test scratch === plan.thread_scratch[1]
+    @test scratch isa Acquisition.AcquisitionScratch
+    for f in duplicated_fields
+        @test hasfield(typeof(scratch), f)
+    end
+end

--- a/test/plan.jl
+++ b/test/plan.jl
@@ -229,6 +229,37 @@ end
         (length(search_plan.doppler_freqs), search_plan.num_data_bits)
 end
 
+@testset "noncoherent_integration_buf is 0x0 when fused FFT+abs2+fftshift kernel runs" begin
+    # At N_nc==1 with the simple/pilot path, the fused kernel writes |FFT|²
+    # straight into the accumulator with fftshift permutation and never touches
+    # `noncoherent_integration_buf`. The buf can be dropped per-thread; sign-search
+    # path and multistep (N_nc>1) still need it full-sized.
+    system = GPSL1CA()
+    sampling_freq = 2.048e6Hz
+
+    fused_plan = plan_acquire(system, sampling_freq, [1];
+        num_coherently_integrated_code_periods = 1, bit_edge_search_steps = 1,
+        num_noncoherent_accumulations = 1)
+    fused_scratch = Acquisition._default_scratch(fused_plan)
+    @test size(fused_scratch.noncoherent_integration_buf) == (0, 0)
+    for t_scratch in fused_plan.thread_scratch
+        @test size(t_scratch.noncoherent_integration_buf) == (0, 0)
+    end
+
+    # Sign-search at N_nc=1 still needs the buf.
+    sign_search_plan = plan_acquire(system, sampling_freq, [1];
+        min_doppler_coverage = 10_000Hz,
+        num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 4)
+    @test size(Acquisition._default_scratch(sign_search_plan).noncoherent_integration_buf) ==
+        (length(sign_search_plan.doppler_freqs), sign_search_plan.samples_per_code)
+
+    # Multistep (N_nc>1) needs the buf too, even on the simple path.
+    multi_plan = plan_acquire(system, sampling_freq, [1];
+        num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 2)
+    @test size(Acquisition._default_scratch(multi_plan).noncoherent_integration_buf) ==
+        (length(multi_plan.doppler_freqs), multi_plan.samples_per_code)
+end
+
 @testset "sequential N_nc=1 layout: empty per-PRN matrices, full per-thread accumulator" begin
     # When num_noncoherent_accumulations == 1 the per-PRN noncoherent matrices
     # collapse into a single per-thread accumulator reused across PRNs. Layout

--- a/test/plan.jl
+++ b/test/plan.jl
@@ -228,3 +228,33 @@ end
     @test size(search_scratch.sub_block_ffts) ==
         (length(search_plan.doppler_freqs), search_plan.num_data_bits)
 end
+
+@testset "sequential N_nc=1 layout: empty per-PRN matrices, full per-thread accumulator" begin
+    # When num_noncoherent_accumulations == 1 the per-PRN noncoherent matrices
+    # collapse into a single per-thread accumulator reused across PRNs. Layout
+    # should be: empty Vector{Matrix{Float32}} on the plan, full-sized
+    # accumulator per thread.
+    system = GPSL1CA()
+    sampling_freq = 2.048e6Hz
+    prns = collect(1:4)
+
+    seq_plan = plan_acquire(system, sampling_freq, prns;
+        num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 1)
+    seq_scratch = Acquisition._default_scratch(seq_plan)
+    @test length(seq_plan.noncoherent_integration_matrices) == 0
+    expected = (length(seq_plan.doppler_freqs), seq_plan.samples_per_code)
+    @test size(seq_scratch.noncoherent_integration_accumulator) == expected
+    for t_scratch in seq_plan.thread_scratch
+        @test size(t_scratch.noncoherent_integration_accumulator) == expected
+    end
+
+    # N_nc>1 path keeps the per-PRN matrices and uses no accumulator.
+    multi_plan = plan_acquire(system, sampling_freq, prns;
+        num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 2)
+    multi_scratch = Acquisition._default_scratch(multi_plan)
+    @test length(multi_plan.noncoherent_integration_matrices) == length(prns)
+    for nim in multi_plan.noncoherent_integration_matrices
+        @test size(nim) == (length(multi_plan.doppler_freqs), multi_plan.samples_per_code)
+    end
+    @test size(multi_scratch.noncoherent_integration_accumulator) == (0, 0)
+end

--- a/test/plan.jl
+++ b/test/plan.jl
@@ -195,3 +195,36 @@ end
     acquire!(plan, sig, [1, 2]; interm_freq = 0.0Hz, store_power_bins = true)
     @test plan.result_buffers[1] === cached
 end
+
+@testset "sign-search scratch is 0x0 when the simple path is provably taken" begin
+    # The router in _accumulate_noncoherent_integration_step! takes the simple/pilot
+    # path when num_data_bits == 1 && bit_edge_search_steps == 1. In that regime
+    # noncoherent_integration_max_buf and sub_block_ffts are never read, so the
+    # plan should allocate them as 0x0 sentinels per thread.
+    system = GPSL1CA()
+    sampling_freq = 2.048e6Hz
+
+    simple_plan = plan_acquire(system, sampling_freq, [1];
+        num_coherently_integrated_code_periods = 1, bit_edge_search_steps = 1)
+    simple_scratch = Acquisition._default_scratch(simple_plan)
+    @test simple_plan.num_data_bits == 1
+    @test simple_plan.bit_edge_search_steps == 1
+    @test size(simple_scratch.noncoherent_integration_max_buf) == (0, 0)
+    @test size(simple_scratch.sub_block_ffts) == (0, 0)
+    # And every thread's slot matches — not just thread 1.
+    for t_scratch in simple_plan.thread_scratch
+        @test size(t_scratch.noncoherent_integration_max_buf) == (0, 0)
+        @test size(t_scratch.sub_block_ffts) == (0, 0)
+    end
+
+    # Sign-search path: bit_edge_search_steps > 1 makes the kernel actually read
+    # these buffers, so they must be full-sized.
+    search_plan = plan_acquire(system, sampling_freq, [1];
+        min_doppler_coverage = 10_000Hz,
+        num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 4)
+    search_scratch = Acquisition._default_scratch(search_plan)
+    expected = (length(search_plan.doppler_freqs), search_plan.samples_per_code)
+    @test size(search_scratch.noncoherent_integration_max_buf) == expected
+    @test size(search_scratch.sub_block_ffts) ==
+        (length(search_plan.doppler_freqs), search_plan.num_data_bits)
+end


### PR DESCRIPTION
## Summary

Closes the implementation slices of #60 (RAM reduction of `plan_acquire` for 32-PRN acquisition on L1C-P / L5I). Five conventional commits, each independently revertible. Bench [PR #61](https://github.com/JuliaGNSS/Acquisition.jl/pull/61) (slice 0) shipped earlier and is the harness this PR's before/after numbers are diffed against.

Single-thread, 4 PRNs, `min_doppler_coverage=2000Hz` (the bench config from #61, sized to fit CI):

| signal       | `plan_acquire` mem      | `acquire!` (min)         |
|--------------|-------------------------|--------------------------|
| L1C-P 16 MHz | 572.5 → **174.4** MiB (-70%) | 432 → **311** ms (-28%)  |
| E1B  15 MHz  |  91.4 →  **31.4** MiB (-66%) |  46 →  **34** ms (-26%)  |
| L5I  25 MHz  |  25.8 →  **15.6** MiB (-40%) | 8.1 →  **6.6** ms (-19%) |
| L1CA  5 MHz  |   3.6 →   **1.5** MiB (-58%) | 1.25 → **1.06** ms (-15%) |

`acquire!` still reports 0 allocations across all four signals. Multi-thread savings scale per-thread on top of these numbers (the per-thread scratch entries each drop in size).

## Slices

1. **`4088b84` `refactor:`** — drop 11 plan-level fields that duplicated `AcquisitionScratch` entries; introduce `_default_scratch(plan)` to name the "thread 1 is the ambient single-threaded scratch" convention.
2. **`67d0e93` `perf:`** — `result_buffers` becomes `Vector{Union{Nothing,Matrix{Float32}}}`, allocated on the first `store_power_bins=true` call per PRN.
3. **`1144f72` `perf:`** — when `num_data_bits == 1 && bit_edge_search_steps == 1`, allocate `noncoherent_integration_max_buf` and `sub_block_ffts` as 0×0 sentinels per thread (the sign-search kernel is provably unreachable).
4. **`dd861e6` `perf:`** — at `num_noncoherent_accumulations == 1`, dispatch into a new fused per-PRN path that runs build_CIM → accumulate → extract against a single per-thread `noncoherent_integration_accumulator`, instead of holding 32 noncoherent matrices simultaneously. Multistep path is left untouched.
5. **`bdb2970` `perf:`** — fuse `|FFT|² + fftshift` directly into the accumulator on the N_nc=1 simple path. Drops the `noncoherent_integration_buf` intermediate to 0×0 in that configuration and saves a full read+write of memory traffic per PRN. (Listed as OOS in the PRD on speed-regression grounds; empirically the opposite — see commit body.)

## Tests

- 198 FM-DBZP tests pass (up from 166 pre-slice-1) under `claude_scratch/run_fmdbzp_tests.jl -t 1`.
- Every slice ships a regression-lock testset in `test/plan.jl`:
  - dropped plan-level duplicates stay dropped,
  - `result_buffers` are `nothing` by default,
  - sign-search bufs are 0×0 on the simple path,
  - sequential N_nc=1 layout (empty per-PRN matrices + full per-thread accumulator),
  - `noncoherent_integration_buf` is 0×0 only when the fused kernel runs.
- `test/acquire.jl` adds an N_nc=1 sequential vs N_nc=2 multistep parity test (same code phase / doppler detected on both paths).
- `_acquire_step_threaded!`'s direct-call test was updated to use `N_nc=2` (the threaded fan-out is only reached on the multistep path now).
- One test in `test/noncoherent_integration.jl` that drove the unfused kernel directly on a simple-path-N_nc=1 plan now goes end-to-end through `acquire!` (the unfused kernel's simple-path branch is no longer reachable from `acquire!` under that config).

## Follow-up

- #62 — extend the slice-5 fusion to the multistep simple path (N_nc>1). Zero benefit for the L1C-P / L5I targets in #60 (both N_nc=1) but helps the CFAR M=8 detection workload and any future multi-second noncoherent integration runs.

## Test plan

- [x] `julia --project="." --startup-file=no -t 1 claude_scratch/run_fmdbzp_tests.jl` → 198/198 FM-DBZP pass
- [x] `julia --project="." --startup-file=no -t 1 claude_scratch/bench_slice1.jl` shows the RAM table above and 0 allocations on `acquire!`
- [ ] Reviewer: re-run with `julia -t 16` to confirm the per-thread savings actually multiply (predicted in `docs/plans/2026-05-25-acquisition-ram-v2.md`)
- [ ] Reviewer: spot-check a 32-PRN call on L1C-P fits inside expected RAM budget end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)