### PR TITLE
fix: count secondary-code rotation expansion in get_num_cells (#70)

### DIFF
--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -58,6 +58,8 @@ Results from GNSS signal acquisition for a single PRN.
   - `dopplers`: Doppler frequencies searched
   - `num_blocks::Int`: FM-DBZP number of blocks per code period
   - `block_size::Int`: FM-DBZP samples per block
+  - `num_secondary_rotations::Int`: Secondary-code rotation hypotheses per cell (`1` off
+    the rotation-search path). Part of the CFAR cell count — see [`get_num_cells`](@ref).
 
 # Plotting
 
@@ -95,15 +97,30 @@ struct AcquisitionResults{S<:AbstractGNSSSignal,T,D<:AbstractRange}
     dopplers::D
     num_blocks::Int
     block_size::Int
+    # Number of secondary-code rotation hypotheses searched per (Doppler, code
+    # phase) cell. `1` on every non-rotation path; `get_secondary_code_length(system)`
+    # when the secondary-code rotation search is active. The peak is taken over the
+    # expanded `num_doppler_bins × (samples_per_code × num_secondary_rotations)`
+    # surface, so this factor is part of the CFAR cell count (see `get_num_cells`).
+    num_secondary_rotations::Int
 end
 
 """
     get_num_cells(result::AcquisitionResults) -> Int
 
-Return the number of search cells (Doppler bins × code phases) in the acquisition
-result. This is the `num_cells` argument expected by [`cfar_threshold`](@ref).
+Return the number of search cells in the acquisition result. This is the `num_cells`
+argument expected by [`cfar_threshold`](@ref).
+
+The base grid is Doppler bins × code phases (`num_blocks * block_size == samples_per_code`).
+On the secondary-code rotation-search path the peak is taken over an expanded surface that
+carries `num_secondary_rotations` independent code-phase hypotheses per cell, so the count
+is multiplied by `num_secondary_rotations` (`1` on every non-rotation path). Omitting this
+factor understates the cell count `num_secondary_rotations`-fold, which sets the CFAR
+threshold too low and inflates the realised false-alarm rate (issue #70).
 """
-get_num_cells(result::AcquisitionResults) = length(result.dopplers) * result.num_blocks * result.block_size
+get_num_cells(result::AcquisitionResults) =
+    length(result.dopplers) * result.num_blocks * result.block_size *
+    result.num_secondary_rotations
 
 """
     is_detected(result::AcquisitionResults; pfa=0.01) -> Bool

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -411,7 +411,8 @@ function _extract_result!(plan, scratch, prn, prn_idx, power_bins, signal, inter
         # understates the cell count L-fold, dropping the CFAR threshold enough
         # that pure-noise peaks clear it and the estimator fires on absent PRNs —
         # that was the AcquireSignals/L5I regression. (`num_blocks × block_size ==
-        # samples_per_code`.)
+        # samples_per_code`.) This matches `get_num_cells` of the result built below
+        # — the public `is_detected` undercounted the same way until issue #70.
         num_cells = num_doppler_bins * plan.samples_per_code * plan.num_secondary_rotations
         threshold = cfar_threshold(0.01, num_cells;
             num_noncoherent_integrations = plan.num_noncoherent_accumulations)
@@ -449,6 +450,7 @@ function _extract_result!(plan, scratch, prn, prn_idx, power_bins, signal, inter
         plan.doppler_freqs,
         plan.num_blocks,
         plan.block_size,
+        plan.num_secondary_rotations,
     )
 end
 

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -552,7 +552,7 @@ function plan_acquire(
     # Pre-allocate concrete-typed results buffer to avoid boxing allocations in acquire!
     dummy_result = AcquisitionResults(
         system, 0, convert(typeof(1.0Hz), sampling_freq), 0.0Hz, 0.0, nothing, 0.0,
-        0f0, 0f0, 0, nothing, doppler_freqs, num_blocks, block_size)
+        0f0, 0f0, 0, nothing, doppler_freqs, num_blocks, block_size, num_secondary_rotations)
     acq_results_buf = Vector{typeof(dummy_result)}(undef, length(prns))
 
     # Pre-compute the ±1 sign-pattern matrix once per PRN. The dispatcher in

--- a/test/secondary_code_search.jl
+++ b/test/secondary_code_search.jl
@@ -463,4 +463,65 @@ end
         peak_rot_500, peak_long_500 = peaks_at(500.0)
         @test peak_rot_500 / peak_long_500 > 0.95
     end
+
+    @testset "get_num_cells / is_detected count the rotation expansion (issue #70)" begin
+        # On the rotation-search path the peak is taken over an EXPANDED surface
+        # num_doppler_bins × (samples_per_code × num_secondary_rotations) — L× more
+        # independent cells than the bare Doppler × code-phase grid. `get_num_cells`
+        # (and therefore `is_detected`) used to return only num_doppler_bins ×
+        # samples_per_code, understating the count L-fold → the Bonferroni CFAR
+        # correction was applied for too few cells → threshold too low → realised
+        # false-alarm rate well above the requested pfa, and pure-noise peaks called
+        # "detected". The fix carries `num_secondary_rotations` on the result and folds
+        # it into `get_num_cells`.
+        system        = GPSL5I()
+        sampling_freq = 12e6Hz
+        prn           = 1
+
+        plan = plan_acquire(system, sampling_freq, [prn];
+            num_coherently_integrated_code_periods = 10, num_noncoherent_accumulations = 1)
+        @test plan.num_secondary_rotations == 10   # rotation search active
+
+        (; signal) = generate_test_signal(system, prn;
+            num_samples = 10 * 12000, doppler = 1000Hz, code_phase = 1234.5,
+            sampling_freq, interm_freq = 0.0Hz, CN0 = 45)
+        result = acquire!(plan, signal, prn; interm_freq = 0.0Hz, store_power_bins = true)
+
+        # The expansion factor is carried on the result …
+        @test result.num_secondary_rotations == plan.num_secondary_rotations
+        # … and `get_num_cells` is the full expanded count, which equals the stored
+        # power-surface size (num_doppler_bins × samples_per_code × num_rotations).
+        num_dop = length(result.dopplers)
+        @test get_num_cells(result) ==
+              num_dop * plan.samples_per_code * plan.num_secondary_rotations
+        @test get_num_cells(result) == length(result.power_bins)
+        # It is exactly L× what the pre-fix formula (Doppler × code-phase only) gave.
+        @test get_num_cells(result) ==
+              10 * num_dop * plan.num_blocks * plan.block_size
+
+        # `is_detected` now flips exactly at the expanded-count threshold, the same
+        # threshold the `secondary_code_phase` gate uses — the two were inconsistent
+        # before the fix (the gate already counted the expansion, `is_detected` did not).
+        thr = cfar_threshold(0.01, get_num_cells(result);
+            num_noncoherent_integrations = result.num_noncoherent_integrations)
+        @test is_detected(result; pfa = 0.01) == (result.peak_to_noise_ratio > thr)
+        # A detected rotation peak carries a secondary-code phase; both decisions agree.
+        @test is_detected(result; pfa = 0.01)
+        @test result.secondary_code_phase !== nothing
+    end
+
+    @testset "get_num_cells unchanged off the rotation path (issue #70 regression guard)" begin
+        # The expansion must be a no-op everywhere the rotation search is inactive:
+        # num_secondary_rotations == 1, so `get_num_cells` stays the bare
+        # Doppler × code-phase grid. Guards against the fix changing CFAR statistics
+        # on L1 C/A and the pilot/sign-search paths.
+        system        = GPSL1CA()
+        prn           = 1
+        (; signal, sampling_freq, interm_freq) = generate_test_signal(system, prn)
+        result = only(acquire(system, signal, sampling_freq, [prn]; interm_freq))
+
+        @test result.num_secondary_rotations == 1
+        @test get_num_cells(result) ==
+              length(result.dopplers) * result.num_blocks * result.block_size
+    end
 end


### PR DESCRIPTION
Closes #70. Stacked on #69 (base branch `acquisition-doppler-ambiguity`).

## Summary

On the secondary-code rotation-search path, `get_num_cells` (and therefore `is_detected`) undercounted the number of searched cells by a factor of `num_secondary_rotations`, so the CFAR threshold was set too low and the realised false-alarm rate ran well above the requested `pfa`.

`num_blocks * block_size == samples_per_code`, so

```julia
get_num_cells(result) = length(result.dopplers) * result.num_blocks * result.block_size
```

returned `num_doppler_bins × samples_per_code`. But when the rotation search is active the peak is taken over the **expanded** `power_bins` surface

```
num_doppler_bins × (samples_per_code × num_secondary_rotations)
```

i.e. `num_secondary_rotations`× more independent cells than the count fed to `cfar_threshold`. The Bonferroni-style correction was therefore applied for too few cells → threshold too low → `is_detected` over-reported (GPS L5I NH10 → 10× cells, ~17% lower threshold; pure-noise peaks routinely called "detected").

This also reconciles `is_detected` with the internal `secondary_code_phase` detection gate added in #69, which **already** counted the rotation expansion — the public and internal cell counts disagreed until now.

## Fix

- Carry `num_secondary_rotations::Int` on `AcquisitionResults` (`1` off the rotation path, so **no behavior change** on L1 C/A or any pilot/sign-search path).
- Fold it into `get_num_cells`.
- Populate the field at both construction sites (`_extract_result!`, `dummy_result`).

## Verification

- Full suite green; `secondary_code_search` 93 tests (was 83).
- New regression tests assert `get_num_cells` equals the expanded `num_doppler_bins × samples_per_code × num_secondary_rotations` (== stored `power_bins` size), that `is_detected` flips at the expanded-count threshold consistent with the `secondary_code_phase` gate, and that the count is unchanged off the rotation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
