### PR TITLE
Fix Doppler sign ambiguity on the secondary-code rotation search (#68)

### DIFF
--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -40,6 +40,14 @@ Results from GNSS signal acquisition for a single PRN.
   - `sampling_frequency`: Sampling frequency of the signal
   - `carrier_doppler`: Estimated carrier Doppler frequency
   - `code_phase::Float64`: Estimated code phase in chips
+  - `secondary_code_phase::Union{Int,Nothing}`: Secondary-code phase index — the
+    secondary-code chip the start of the coherent window aligned to, in
+    `0:get_secondary_code_length(system)-1`. Estimated exactly by despreading the
+    per-period prompt correlations at the recovered `(carrier_doppler, code_phase)`.
+    `nothing` when no rotation search ran (no secondary code, `use_secondary_code = false`,
+    or `num_coherently_integrated_code_periods == 1`) or when the peak does not clear the
+    CFAR detection threshold (a non-detected peak has no meaningful secondary phase).
+    Useful for seeding a tracking loop's secondary-code alignment.
   - `CN0::Float64`: Carrier-to-noise density ratio in dB-Hz
   - `noise_power::T`: Estimated noise power
   - `peak_to_noise_ratio::T`: Ratio of peak correlation power to estimated noise power
@@ -71,6 +79,14 @@ struct AcquisitionResults{S<:AbstractGNSSSignal,T,D<:AbstractRange}
     sampling_frequency::typeof(1.0Hz)
     carrier_doppler::typeof(1.0Hz)
     code_phase::Float64
+    # Secondary-code phase index (which secondary-code chip the start of the
+    # coherent integration window aligned to) recovered by the secondary-code
+    # rotation search. `nothing` when no rotation search ran — i.e. the signal
+    # has no secondary code, `use_secondary_code = false`, or
+    # `num_coherently_integrated_code_periods == 1`. When populated it is an
+    # integer in `0:get_secondary_code_length(system)-1`, suitable for seeding a
+    # tracking loop's secondary-code alignment.
+    secondary_code_phase::Union{Int, Nothing}
     CN0::Float64
     noise_power::T
     peak_to_noise_ratio::T

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -404,6 +404,10 @@ Convenience wrapper: calls [`plan_acquire`](@ref) then [`acquire!`](@ref).
   - `num_coherently_integrated_code_periods`: Code periods per coherent block (default: `1`)
   - `bit_edge_search_steps`: Bit edge search positions (default: `1`)
   - `num_noncoherent_accumulations`: Non-coherent integration steps (default: `1`)
+  - `use_secondary_code`: enable the secondary-code rotation search (default: `true`).
+    Requires `num_coherently_integrated_code_periods` to be a whole multiple of the
+    secondary-code length `L`; a partial period is rejected to avoid the ±Doppler sign
+    ambiguity (issue #68). See [`plan_acquire`](@ref).
   - `fft_flag`: FFTW planning flag (default: `FFTW.MEASURE`)
 
 # Keyword Arguments forwarded to `acquire!`:

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -196,6 +196,7 @@ function _acquire_multistep!(plan, signal, prns, segment_length, interm_freq_hz,
         scratch, slot = _claim_scratch!(plan)
         try
             results[result_idx] = _extract_result!(plan, scratch, prn, prn_idx, power_bins,
+                signal, interm_freq_hz,
                 sampling_freq_hz, code_freq_hz, code_length, code_period,
                 num_doppler_bins, doppler_step, subsample_interpolation, store_power_bins)
         finally
@@ -276,6 +277,7 @@ function _acquire_sequential!(plan, signal, prns, segment_length, interm_freq_hz
             end
 
             results[result_idx] = _extract_result!(plan, scratch, prn, prn_idx, accumulator,
+                signal, interm_freq_hz,
                 sampling_freq_hz, code_freq_hz, code_length, code_period,
                 num_doppler_bins, doppler_step, subsample_interpolation, store_power_bins)
         finally
@@ -285,11 +287,63 @@ function _acquire_sequential!(plan, signal, prns, segment_length, interm_freq_hz
     return results
 end
 
+# Exact secondary-code phase estimate. The FM-DBZP rotation index (`rotation_block`)
+# is ±1 at worst-case code phases — the chip and the sub-chip code phase entangle in
+# the factored search. So instead, with the peak's `(doppler, code_phase)` in hand,
+# we despread the first `L` per-coherent-period prompt correlations against each of the
+# `L` secondary-code rotations and take the strongest. A full secondary-code period of
+# coherent despread is the unambiguous case (bounded periodic autocorrelation), so this
+# is exact at every code phase. `L = num_secondary_rotations` and only the first `L`
+# periods are used, so an unknown data-bit flip at a symbol boundary (N > L) never
+# enters — the NH-phase is constant across symbols anyway (N is a multiple of L).
+#
+# Carrier (interm + doppler) wipe-off uses an incremental complex phasor reset each
+# period (one `sincos` per period, not per sample) to stay cheap and bound Float32
+# drift to within a primary-code period. The primary-code reference is generated once
+# per call; for signals whose `gen_code` bakes the secondary code (e.g. GPS L5I) it
+# carries a single constant chip, a global ±1 that cancels in the magnitude `argmax`.
+function _estimate_secondary_code_phase(plan, prn, signal, interm_freq_hz,
+                                        sampling_freq_hz, code_phase, doppler_hz)
+    system = plan.system
+    L = plan.num_secondary_rotations
+    spc = plan.samples_per_code
+    sec = get_secondary_code(system)
+    code = gen_code(spc, system, prn, plan.sampling_freq, get_code_frequency(system), code_phase)
+    phase_step = -2.0 * π * (interm_freq_hz + doppler_hz) / sampling_freq_hz
+    dphi = ComplexF32(cos(phase_step), sin(phase_step))   # per-sample carrier rotation
+    zs = Vector{ComplexF32}(undef, L)
+    @inbounds for k in 0:L-1
+        base = k * spc
+        s0, c0 = sincos(phase_step * base)                # reset phasor each period
+        carr = ComplexF32(c0, s0)
+        acc = zero(ComplexF32)
+        for n in 0:spc-1
+            acc += ComplexF32(signal[base + n + 1]) * carr * ComplexF32(code[n + 1])
+            carr *= dphi
+        end
+        zs[k + 1] = acc
+    end
+    best_r = 0
+    best_mag = -1.0f0
+    @inbounds for r in 0:L-1
+        s = zero(ComplexF32)
+        for k in 0:L-1
+            s += Float32(GNSSSignals.secondary_value(sec, prn, mod(k + r, L))) * zs[k + 1]
+        end
+        mag = abs2(s)
+        if mag > best_mag
+            best_mag = mag
+            best_r = r
+        end
+    end
+    return best_r
+end
+
 # Read the peak out of `power_bins` and assemble an AcquisitionResults. Used by
 # both the sequential and multistep paths; in the sequential path `power_bins`
 # is the per-thread accumulator (and is reused by the next PRN), so the
 # store_power_bins copy must happen here before this function returns.
-function _extract_result!(plan, scratch, prn, prn_idx, power_bins,
+function _extract_result!(plan, scratch, prn, prn_idx, power_bins, signal, interm_freq_hz,
                           sampling_freq_hz, code_freq_hz, code_length, code_period,
                           num_doppler_bins, doppler_step, subsample_interpolation, store_power_bins)
     col_sums_buf = scratch.col_sums_buf
@@ -307,9 +361,10 @@ function _extract_result!(plan, scratch, prn, prn_idx, power_bins,
 
     # On the rotation path the cp axis is expanded to
     # `samples_per_code * num_secondary_rotations` and the peak col encodes
-    # `(cp_within, rotation_idx)` together. Decode back to cp_within for the
-    # public `code_phase` output; rotation_idx is currently hidden (the
-    # detection geometry doesn't need it for downstream tracking).
+    # `(cp_within, rotation_idx)` together. We decode `cp_within` for the public
+    # `code_phase`; the secondary-code phase is recovered exactly further below
+    # via `_estimate_secondary_code_phase` (the raw `rotation_idx` is ±1 at
+    # worst-case code phases, so it is not used for the public field).
     samples_per_code = plan.samples_per_code
     rotation_block = (code_bin_idx - 1) ÷ samples_per_code
     scrambled_col = (code_bin_idx - 1) % samples_per_code
@@ -344,6 +399,25 @@ function _extract_result!(plan, scratch, prn, prn_idx, power_bins,
         end
     end
 
+    # Exact secondary-code phase — only on the rotation path AND only when the peak
+    # clears the CFAR detection threshold. A secondary phase for a non-detected PRN is
+    # meaningless (it would despread noise), so it stays `nothing`; this also means
+    # absent PRNs in a wide search pay nothing for the estimator (it's the few detected
+    # PRNs that run it). The gate uses the same default pfa as [`is_detected`](@ref).
+    secondary_code_phase = if plan.num_secondary_rotations > 1
+        num_cells = num_doppler_bins * plan.num_blocks * plan.block_size
+        threshold = cfar_threshold(0.01, num_cells;
+            num_noncoherent_integrations = plan.num_noncoherent_accumulations)
+        if peak_to_noise > threshold
+            _estimate_secondary_code_phase(plan, prn, signal, interm_freq_hz,
+                sampling_freq_hz, code_phase, ustrip(Hz, doppler))
+        else
+            nothing
+        end
+    else
+        nothing
+    end
+
     result_buf = if store_power_bins
         cached = plan.result_buffers[prn_idx]
         buf = cached === nothing ? similar(power_bins) : cached
@@ -359,6 +433,7 @@ function _extract_result!(plan, scratch, prn, prn_idx, power_bins,
         plan.sampling_freq,
         doppler,
         code_phase,
+        secondary_code_phase,
         CN0,
         Float32(noise_power),
         Float32(peak_to_noise),

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -405,7 +405,14 @@ function _extract_result!(plan, scratch, prn, prn_idx, power_bins, signal, inter
     # absent PRNs in a wide search pay nothing for the estimator (it's the few detected
     # PRNs that run it). The gate uses the same default pfa as [`is_detected`](@ref).
     secondary_code_phase = if plan.num_secondary_rotations > 1
-        num_cells = num_doppler_bins * plan.num_blocks * plan.block_size
+        # True searched-cell count INCLUDING the rotation expansion: the rotation
+        # path's power_bins is `num_doppler_bins × (samples_per_code ×
+        # num_secondary_rotations)`. Omitting the `× num_secondary_rotations`
+        # understates the cell count L-fold, dropping the CFAR threshold enough
+        # that pure-noise peaks clear it and the estimator fires on absent PRNs —
+        # that was the AcquireSignals/L5I regression. (`num_blocks × block_size ==
+        # samples_per_code`.)
+        num_cells = num_doppler_bins * plan.samples_per_code * plan.num_secondary_rotations
         threshold = cfar_threshold(0.01, num_cells;
             num_noncoherent_integrations = plan.num_noncoherent_accumulations)
         if peak_to_noise > threshold

--- a/src/noncoherent_integration.jl
+++ b/src/noncoherent_integration.jl
@@ -280,28 +280,44 @@ function _sign_search_step_with_rotations!(
             # layout the noise floor is calibrated against). DATA-BIT polarity, by
             # contrast, is a nuisance hypothesis (the unknown data sign), so the
             # `num_data_combos` patterns sharing a rotation are collapsed by a
-            # cell-wise MAX into that rotation's slice — exactly as the
-            # non-rotation `_sign_search_step!` maxes data combos. When
-            # num_data_combos == 1 (no multi-bit search, the only case before this
-            # fix) the max is against the 0-initialised buffer, so it reduces to a
-            # plain write and the N < 2L behaviour is unchanged. Result extraction
-            # decodes via `(col-1) ÷ samples_per_code → rotation_idx`.
+            # cell-wise MAX into that rotation's slice — exactly as the non-rotation
+            # `_sign_search_step!` maxes data combos. Result extraction decodes via
+            # `(col-1) ÷ samples_per_code → rotation_idx`.
+            #
+            # `num_data_combos == 1` (no multi-bit search) is the dominant case: each
+            # pattern is its own rotation, so dest_col cells never collide and we use a
+            # plain SIMD store. Only when combos > 1 do the loops read-then-max — that
+            # read-compare-store can't vectorise like the pure store, so gating it keeps
+            # the common path at the pre-fix speed (see the fold-fftshift kernel).
             rotation_idx = (q - 1) ÷ num_data_combos
             dest_col = col_idx + rotation_idx * samples_per_code
-            @inbounds for ω in 1:half
-                cell_power = muladd(combine_buf_re[ω], combine_buf_re[ω],
-                                    combine_buf_im[ω] * combine_buf_im[ω])
-                dst = ω + half
-                if cell_power > noncoherent_integration_buf[dst, dest_col]
-                    noncoherent_integration_buf[dst, dest_col] = cell_power
+            if num_data_combos == 1
+                @inbounds @simd for ω in 1:half
+                    noncoherent_integration_buf[ω + half, dest_col] =
+                        muladd(combine_buf_re[ω], combine_buf_re[ω],
+                               combine_buf_im[ω] * combine_buf_im[ω])
                 end
-            end
-            @inbounds for ω in half+1:num_doppler_bins
-                cell_power = muladd(combine_buf_re[ω], combine_buf_re[ω],
-                                    combine_buf_im[ω] * combine_buf_im[ω])
-                dst = ω - half
-                if cell_power > noncoherent_integration_buf[dst, dest_col]
-                    noncoherent_integration_buf[dst, dest_col] = cell_power
+                @inbounds @simd for ω in half+1:num_doppler_bins
+                    noncoherent_integration_buf[ω - half, dest_col] =
+                        muladd(combine_buf_re[ω], combine_buf_re[ω],
+                               combine_buf_im[ω] * combine_buf_im[ω])
+                end
+            else
+                @inbounds for ω in 1:half
+                    cell_power = muladd(combine_buf_re[ω], combine_buf_re[ω],
+                                        combine_buf_im[ω] * combine_buf_im[ω])
+                    dst = ω + half
+                    if cell_power > noncoherent_integration_buf[dst, dest_col]
+                        noncoherent_integration_buf[dst, dest_col] = cell_power
+                    end
+                end
+                @inbounds for ω in half+1:num_doppler_bins
+                    cell_power = muladd(combine_buf_re[ω], combine_buf_re[ω],
+                                        combine_buf_im[ω] * combine_buf_im[ω])
+                    dst = ω - half
+                    if cell_power > noncoherent_integration_buf[dst, dest_col]
+                        noncoherent_integration_buf[dst, dest_col] = cell_power
+                    end
                 end
             end
         end

--- a/src/noncoherent_integration.jl
+++ b/src/noncoherent_integration.jl
@@ -107,8 +107,8 @@ end
 """
     _sign_search_step_with_rotations!(noncoherent_integration_buf, coherent_integration_matrix, col_buf,
                                       combine_buf_re, combine_buf_im, col_fft_plan,
-                                      samples_per_code, num_doppler_bins, num_coh_periods, num_blocks,
-                                      block_size, row_offset, sub_block_ffts,
+                                      samples_per_code, num_doppler_bins, num_coh_periods, num_data_combos,
+                                      num_blocks, block_size, row_offset, sub_block_ffts,
                                       tiled_phase_patterns_re, tiled_phase_patterns_im)
 
 Sign-pattern search step for one bit-edge alignment when per-coherent-period signs vary
@@ -116,7 +116,17 @@ Sign-pattern search step for one bit-edge alignment when per-coherent-period sig
 `num_blocks` rows each (one per coherent code period) and computes one column FFT per
 sub-block. Then, for each pattern column, accumulates
 `tiled_phase_patterns[ω, p, q] * sub_block_FFT_p[ω]` over the `num_coh_periods` sub-blocks
-and cell-wise-maxes `|result|²` into `noncoherent_integration_buf`.
+and writes `|result|²` into `noncoherent_integration_buf`.
+
+The `num_sign_patterns` pattern columns are the Cartesian product of
+`num_secondary_rotations` secondary-code rotations and `num_data_combos = 2^(num_data_bits−1)`
+data-bit polarities (rotation-major, data-minor; see [`sign_patterns`](@ref)). Each rotation
+is a distinct code phase and gets its own `samples_per_code`-wide cp slice; the
+`num_data_combos` polarities sharing a rotation are collapsed into that slice by a cell-wise
+max (the data sign is a nuisance hypothesis). The buffer's cp axis must therefore be at least
+`(num_sign_patterns ÷ num_data_combos) * samples_per_code` wide. (Before this was fixed the
+kernel wrote one slice per *pattern* into a buffer sized for one slice per *rotation*, which
+overran the buffer whenever `num_data_combos > 1`, i.e. N ≥ 2·L — a segfault.)
 
 This is the generalisation of [`_sign_search_step!`](@ref) — that kernel groups consecutive
 coherent periods into one sub-block per data bit (`num_data_bits` sub-blocks total) and is
@@ -179,6 +189,7 @@ function _sign_search_step_with_rotations!(
     samples_per_code::Int,
     num_doppler_bins::Int,
     num_coh_periods::Int,
+    num_data_combos::Int,
     num_blocks::Int,
     block_size::Int,
     row_offset::Int,
@@ -187,6 +198,14 @@ function _sign_search_step_with_rotations!(
     tiled_phase_patterns_im::Array{Float32,3},
 )
     num_sign_patterns = size(tiled_phase_patterns_re, 3)
+    num_data_combos >= 1 || throw(ArgumentError("num_data_combos must be >= 1, got $num_data_combos"))
+    num_sign_patterns % num_data_combos == 0 || throw(ArgumentError(
+        "num_sign_patterns=$num_sign_patterns must be a multiple of num_data_combos=$num_data_combos"))
+    num_rotation_blocks = num_sign_patterns ÷ num_data_combos
+    size(noncoherent_integration_buf, 2) >= num_rotation_blocks * samples_per_code || throw(ArgumentError(
+        "noncoherent_integration_buf has $(size(noncoherent_integration_buf, 2)) cp columns, " *
+        "need num_rotation_blocks*samples_per_code=$(num_rotation_blocks * samples_per_code) " *
+        "(num_sign_patterns=$num_sign_patterns ÷ num_data_combos=$num_data_combos rotations × samples_per_code=$samples_per_code)"))
     size(tiled_phase_patterns_re, 1) == num_doppler_bins || throw(ArgumentError(
         "tiled_phase_patterns_re has $(size(tiled_phase_patterns_re, 1)) rows, expected num_doppler_bins=$num_doppler_bins"))
     size(tiled_phase_patterns_re, 2) == num_coh_periods || throw(ArgumentError(
@@ -220,12 +239,14 @@ function _sign_search_step_with_rotations!(
         end
 
         # Combine sub-block FFTs with the precomputed (ω, p, q)-tiled phasors,
-        # then WRITE per-pattern to the q-th cp slice of the noncoherent buffer
-        # in sorted-Doppler row order (no cell-wise max — each rotation
-        # hypothesis gets its own cell so the CFAR statistics match LongL5I's
-        # matched-filter layout, recovering the ~5 dB noise-floor inflation
-        # that cell-wise max would otherwise cost). Loop ordering: outer
-        # pattern q, middle sub-block p, inner ω. The complex MAC is unfused
+        # then WRITE each pattern to its ROTATION's cp slice of the noncoherent
+        # buffer in sorted-Doppler row order. Rotations get their own cells (no
+        # collapse) so the CFAR statistics match LongL5I's matched-filter layout,
+        # recovering the ~5 dB noise-floor inflation that collapsing distinct code
+        # phases would cost; the `num_data_combos` data-bit polarities that share a
+        # rotation ARE collapsed by cell-wise max (nuisance hypothesis — see the
+        # dest_col block below). Loop ordering: outer pattern q, middle sub-block
+        # p, inner ω. The complex MAC is unfused
         # into four real `muladd`s so the compiler packs the inner loop into
         # Float32 SIMD lanes — measured ~3× faster than the equivalent
         # ComplexF32-storage form.
@@ -250,19 +271,38 @@ function _sign_search_step_with_rotations!(
                     combine_buf_im[ω] = muladd(ar, bi, muladd( ai, br, combine_buf_im[ω]))
                 end
             end
-            # Each rotation hypothesis q maps to a samples_per_code-wide slice
-            # of the expanded cp axis. Result extraction decodes back via
-            # `(col-1) ÷ samples_per_code → rotation_idx`, `(col-1) % samples_per_code + 1 → cp_within`.
-            dest_col = col_idx + (q - 1) * samples_per_code
+            # Patterns are laid out rotation-major, data-bit-minor (see
+            # `sign_patterns`): pattern q decodes to rotation
+            # `(q-1) ÷ num_data_combos` and data-bit combo `(q-1) % num_data_combos`.
+            # ROTATIONS are distinct secondary-code phases — distinct code phases
+            # in the LongL5I sense — so each gets its own samples_per_code-wide
+            # slice of the cp axis (no collapse; preserves the matched-filter CFAR
+            # layout the noise floor is calibrated against). DATA-BIT polarity, by
+            # contrast, is a nuisance hypothesis (the unknown data sign), so the
+            # `num_data_combos` patterns sharing a rotation are collapsed by a
+            # cell-wise MAX into that rotation's slice — exactly as the
+            # non-rotation `_sign_search_step!` maxes data combos. When
+            # num_data_combos == 1 (no multi-bit search, the only case before this
+            # fix) the max is against the 0-initialised buffer, so it reduces to a
+            # plain write and the N < 2L behaviour is unchanged. Result extraction
+            # decodes via `(col-1) ÷ samples_per_code → rotation_idx`.
+            rotation_idx = (q - 1) ÷ num_data_combos
+            dest_col = col_idx + rotation_idx * samples_per_code
             @inbounds for ω in 1:half
                 cell_power = muladd(combine_buf_re[ω], combine_buf_re[ω],
                                     combine_buf_im[ω] * combine_buf_im[ω])
-                noncoherent_integration_buf[ω + half, dest_col] = cell_power
+                dst = ω + half
+                if cell_power > noncoherent_integration_buf[dst, dest_col]
+                    noncoherent_integration_buf[dst, dest_col] = cell_power
+                end
             end
             @inbounds for ω in half+1:num_doppler_bins
                 cell_power = muladd(combine_buf_re[ω], combine_buf_re[ω],
                                     combine_buf_im[ω] * combine_buf_im[ω])
-                noncoherent_integration_buf[ω - half, dest_col] = cell_power
+                dst = ω - half
+                if cell_power > noncoherent_integration_buf[dst, dest_col]
+                    noncoherent_integration_buf[dst, dest_col] = cell_power
+                end
             end
         end
     end
@@ -567,6 +607,9 @@ function _accumulate_noncoherent_integration_step!(
         # accumulates across non-coherent steps. No fftshift scatter needed.
         bit_period_codes = plan.num_coherently_integrated_code_periods ÷ plan.num_data_bits
         edge_step = bit_period_codes * plan.num_blocks ÷ plan.bit_edge_search_steps
+        # Number of data-bit polarity patterns per rotation (1 when num_data_bits == 1).
+        # The rotation kernel maps each tiled pattern back to its rotation via this.
+        num_data_combos = 1 << (plan.num_data_bits - 1)
         if plan.bit_edge_search_steps == 1
             # No outer max — the kernel writes the only alignment's result
             # directly. Skip `sign_search_max_buf` (sized 0×0 in this case).
@@ -576,7 +619,7 @@ function _accumulate_noncoherent_integration_step!(
                     scratch.col_buf, scratch.combine_buf_re, scratch.combine_buf_im,
                     plan.col_fft_plan,
                     plan.samples_per_code, num_doppler_bins,
-                    plan.num_coherently_integrated_code_periods, plan.num_blocks,
+                    plan.num_coherently_integrated_code_periods, num_data_combos, plan.num_blocks,
                     plan.block_size,
                     0, scratch.sub_block_ffts,
                     plan.tiled_phase_patterns_re_by_prn[prn],
@@ -600,7 +643,7 @@ function _accumulate_noncoherent_integration_step!(
                         scratch.col_buf, scratch.combine_buf_re, scratch.combine_buf_im,
                         plan.col_fft_plan,
                         plan.samples_per_code, num_doppler_bins,
-                        plan.num_coherently_integrated_code_periods, plan.num_blocks,
+                        plan.num_coherently_integrated_code_periods, num_data_combos, plan.num_blocks,
                         plan.block_size,
                         row_offset, scratch.sub_block_ffts,
                         plan.tiled_phase_patterns_re_by_prn[prn],

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -232,6 +232,18 @@ start Julia with `-t N` before calling `plan_acquire` to enable multi-threaded a
 - `num_noncoherent_accumulations`: Number of successive incoherent integration
   steps (default: `1`). Signal passed to `acquire!` must contain at least
   `num_noncoherent_accumulations` full segments.
+- `use_secondary_code`: enable the secondary-code rotation search (default: `true`).
+  When the signal has a secondary code of length `L > 1` and
+  `num_coherently_integrated_code_periods > 1`, the search jointly estimates the
+  unknown secondary-code start phase, recovering the full coherent gain.
+  **`num_coherently_integrated_code_periods` must then be a whole multiple of `L`**
+  (e.g. `10` for GPS L5I's NH10). A partial secondary period introduces a ±Doppler
+  sign ambiguity (a near-equal mirror peak at `-f`; issue #68) and is rejected with
+  an `ArgumentError`. Set `false` to opt out of the search (no constraint, coarser
+  effective gain when a secondary code is present).
+- `max_secondary_code_rotations`: cap on the secondary-code rotation-search size
+  (default: `32`). `plan_acquire` errors if `L` exceeds this, before allocating
+  buffers, so large-`L` signals (e.g. GPS L1C-P, `L = 1800`) fail fast.
 - `noise_estimator`: how `acquire!` estimates noise power for the CFAR
   test statistic. Defaults to [`OppositeRowNoiseEstimator`](@ref) (averages
   one Doppler row, robust to Doppler-conditional banding from DC offset/IF
@@ -281,17 +293,41 @@ function plan_acquire(
                 "(2) raise max_secondary_code_rotations to at least $L; or " *
                 "(3) set use_secondary_code = false to opt out of the rotation search."))
         end
-        # Rotation-length divisibility: when the integration window spans more than one
-        # secondary-code period (N > L), the window must cover a whole number of those
-        # periods so the cyclic-rotation semantics are well-defined. For data signals this
-        # collapses into the existing bit_period_codes check (bit_period_codes is a
-        # multiple of L in practice), so this is only meaningful for pilot signals.
+        # Rotation-length divisibility: when the rotation search is active, the coherent
+        # window must span a WHOLE number of secondary-code periods (N a multiple of L).
+        # Two distinct failures motivate this — both resolved by the same constraint:
+        #
+        #  - N > L, non-multiple: the cyclic-rotation semantics are ill-defined; the
+        #    trailing partial period doesn't map to a clean secondary-chip sequence.
+        #  - N not a multiple of L (notably the sub-bit regime N < L, e.g. 5 ms on
+        #    GPS L5I whose NH10 has L = 10): a ±Doppler SIGN AMBIGUITY (issue #68). Over
+        #    a partial secondary period the cross-correlation between a WRONG rotation
+        #    hypothesis and the true sequence can fit a frequency-mirrored carrier almost
+        #    as well as the true rotation fits the true carrier. The rotation search then
+        #    surfaces a near-equal mirror peak at -f, and the acquired Doppler keeps a
+        #    stable magnitude but flips sign at random under noise — tracking gets seeded
+        #    ~2|f| off and never locks. The mirror cancels only when the window covers a
+        #    full secondary-code period (N % L == 0), where the periodic autocorrelation
+        #    of the secondary code is bounded.
+        #
+        # For data signals this mostly coincides with the bit_period_codes check below
+        # (bit_period_codes is typically a multiple of L), but it ALSO catches the sub-bit
+        # regime N < bit_period_codes, which that check deliberately allows.
         if use_secondary_code && L > 1 &&
-           num_coherently_integrated_code_periods > L &&
+           num_coherently_integrated_code_periods > 1 &&
            num_coherently_integrated_code_periods % L != 0
             throw(ArgumentError(
-                "secondary-code rotation length L=$L must divide " *
-                "num_coherently_integrated_code_periods=$num_coherently_integrated_code_periods when N > L."))
+                "Secondary-code rotation search requires num_coherently_integrated_code_periods " *
+                "to be a whole multiple of the secondary-code length L=$L, got " *
+                "num_coherently_integrated_code_periods=$num_coherently_integrated_code_periods. " *
+                "A partial secondary-code period makes the rotation search produce a ±Doppler " *
+                "sign ambiguity — a near-equal mirror peak at -f whose sign flips at random under " *
+                "noise (issue #68). Remedies (in order): " *
+                "(1) set num_coherently_integrated_code_periods to a multiple of $L " *
+                "(e.g. $L for one full secondary-code period); " *
+                "(2) set num_coherently_integrated_code_periods = 1 and raise " *
+                "num_noncoherent_accumulations for a robust sign at coarser Doppler resolution; or " *
+                "(3) set use_secondary_code = false to opt out of the rotation search."))
         end
     end
 

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -551,7 +551,7 @@ function plan_acquire(
 
     # Pre-allocate concrete-typed results buffer to avoid boxing allocations in acquire!
     dummy_result = AcquisitionResults(
-        system, 0, convert(typeof(1.0Hz), sampling_freq), 0.0Hz, 0.0, 0.0,
+        system, 0, convert(typeof(1.0Hz), sampling_freq), 0.0Hz, 0.0, nothing, 0.0,
         0f0, 0f0, 0, nothing, doppler_freqs, num_blocks, block_size)
     acq_results_buf = Vector{typeof(dummy_result)}(undef, length(prns))
 

--- a/test/plan.jl
+++ b/test/plan.jl
@@ -86,6 +86,40 @@ end
     @test occursin("10", msg)                     # L
 end
 
+@testset "plan_acquire — partial secondary period rejected (Doppler sign ambiguity, #68)" begin
+    # Issue #68: GPS L5I has NH10 (L = 10). A partial-secondary-period coherent length
+    # (e.g. N = 5, the user's natural 5 ms choice) makes the rotation search produce a
+    # ±Doppler sign ambiguity — a near-equal mirror peak at -f whose sign flips at random
+    # under noise. With use_secondary_code = true (the default), plan_acquire must reject
+    # any N that is not a whole multiple of L > 1.
+    err = try
+        plan_acquire(GPSL5I(), 10.24e6Hz, [1];
+            min_doppler_coverage = 1_000Hz, num_coherently_integrated_code_periods = 5)
+        nothing
+    catch e
+        e
+    end
+    @test err isa ArgumentError
+    msg = sprint(showerror, err)
+    @test occursin("secondary", lowercase(msg))
+    @test occursin("5", msg)                       # offending N
+    @test occursin("10", msg)                      # L
+    @test occursin("68", msg)                       # references the issue
+    # All three documented remedies are present in the message.
+    @test occursin("num_coherently_integrated_code_periods", msg)
+    @test occursin("num_noncoherent_accumulations", msg)
+    @test occursin("use_secondary_code", msg)
+
+    # Full secondary period (N = L) is accepted, and opting out at the partial period is
+    # accepted (no rotation search → no ambiguity).
+    @test plan_acquire(GPSL5I(), 10.24e6Hz, [1];
+        min_doppler_coverage = 1_000Hz,
+        num_coherently_integrated_code_periods = 10).num_secondary_rotations == 10
+    @test plan_acquire(GPSL5I(), 10.24e6Hz, [1];
+        min_doppler_coverage = 1_000Hz, num_coherently_integrated_code_periods = 5,
+        use_secondary_code = false).num_secondary_rotations == 1
+end
+
 @testset "plan_acquire — secondary-code search cap (L1C_P)" begin
     # L1C-P has L=1800 ≫ default cap of 32. With use_secondary_code=true (default) and
     # N > 1, plan_acquire must throw with an actionable message *before* allocating any

--- a/test/secondary_code_search.jl
+++ b/test/secondary_code_search.jl
@@ -69,6 +69,20 @@ end
             # Rotation discovery: with the search active, the peak should clear the opt-out
             # baseline by a substantial margin, regardless of NH10 starting phase.
             @test peak_on > 5 * peak_off
+            # The recovered secondary-code phase must equal the planted rotation r
+            # (the NH10 chip the integration window started on). Locks the
+            # `rotation_block → secondary_code_phase` decode convention.
+            @test results_on[1].secondary_code_phase == r
+        end
+
+        # When no rotation search runs the field is `nothing`, not an integer:
+        # use_secondary_code = false (opt-out)…
+        @test acquire!(plan_off, ref_signal, [prn])[1].secondary_code_phase === nothing
+        # …and a signal with no secondary code at all (L1 C/A, L = 1).
+        let l1 = GPSL1CA()
+            l1plan = plan_acquire(l1, 5e6Hz, [1]; num_coherently_integrated_code_periods = 1)
+            l1sig = ComplexF32.(randn(ComplexF64, l1plan.samples_per_code))
+            @test acquire!(l1plan, l1sig, [1])[1].secondary_code_phase === nothing
         end
     end
 

--- a/test/secondary_code_search.jl
+++ b/test/secondary_code_search.jl
@@ -199,6 +199,92 @@ end
         @test abs(result.carrier_doppler / 1Hz - ustrip(Hz, true_doppler)) < ustrip(Hz, step(plan.doppler_freqs))
     end
 
+    @testset "L5I rotation search — multi-symbol N≥2L (data-bit × rotation; segfault regression)" begin
+        # ──────────────────────────────────────────────────────────────────────
+        # Regression for the buffer-overflow segfault when BOTH the data-bit
+        # search and the rotation search are active (N ≥ 2·L). At N = 20 on L5I
+        # (L = 10) the kernel enumerates num_data_combos(2) × num_secondary_
+        # rotations(10) = 20 pattern columns, but the noncoherent buffer's cp
+        # axis is only widened by num_secondary_rotations = 10. The kernel used
+        # to write `dest_col = col + (q-1)*samples_per_code` for all 20 patterns,
+        # overrunning the 10-block buffer → out-of-bounds write → segfault. No
+        # prior test exercised this: every other rotation test uses N = 10
+        # (num_data_bits = 1), so num_data_combos = 1 and pattern index == rotation
+        # index. The fix maps each pattern back to its rotation block and collapses
+        # the data-bit polarities sharing a rotation by a cell-wise max (the data
+        # sign is a nuisance hypothesis, exactly as the non-rotation kernel treats
+        # it). This test plants a genuine data-bit sign flip between the two 10 ms
+        # symbols so the data-combo max must pick the correct polarity to detect.
+        system        = GPSL5I()
+        sampling_freq = 12e6Hz
+        prn           = 1
+        true_doppler  = 1000Hz        # on the 50 Hz grid at N = 20
+        true_cp       = 1234.5
+        N = 20; L = 10
+
+        fc  = get_code_frequency(system)
+        spc = ceil(Int, get_code_length(system) / fc * sampling_freq)
+        sec = get_secondary_code(system)
+        primary = ComplexF32.(gen_code(spc, system, prn, sampling_freq, fc, true_cp))
+
+        signal = ComplexF32[]
+        for k in 0:N-1
+            nh10      = Float32(GNSSSignals.secondary_value(sec, prn, mod(k, L)))
+            data_sign = k < L ? 1.0f0 : -1.0f0   # bit flip between the two symbols
+            append!(signal, (nh10 * data_sign) .* primary)
+        end
+        ω = 2π * ustrip(Hz, true_doppler) / ustrip(Hz, sampling_freq)
+        signal .*= ComplexF32.(cis.(ω .* (0:length(signal)-1)))
+
+        plan = plan_acquire(system, sampling_freq, [prn];
+            num_coherently_integrated_code_periods = N, num_noncoherent_accumulations = 1)
+        @test plan.num_secondary_rotations == L   # rotation search active
+        @test plan.num_data_bits == N ÷ L         # data-bit search active (= 2)
+
+        result = acquire!(plan, signal, prn; interm_freq = 0.0Hz)   # must not segfault
+
+        @test is_detected(result)
+        @test result.code_phase ≈ true_cp atol = 1.0
+        @test abs(result.carrier_doppler / 1Hz - ustrip(Hz, true_doppler)) < ustrip(Hz, step(plan.doppler_freqs))
+        # NH10 starts at chip 0 here (mod(k, L)); the estimator must recover it even
+        # across the data-bit boundary at the 10 ms mark.
+        @test result.secondary_code_phase == 0
+    end
+
+    @testset "secondary_code_phase is exact across code phase & Doppler (estimator)" begin
+        # `_estimate_secondary_code_phase` despreads the first L per-period prompt
+        # correlations at the recovered (doppler, code_phase) — exact at every code
+        # phase, unlike the raw FM-DBZP rotation index which is ±1 at worst-case code
+        # phases (primary-code wrap mid-block). This sweep is the regression guard for
+        # that fix: a non-zero code phase like 5115 (the documented worst case) and a
+        # mid-grid Doppler used to mis-report the secondary phase by one chip.
+        system        = GPSL5I()
+        sampling_freq = 12e6Hz
+        prn           = 1
+        N = 10; L = 10
+        fc  = get_code_frequency(system)
+        spc = ceil(Int, get_code_length(system) / fc * sampling_freq)
+        sec = get_secondary_code(system)
+        plan = plan_acquire(system, sampling_freq, [prn];
+            num_coherently_integrated_code_periods = N, num_noncoherent_accumulations = 1)
+
+        @testset "r0=$r0, cp=$cp, dop=$dop" for r0 in (0, 3, 7, 9),
+                                                 cp in (0.0, 2000.0, 5115.0, 9000.0),
+                                                 dop in (0.0, 1300.0)
+            primary = ComplexF32.(gen_code(spc, system, prn, sampling_freq, fc, cp))
+            signal = ComplexF32[]
+            for k in 0:N-1
+                append!(signal, Float32(GNSSSignals.secondary_value(sec, prn, mod(k + r0, L))) .* primary)
+            end
+            if dop != 0.0
+                ω = 2π * dop / ustrip(Hz, sampling_freq)
+                signal .*= ComplexF32.(cis.(ω .* (0:length(signal)-1)))
+            end
+            result = acquire!(plan, signal, prn; interm_freq = 0.0Hz)
+            @test result.secondary_code_phase == r0
+        end
+    end
+
     @testset "L5I rotation search — correct Doppler/code-phase with non-zero code drift (N_nc>1)" begin
         # Locks the sign-search path's drift correction. `_apply_code_drift!` is
         # currently called per non-coherent step with a sorted-row buf; any future


### PR DESCRIPTION
Closes #68.

## Summary

Fixes the ±Doppler sign ambiguity in the secondary-code rotation search, fixes a related latent segfault found while benchmarking, and exposes the recovered secondary-code phase for tracking hand-off. Three logically-separate commits.

### 1. Reject partial secondary-code periods (#68)
The rotation search produces a near-equal mirror peak at `-f` when `num_coherently_integrated_code_periods` (N) isn't a whole multiple of the secondary-code length `L` (e.g. 5 ms on GPS L5I, NH10 `L=10`). The acquired Doppler then keeps a stable magnitude but flips sign at random under noise, seeding tracking ~`2|f|` off.

This is fundamental to partial-period despreading, not a coding bug: with the *correct* rotation the matched filter has no mirror, but searching all `L` rotations gives `L` chances for a *wrong* rotation's partial cross-correlation to fit a frequency-mirrored carrier almost as well as the truth. It cancels only over a full secondary-code period (bounded periodic autocorrelation) — confirmed empirically (`+f/-f` ratio 1.12 at N=5 vs 159 at N=10). The existing `N > L` divisibility check is extended to require `N % L == 0` whenever the rotation search is active, with an actionable error.

### 2. Exact `secondary_code_phase` in `AcquisitionResults`
New `secondary_code_phase::Union{Int,Nothing}` field — the secondary-code chip the coherent window started on (`0:L-1`), for seeding a tracking loop's secondary-code alignment. The raw FM-DBZP rotation index is ±1 at worst-case code phases (chip and sub-chip code phase entangle in the factored search), so it's estimated *exactly* by despreading the first `L` per-period prompt correlations at the recovered `(doppler, code_phase)` and taking `argmax` over rotations — verified exact across all phases × code phases × Dopplers. Gated on detection, so absent PRNs and the non-rotation path pay nothing; `nothing` otherwise.

### 3. Rotation-kernel buffer overflow at N ≥ 2L
When the data-bit search **and** rotation search are both active (e.g. 20 ms on L5I), the kernel enumerated `num_data_combos × num_secondary_rotations` patterns but the buffer's code-phase axis was only widened by `num_secondary_rotations` → out-of-bounds write → segfault. No test covered it (all prior rotation tests used N=10, `num_data_bits=1`). Fixed by mapping each pattern to its rotation block and collapsing data-bit polarities by cell-wise max (the data sign is a nuisance hypothesis); rotations stay distinct cells.

## Verification
- Full suite green (`--check-bounds=yes`); `secondary_code_search` 83 tests (was 33).
- `secondary_code_phase` exact: 820/820 across NH10 phase × code phase × Doppler.
- Regression benchmark: **0%** for absent PRNs and the entire non-rotation path; **+6–7%** per *detected* rotation-path PRN (the estimator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)