### PR TITLE
perf: fuse multistep simple-path drift kernel (closes #62)

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -279,4 +279,25 @@ if _is_fmdbzp
         SUITE["AcquireSignals"][label] =
             @benchmarkable acquire!($plan, $signal, $bench_prns; interm_freq = 0.0Hz)
     end
+
+    # Multistep simple path — exercises the fused FFT+|x|²+code-drift+fftshift
+    # kernel (Issue #62) over N_nc accumulation steps. L1CA at 5 MHz with
+    # N_coh=1, N_nc=8 is the canonical simple-path noncoherent workload; the
+    # entry is here so RAM/runtime diffs around the multistep fusion land in a
+    # stable AirSpeedVelocity series.
+    let
+        fs = 5.0e6Hz
+        label = "L1CA_5MHz_Nnc8"
+        N_nc = 8
+        plan = plan_acquire(GNSSSignals.GPSL1CA(), fs, bench_prns;
+            min_doppler_coverage = bench_min_doppler,
+            num_noncoherent_accumulations = N_nc)
+        signal = _make_signal(plan, N_nc)
+        SUITE["AcquireSignals"][label] =
+            @benchmarkable acquire!($plan, $signal, $bench_prns; interm_freq = 0.0Hz)
+        SUITE["PlanAcquire"][label] =
+            @benchmarkable plan_acquire(GNSSSignals.GPSL1CA(), $fs, $bench_prns;
+                min_doppler_coverage = $bench_min_doppler,
+                num_noncoherent_accumulations = $N_nc)
+    end
 end

--- a/src/noncoherent_integration.jl
+++ b/src/noncoherent_integration.jl
@@ -167,6 +167,90 @@ function _accumulate_fftshifted_power_pilot_batched!(
     end
 end
 
+# Per-column FFT followed by `|x|²` accumulation with per-row code-drift column
+# shift AND fftshift row permutation, folded into one pass. Extends the slice-5
+# fusion (`_accumulate_fftshifted_power_pilot!`) to the multistep simple path
+# (Issue #62): drops the `noncoherent_integration_buf` intermediate that the
+# unfused pipeline (`pilot! → _apply_code_drift! → _scatter_fftshift_accumulate!`)
+# materialises and traverses twice per step.
+#
+# `code_drift_shifts[r]` is the row-r column shift, pre-normalised to
+# `[0, samples_per_code)` by `_fill_code_drift_shifts!`. That lets the inner
+# loop replace `mod(c-1+shift_r, spc)+1` with a single conditional subtract.
+# The caller must dispatch to the non-drift slice-5 kernel when every row's
+# drift rounds to 0 (step 0, or any step whose rounded drift is zero — at the
+# L1CA / 5 MHz / N_coh=1 grid that's true for every step up to N_nc≈8, so the
+# early-exit covers the dominant simple-path case).
+function _accumulate_fftshifted_power_drift_pilot!(
+    accumulator::Matrix{Float32},
+    coherent_integration_matrix::Matrix{ComplexF32},
+    col_buf::Vector{ComplexF32},
+    col_fft_plan,
+    samples_per_code::Int,
+    num_doppler_bins::Int,
+    fftshift_perm::Vector{Int},
+    code_drift_shifts::Vector{Int},
+)
+    @inbounds for col_idx in 1:samples_per_code
+        copyto!(col_buf, 1, coherent_integration_matrix, (col_idx - 1) * num_doppler_bins + 1, num_doppler_bins)
+        mul!(col_buf, col_fft_plan, col_buf)
+        c_minus_1 = col_idx - 1
+        for r in 1:num_doppler_bins
+            sum = c_minus_1 + code_drift_shifts[r]
+            dst_col = (sum >= samples_per_code ? sum - samples_per_code : sum) + 1
+            accumulator[fftshift_perm[r], dst_col] += abs2(col_buf[r])
+        end
+    end
+end
+
+# Batched-FFT counterpart of `_accumulate_fftshifted_power_drift_pilot!`.
+function _accumulate_fftshifted_power_drift_pilot_batched!(
+    accumulator::Matrix{Float32},
+    coherent_integration_matrix::Matrix{ComplexF32},
+    col_batch_fft_plan,
+    samples_per_code::Int,
+    num_doppler_bins::Int,
+    fftshift_perm::Vector{Int},
+    code_drift_shifts::Vector{Int},
+)
+    mul!(coherent_integration_matrix, col_batch_fft_plan, coherent_integration_matrix)
+    @inbounds for col_idx in 1:samples_per_code
+        c_minus_1 = col_idx - 1
+        for r in 1:num_doppler_bins
+            sum = c_minus_1 + code_drift_shifts[r]
+            dst_col = (sum >= samples_per_code ? sum - samples_per_code : sum) + 1
+            accumulator[fftshift_perm[r], dst_col] += abs2(coherent_integration_matrix[r, col_idx])
+        end
+    end
+end
+
+# Fill `shifts[r]` with the row-r column shift from `_apply_code_drift!`,
+# normalised to `[0, samples_per_code)` so the hot loop in the fused kernel
+# can drop `mod` for a single conditional subtract. Returns `true` if any
+# shift rounded to non-zero (caller dispatches to the fused-drift kernel) or
+# `false` if every row's drift rounds to 0 (caller uses the cheaper non-drift
+# slice-5 kernel — the typical case at low-fs / short-T_coh grids).
+function _fill_code_drift_shifts!(shifts::Vector{Int}, plan::AcquisitionPlan, accumulation_step_index::Int)
+    if accumulation_step_index == 0
+        fill!(shifts, 0)
+        return false
+    end
+    sampling_freq_hz = ustrip(Hz, plan.sampling_freq)
+    carrier_freq_hz = ustrip(Hz, get_center_frequency(plan.system))
+    coherent_duration_s = plan.num_coherently_integrated_code_periods * plan.samples_per_code / sampling_freq_hz
+    samples_per_code = plan.samples_per_code
+    has_drift = false
+    @inbounds for r in 1:length(shifts)
+        doppler_hz = ustrip(Hz, plan.doppler_freqs[r])
+        raw = round(Int, doppler_hz * accumulation_step_index * coherent_duration_s * sampling_freq_hz / carrier_freq_hz)
+        if raw != 0
+            has_drift = true
+        end
+        shifts[r] = mod(raw, samples_per_code)
+    end
+    return has_drift
+end
+
 # Scatter `src` into `dst` applying fftshift row permutation (accumulating).
 # For even num_doppler_bins — the only case in practice — this is a top/bottom
 # half swap, which SIMDs. For odd N, fall back to the indexed scatter (the
@@ -217,30 +301,43 @@ function _accumulate_noncoherent_integration_step!(
     accumulation_step_index::Int,
 )
     num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks
-    noncoherent_integration_max_buf = scratch.noncoherent_integration_max_buf
-    noncoherent_integration_buf = scratch.noncoherent_integration_buf
 
     if plan.num_data_bits == 1 && plan.bit_edge_search_steps == 1
-        # Pilot channel or no bit edge search requested: fast path
-        fill!(noncoherent_integration_buf, 0.0f0)
-        if num_doppler_bins <= BATCH_FFT_THRESHOLD
-            # Batched column FFT: FFT all columns at once along dim 1 (in-place on CIM).
-            # Faster than individual column FFTs when num_doppler_bins is small because
-            # it amortises FFTW plan-dispatch overhead across all columns.
-            mul!(coherent_integration_matrix, plan.col_batch_fft_plan, coherent_integration_matrix)
-            @inbounds for col_idx in 1:plan.samples_per_code
-                for doppler_bin in 1:num_doppler_bins
-                    noncoherent_integration_buf[doppler_bin, col_idx] += abs2(coherent_integration_matrix[doppler_bin, col_idx])
-                end
+        # Simple/pilot path: fused FFT+|x|²+(code-drift)+fftshift kernel writes
+        # straight into `noncoherent_integration_matrix`. The drift kernel is
+        # taken only when at least one row's rounded drift is non-zero — at
+        # step 0, and at every step where the rounded drift is 0 for all rows
+        # (typical for short coherent durations / small doppler grids), the
+        # cheaper SIMD-friendly slice-5 non-drift kernel runs instead.
+        has_drift = _fill_code_drift_shifts!(scratch.code_drift_shifts, plan, accumulation_step_index)
+        if !has_drift
+            if num_doppler_bins <= BATCH_FFT_THRESHOLD
+                _accumulate_fftshifted_power_pilot_batched!(
+                    noncoherent_integration_matrix, coherent_integration_matrix,
+                    plan.col_batch_fft_plan, plan.samples_per_code, num_doppler_bins)
+            else
+                _accumulate_fftshifted_power_pilot!(
+                    noncoherent_integration_matrix, coherent_integration_matrix,
+                    scratch.col_buf, plan.col_fft_plan,
+                    plan.samples_per_code, num_doppler_bins)
             end
         else
-            # Individual column FFTs: better cache utilisation for large num_doppler_bins.
-            _accumulate_noncoherent_integration_pilot!(noncoherent_integration_buf, coherent_integration_matrix, scratch.col_buf,
-                plan.col_fft_plan, plan.samples_per_code)
+            if num_doppler_bins <= BATCH_FFT_THRESHOLD
+                _accumulate_fftshifted_power_drift_pilot_batched!(
+                    noncoherent_integration_matrix, coherent_integration_matrix,
+                    plan.col_batch_fft_plan, plan.samples_per_code, num_doppler_bins,
+                    plan.fftshift_perm, scratch.code_drift_shifts)
+            else
+                _accumulate_fftshifted_power_drift_pilot!(
+                    noncoherent_integration_matrix, coherent_integration_matrix,
+                    scratch.col_buf, plan.col_fft_plan,
+                    plan.samples_per_code, num_doppler_bins,
+                    plan.fftshift_perm, scratch.code_drift_shifts)
+            end
         end
-        _apply_code_drift!(noncoherent_integration_buf, plan, scratch, accumulation_step_index)
-        _scatter_fftshift_accumulate!(noncoherent_integration_matrix, noncoherent_integration_buf, plan.fftshift_perm, plan.samples_per_code)
     else
+        noncoherent_integration_max_buf = scratch.noncoherent_integration_max_buf
+        noncoherent_integration_buf = scratch.noncoherent_integration_buf
         # Data channel or sub-bit with bit edge search: iterate over bit_edge_search_steps candidate
         # alignments. For sub-bit (num_data_bits==1), only one bit sign pattern exists so
         # _accumulate_noncoherent_integration_data_bits! just picks the best-aligned window. For multi-bit

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -27,6 +27,10 @@ struct AcquisitionScratch
     noncoherent_integration_accumulator::Matrix{Float32}
     sub_block_ffts::Matrix{ComplexF32}              # (num_doppler_bins, num_data_bits) — 0x0 when simple path is taken (see plan_acquire)
     col_sums_buf::Vector{Float32}                   # length samples_per_code — scratch for est_signal_noise_power
+    # Row-wise code-drift shifts pre-filled per accumulation step on the
+    # multistep simple path. length num_doppler_bins when that path is active;
+    # 0 otherwise (sequential N_nc=1 path and sign-search path don't use it).
+    code_drift_shifts::Vector{Int}
 end
 
 """
@@ -310,13 +314,21 @@ function plan_acquire(
     sign_search_max_cols = sign_search_path_active ? samples_per_code  : 0
     sub_block_cols       = sign_search_path_active ? num_data_bits     : 0
 
-    # `noncoherent_integration_buf` (the |x|² intermediate) is bypassed when the
-    # fused FFT+|x|²+fftshift kernel runs (sequential N_nc==1 + simple path).
-    # Sign-search-at-N_nc==1 and any multistep path still consume the buf, so
-    # we only allocate it when at least one of those routes can fire.
-    integration_buf_needed = sign_search_path_active || !sequential_prn_mode
+    # `noncoherent_integration_buf` (the |x|² intermediate) is bypassed by the
+    # fused FFT+|x|²+(code-drift)+fftshift kernel on every simple-path route:
+    # sequential N_nc==1 (slice 5) and multistep N_nc>1 (Issue #62). Only the
+    # sign-search path still consumes the buf — it reuses the buf across
+    # bit-edge-search alignments to take the cell-wise max.
+    integration_buf_needed = sign_search_path_active
     integration_buf_rows = integration_buf_needed ? num_doppler_bins : 0
     integration_buf_cols = integration_buf_needed ? samples_per_code : 0
+
+    # Multistep simple path uses `code_drift_shifts` (length num_doppler_bins)
+    # to precompute the per-row column shift once per accumulation step before
+    # the per-PRN parallel loop. Sequential N_nc=1 doesn't drift; sign-search
+    # uses the unfused `_apply_code_drift!` on the buf directly.
+    multistep_simple_path_active = !sequential_prn_mode && !sign_search_path_active
+    code_drift_shifts_len = multistep_simple_path_active ? num_doppler_bins : 0
 
     # Per-thread scratch: one entry per thread, indexed by Threads.threadid().
     # Use maxthreadid() to cover Julia's internal task-switching threads (always >= nthreads()).
@@ -340,6 +352,7 @@ function plan_acquire(
             zeros(Float32, accumulator_rows, accumulator_cols),
             zeros(ComplexF32, sign_search_max_rows, sub_block_cols),
             zeros(Float32, samples_per_code),
+            zeros(Int, code_drift_shifts_len),
         )
         for _ in 1:nthreads
     ]

--- a/test/noncoherent_integration.jl
+++ b/test/noncoherent_integration.jl
@@ -1,6 +1,149 @@
 # test/noncoherent_integration.jl
 # Tests for noncoherent integration: column FFT accumulation, data bit search, code drift correction
 
+@testset "Fused FFT+|x|²+code-drift+fftshift kernel matches unfused pipeline" begin
+    # Issue #62: extends the slice-5 fusion to the multistep simple path by
+    # folding `_apply_code_drift!` into the per-column accumulator loop. Each
+    # row r writes its (c) cell into nim[fftshift_perm[r], (c + shift_r) mod spc]
+    # where shift_r is the existing _apply_code_drift! formula (which reads
+    # plan.doppler_freqs[r] — we mirror that exact behaviour, including the
+    # raw-FFT-bin vs sorted-doppler indexing convention, for bitwise parity).
+    Random.seed!(20260526)
+    sampling_freq_hz_test = 5.0e6
+    carrier_freq_hz_test = 1.57542e9  # GPS L1
+    for (num_doppler_bins, samples_per_code, accumulation_step) in [
+        (64, 256, 5),       # batched-path size, non-zero step
+        (321, 128, 3),      # per-column-path size (one above the threshold)
+        (8, 5000, 7),       # L1CA 5MHz / N_coh=1 / N_nc=8 (the canonical issue-62 case)
+        (32, 2048, 0),      # step 0: drift must be a no-op
+    ]
+        cim_template = randn(ComplexF32, num_doppler_bins, samples_per_code)
+        col_proto = zeros(ComplexF32, num_doppler_bins)
+        col_fft_plan = plan_fft!(col_proto)
+        col_batch_fft_plan = if num_doppler_bins <= Acquisition.BATCH_FFT_THRESHOLD
+            batch_proto = zeros(ComplexF32, num_doppler_bins, samples_per_code)
+            plan_fft!(batch_proto, 1)
+        else
+            nothing
+        end
+        fftshift_perm = [mod(r - 1 + num_doppler_bins ÷ 2, num_doppler_bins) + 1
+                         for r in 1:num_doppler_bins]
+
+        # Synthetic doppler grid in sorted order (matches plan.doppler_freqs).
+        doppler_coverage_hz = 32_000.0
+        doppler_freqs = range(-doppler_coverage_hz / 2,
+                              step = doppler_coverage_hz / num_doppler_bins,
+                              length = num_doppler_bins)
+        coherent_duration_s = samples_per_code / sampling_freq_hz_test
+        # Raw shifts for the reference circshift (any integer is fine).
+        raw_shifts = [round(Int, doppler_freqs[r] * accumulation_step *
+                       coherent_duration_s * sampling_freq_hz_test / carrier_freq_hz_test)
+                      for r in 1:num_doppler_bins]
+        # Fused kernels expect shifts normalised to [0, samples_per_code) so
+        # they can replace `mod` with a single conditional subtract — matches
+        # the convention `_fill_code_drift_shifts!` writes.
+        norm_shifts = [mod(s, samples_per_code) for s in raw_shifts]
+
+        # Reference: unfused pipeline (pilot accumulator → row-wise circshift → fftshift scatter)
+        ref_acc = zeros(Float32, num_doppler_bins, samples_per_code)
+        ref_buf = zeros(Float32, num_doppler_bins, samples_per_code)
+        col_buf = zeros(ComplexF32, num_doppler_bins)
+        Acquisition._accumulate_noncoherent_integration_pilot!(ref_buf, copy(cim_template),
+            col_buf, col_fft_plan, samples_per_code)
+        # Apply the row-wise circular shift (mirrors _apply_code_drift! body exactly).
+        if accumulation_step != 0
+            row_buf = zeros(Float32, samples_per_code)
+            row_shift_buf = zeros(Float32, samples_per_code)
+            for r in 1:num_doppler_bins
+                raw_shifts[r] == 0 && continue
+                row_buf .= view(ref_buf, r, :)
+                circshift!(row_shift_buf, row_buf, raw_shifts[r])
+                ref_buf[r, :] .= row_shift_buf
+            end
+        end
+        Acquisition._scatter_fftshift_accumulate!(ref_acc, ref_buf, fftshift_perm, samples_per_code)
+
+        # Fused: per-column path
+        fused_acc = zeros(Float32, num_doppler_bins, samples_per_code)
+        Acquisition._accumulate_fftshifted_power_drift_pilot!(fused_acc, copy(cim_template),
+            zeros(ComplexF32, num_doppler_bins), col_fft_plan,
+            samples_per_code, num_doppler_bins, fftshift_perm, norm_shifts)
+        @test fused_acc ≈ ref_acc
+
+        # Fused: batched path (only valid below the threshold)
+        if col_batch_fft_plan !== nothing
+            fused_acc_batched = zeros(Float32, num_doppler_bins, samples_per_code)
+            Acquisition._accumulate_fftshifted_power_drift_pilot_batched!(fused_acc_batched,
+                copy(cim_template), col_batch_fft_plan, samples_per_code, num_doppler_bins,
+                fftshift_perm, norm_shifts)
+            @test fused_acc_batched ≈ ref_acc
+        end
+    end
+end
+
+@testset "_fill_code_drift_shifts! has_drift flag and non-drift dispatch" begin
+    # Validate the early-exit that lets the multistep simple path skip the
+    # fused-drift kernel and run the SIMD-friendly slice-5 kernel when every
+    # row's rounded drift is zero. Two scenarios:
+    #   (a) L1CA / 5 MHz / N_coh=1: doppler×step×T_coh×fs/fc rounds to 0 for
+    #       every row up to N_nc≈8. has_drift must stay false → dispatcher
+    #       must produce the same output as the non-drift kernel run direct.
+    #   (b) L1CA / 2.048 MHz / N_coh=20: drift is large enough that some
+    #       rows are non-zero at step=7. has_drift must flip to true and
+    #       shifts must be normalised to [0, samples_per_code).
+    Random.seed!(20260526)
+
+    # (a) all-zero drift on the simple/batched path
+    plan_a = plan_acquire(GPSL1CA(), 5.0e6Hz, [1];
+        min_doppler_coverage = 2000Hz, num_noncoherent_accumulations = 8)
+    n_dop_a = length(plan_a.doppler_freqs)
+    shifts_a = zeros(Int, n_dop_a)
+
+    # step 0: definitionally has_drift=false, shifts all 0
+    @test Acquisition._fill_code_drift_shifts!(shifts_a, plan_a, 0) == false
+    @test all(iszero, shifts_a)
+
+    # step 7: doppler×step×T_coh×fs/fc < 0.5 for every row at this grid →
+    # rounds to 0. has_drift must STILL be false.
+    @test Acquisition._fill_code_drift_shifts!(shifts_a, plan_a, 7) == false
+    @test all(iszero, shifts_a)
+
+    # End-to-end: dispatcher at step 7 must produce the same nim as a direct
+    # call to the non-drift slice-5 kernel on the same CIM.
+    cim_a = randn(ComplexF32, n_dop_a, plan_a.samples_per_code)
+    nim_via_dispatch = zeros(Float32, n_dop_a, plan_a.samples_per_code)
+    Acquisition._accumulate_noncoherent_integration_step!(nim_via_dispatch, copy(cim_a), plan_a, 7)
+
+    nim_direct = zeros(Float32, n_dop_a, plan_a.samples_per_code)
+    if n_dop_a <= Acquisition.BATCH_FFT_THRESHOLD
+        Acquisition._accumulate_fftshifted_power_pilot_batched!(
+            nim_direct, copy(cim_a), plan_a.col_batch_fft_plan,
+            plan_a.samples_per_code, n_dop_a)
+    else
+        Acquisition._accumulate_fftshifted_power_pilot!(
+            nim_direct, copy(cim_a), Acquisition._default_scratch(plan_a).col_buf,
+            plan_a.col_fft_plan, plan_a.samples_per_code, n_dop_a)
+    end
+    @test nim_via_dispatch ≈ nim_direct
+
+    # (b) non-zero drift on the per-column path
+    plan_b = plan_acquire(GPSL1CA(), 2.048e6Hz, [1];
+        min_doppler_coverage = 12_000Hz,
+        num_coherently_integrated_code_periods = 20,
+        num_noncoherent_accumulations = 8)
+    n_dop_b = length(plan_b.doppler_freqs)
+    shifts_b = zeros(Int, n_dop_b)
+
+    # step 0 is still has_drift=false even on the larger grid.
+    @test Acquisition._fill_code_drift_shifts!(shifts_b, plan_b, 0) == false
+    @test all(iszero, shifts_b)
+
+    # step 7 must flip has_drift to true and normalise shifts to [0, spc).
+    @test Acquisition._fill_code_drift_shifts!(shifts_b, plan_b, 7) == true
+    @test any(!iszero, shifts_b)
+    @test all(s -> 0 <= s < plan_b.samples_per_code, shifts_b)
+end
+
 @testset "Fused FFT+|x|²+fftshift kernel matches unfused pipeline" begin
     # The slice-5 fused kernel must produce bit-identical output to the
     # unfused `column FFT -> |x|² -> _scatter_fftshift_accumulate!` chain it

--- a/test/plan.jl
+++ b/test/plan.jl
@@ -229,11 +229,11 @@ end
         (length(search_plan.doppler_freqs), search_plan.num_data_bits)
 end
 
-@testset "noncoherent_integration_buf is 0x0 when fused FFT+abs2+fftshift kernel runs" begin
-    # At N_nc==1 with the simple/pilot path, the fused kernel writes |FFT|²
-    # straight into the accumulator with fftshift permutation and never touches
-    # `noncoherent_integration_buf`. The buf can be dropped per-thread; sign-search
-    # path and multistep (N_nc>1) still need it full-sized.
+@testset "noncoherent_integration_buf is 0x0 whenever the simple path runs" begin
+    # The fused FFT+|x|²+(code-drift)+fftshift kernel writes straight into the
+    # destination, so the simple/pilot path never touches `noncoherent_integration_buf`.
+    # That's true at N_nc==1 (slice 5) AND at N_nc>1 (Issue #62). Sign-search is
+    # the only remaining consumer of the buf.
     system = GPSL1CA()
     sampling_freq = 2.048e6Hz
 
@@ -246,6 +246,19 @@ end
         @test size(t_scratch.noncoherent_integration_buf) == (0, 0)
     end
 
+    # Multistep (N_nc>1) simple path: the fused kernel handles code drift, so
+    # the buf is dropped here too. This is the Issue #62 regression-lock.
+    multi_simple_plan = plan_acquire(system, sampling_freq, [1];
+        num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 2)
+    multi_simple_scratch = Acquisition._default_scratch(multi_simple_plan)
+    @test multi_simple_plan.num_data_bits == 1
+    @test multi_simple_plan.bit_edge_search_steps == 1
+    @test multi_simple_plan.num_noncoherent_accumulations == 2
+    @test size(multi_simple_scratch.noncoherent_integration_buf) == (0, 0)
+    for t_scratch in multi_simple_plan.thread_scratch
+        @test size(t_scratch.noncoherent_integration_buf) == (0, 0)
+    end
+
     # Sign-search at N_nc=1 still needs the buf.
     sign_search_plan = plan_acquire(system, sampling_freq, [1];
         min_doppler_coverage = 10_000Hz,
@@ -253,11 +266,13 @@ end
     @test size(Acquisition._default_scratch(sign_search_plan).noncoherent_integration_buf) ==
         (length(sign_search_plan.doppler_freqs), sign_search_plan.samples_per_code)
 
-    # Multistep (N_nc>1) needs the buf too, even on the simple path.
-    multi_plan = plan_acquire(system, sampling_freq, [1];
-        num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 2)
-    @test size(Acquisition._default_scratch(multi_plan).noncoherent_integration_buf) ==
-        (length(multi_plan.doppler_freqs), multi_plan.samples_per_code)
+    # Multistep sign-search needs the buf too.
+    multi_sign_plan = plan_acquire(system, sampling_freq, [1];
+        min_doppler_coverage = 10_000Hz,
+        num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 4,
+        num_noncoherent_accumulations = 2)
+    @test size(Acquisition._default_scratch(multi_sign_plan).noncoherent_integration_buf) ==
+        (length(multi_sign_plan.doppler_freqs), multi_sign_plan.samples_per_code)
 end
 
 @testset "sequential N_nc=1 layout: empty per-PRN matrices, full per-thread accumulator" begin


### PR DESCRIPTION
## Summary

Extends the slice-5 fusion (PR #63) to `num_noncoherent_accumulations > 1`. Drops `noncoherent_integration_buf` per thread on the multistep simple path by folding `|FFT|² + per-row code-drift column shift + fftshift row permutation` into one pass directly into the per-PRN noncoherent matrix. Closes #62.

Two optimisations keep this win at *all* `num_doppler_bins`:

- `_fill_code_drift_shifts!` returns `Bool`. When the rounded drift is 0 for every row (typical for low-fs / short-T_coh grids — e.g. L1CA / 5 MHz / N_coh=1 rounds to 0 for every row up to N_nc=8), the dispatcher routes through the SIMD-friendly slice-5 non-drift kernel.
- Shifts are pre-normalised to `[0, samples_per_code)` so the hot loop drops `mod` for a single conditional subtract. `code_native` confirms no `idiv` survives in the kernel.

## Bench deltas

vs the unfused multistep simple path (200/80 BenchmarkTools samples, single host, fixed signal):

| Workload | Path | acquire! min | Δ time | PlanAcquire | Δ RAM |
|---|---|---|---|---|---|
| L1CA 5 MHz, N_coh=1, N_nc=8 (8 doppler bins) | batched | 8.15 → 8.10 ms | -0.6% | 2.69 → 2.39 MiB | **-0.30 MiB** |
| L1CA 2.048 MHz, N_coh=20, N_nc=8 (640 doppler bins) | per-column | 386.65 → 275.69 ms | **-28.7%** | 51.62 → 41.63 MiB | **-9.99 MiB** |

RAM savings scale with `num_doppler_bins × samples_per_code × nthreads`.

## Test plan

- [x] FM-DBZP testsets all pass (235 tests; 10 new in `test/noncoherent_integration.jl`).
- [x] New parity test: fused-drift kernel (per-column + batched) matches the unfused `pilot! → _apply_code_drift! → _scatter_fftshift_accumulate!` chain on random CIM input, including step 0 / all-zero-shift case.
- [x] New `_fill_code_drift_shifts!` test: `has_drift = false` when drift rounds to 0 on every row; `true` otherwise; shifts normalised to `[0, samples_per_code)`.
- [x] New dispatcher parity check: `_accumulate_noncoherent_integration_step!` with `has_drift = false` produces the same `nim` as a direct call to the slice-5 non-drift kernel.
- [x] Regression-lock testset in `test/plan.jl` flipped — multistep simple path now also drops the buf to 0×0. Sign-search at N_nc>1 still keeps it full-sized.
- [x] CFAR M=8 testset (real-signal end-to-end at L1CA / 5 MHz) still passes.

## Notes for review

- This PR is **stacked on #63** (slice-5 fusion). Once #63 lands, GitHub will retarget this PR to `master`.
- New `AcquireSignals[L1CA_5MHz_Nnc8]` and `PlanAcquire[L1CA_5MHz_Nnc8]` entries in `benchmark/benchmarks.jl` give AirSpeedVelocity a stable series for the multistep simple path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)