### PR TITLE
fix: correct half-band Doppler offset in the sign-search path

### DIFF
--- a/src/noncoherent_integration.jl
+++ b/src/noncoherent_integration.jl
@@ -362,11 +362,9 @@ function _accumulate_noncoherent_integration_step!(
         # identity), leaving the Doppler axis in raw FFT order and biasing every
         # reported Doppler by half the searched band. The pilot reference path
         # (raw-order kernel) is the one that pairs with `_scatter_fftshift_accumulate!`.
-        @inbounds for col_idx in 1:plan.samples_per_code
-            @simd for doppler_bin in 1:num_doppler_bins
-                noncoherent_integration_matrix[doppler_bin, col_idx] += noncoherent_integration_max_buf[doppler_bin, col_idx]
-            end
-        end
+        # Both arrays are (num_doppler_bins, samples_per_code), so a whole-array
+        # broadcast covers the same extent as the former scatter.
+        noncoherent_integration_matrix .+= noncoherent_integration_max_buf
     end
 end
 # Convenience wrapper for tests and single-threaded callers — routes through

--- a/src/noncoherent_integration.jl
+++ b/src/noncoherent_integration.jl
@@ -354,7 +354,19 @@ function _accumulate_noncoherent_integration_step!(
             _apply_code_drift!(noncoherent_integration_buf, plan, scratch, accumulation_step_index)
             @. noncoherent_integration_max_buf = max(noncoherent_integration_max_buf, noncoherent_integration_buf)
         end
-        _scatter_fftshift_accumulate!(noncoherent_integration_matrix, noncoherent_integration_max_buf, plan.fftshift_perm, plan.samples_per_code)
+        # `_accumulate_noncoherent_integration_data_bits!` already fftshifts each
+        # column FFT internally (circshift by N÷2), so `noncoherent_integration_max_buf`
+        # is in sorted-Doppler order — the same order `_apply_code_drift!` assumes
+        # and the result extraction reads. Accumulate directly; applying
+        # `fftshift_perm` here would shift a second time (the two compose to the
+        # identity), leaving the Doppler axis in raw FFT order and biasing every
+        # reported Doppler by half the searched band. The pilot reference path
+        # (raw-order kernel) is the one that pairs with `_scatter_fftshift_accumulate!`.
+        @inbounds for col_idx in 1:plan.samples_per_code
+            @simd for doppler_bin in 1:num_doppler_bins
+                noncoherent_integration_matrix[doppler_bin, col_idx] += noncoherent_integration_max_buf[doppler_bin, col_idx]
+            end
+        end
     end
 end
 # Convenience wrapper for tests and single-threaded callers — routes through

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -198,6 +198,41 @@ end
     @test abs(res_multi.carrier_doppler / 1Hz - ustrip(Hz, doppler_true)) < ustrip(Hz, step(plan_multi.doppler_freqs))
 end
 
+@testset "acquire! — sign-search path reports correct Doppler (no half-band fftshift offset)" begin
+    # Regression for the double-fftshift bug in the sign-search kernel: when
+    # num_data_bits > 1 the column sub-block FFT applied fftshift (circshift by
+    # N/2) AND the result was scattered through fftshift_perm a second time.
+    # Two fftshifts compose to the identity, leaving the Doppler axis in raw FFT
+    # order — every reported Doppler was off by exactly half the searched band,
+    # while code phase (the column axis) stayed correct. The pilot path shifts
+    # once and is unaffected, so existing tests (all num_data_bits == 1) missed it.
+    system = GPSL1CA()
+    sampling_freq = 2.048e6Hz
+    prn = 1
+    doppler_true = 500Hz      # on the 25 Hz Doppler grid
+    code_phase_true = 100.0
+
+    # N_coh = 40 code periods = 2 GPS data-bit periods (20 each) → num_data_bits = 2,
+    # which routes through the sign-search kernel rather than the simple pilot path.
+    (; signal) = generate_test_signal(system, prn;
+        num_samples = 40 * 2048,
+        doppler = doppler_true, code_phase = code_phase_true,
+        sampling_freq, interm_freq = 0.0Hz, CN0 = 45)
+
+    plan = plan_acquire(system, sampling_freq, [prn];
+        num_coherently_integrated_code_periods = 40, num_noncoherent_accumulations = 1,
+        fft_flag = FFTW.ESTIMATE)
+    @test plan.num_data_bits == 2   # confirm the sign-search path is exercised
+
+    result = acquire!(plan, signal, prn; interm_freq = 0.0Hz)
+
+    @test is_detected(result)
+    @test result.code_phase ≈ code_phase_true atol = 1.0
+    # The bug shifted Doppler by half the band (8000 Hz here); a correct result
+    # lands within one Doppler bin of the truth.
+    @test abs(result.carrier_doppler / 1Hz - ustrip(Hz, doppler_true)) < ustrip(Hz, step(plan.doppler_freqs))
+end
+
 @testset "acquire! — PRN not in plan throws ArgumentError" begin
     system = GPSL1CA()
     sampling_freq = 2.048e6Hz


### PR DESCRIPTION
The sign-search path (num_data_bits > 1, or bit-edge search) fftshifted the Doppler axis twice: once inside _accumulate_noncoherent_integration_data_bits! (circshift by N/2 per column FFT) and again via _scatter_fftshift_accumulate!. Two fftshifts on an even-length axis compose to the identity, leaving the matrix in raw FFT order while doppler_freqs (and result extraction) assume sorted order — biasing every reported Doppler by half the searched band. Code phase (the column axis) was unaffected, which is why detection still worked and the bug went unnoticed.

Accumulate the already-sorted buffer directly instead of scattering through fftshift_perm a second time. The kernel's internal circshift is kept on purpose: _apply_code_drift! runs between the two former shifts and relies on sorted-row order for N_nc > 1.

Introduced in 36f5717 (FM-DBZP backend); shipped in v2.0.0 through v2.3.2. Missed by the suite because no test asserted Doppler on the sign-search path (all used N_coh=1 / num_data_bits=1). Adds a regression test at num_data_bits=2 that fails before this change (Doppler off by half-band) and passes after.