### PR TITLE
perf: tile FM-DBZP build+reduce, stream result stats at N_nc=1 (no materialised power surface)

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -177,11 +177,12 @@ if _is_fmdbzp && INCLUDE_BATCH_FFT_CROSSOVER
         for N_ms in [1, 5, 10, 20]
             plan = _make_plan(fs, N_ms; prns = [1], num_noncoherent_accumulations = 1)
             ndop = plan.num_coherently_integrated_code_periods * plan.num_blocks
-            # Slot 1 of the scratch pool is the eagerly-built template scratch
-            # (other slots are materialised lazily on claim).
-            cim    = Acquisition._default_scratch(plan).coherent_integration_matrix
+            # The pipeline consumes one (ndop × block_size) tile at a time, so
+            # the crossover question is now batched-tile vs per-column FFTs
+            # over a tile, repeated num_blocks times per PRN.
+            tile    = Acquisition._default_scratch(plan).coherent_tile
             col_buf = Acquisition._default_scratch(plan).col_buf
-            spc    = plan.samples_per_code
+            bsize   = plan.block_size
             group_key = "ndop=$(ndop)_fs=$(fs_label)_N=$(N_ms)ms"
             SUITE["BatchFFTCrossover"][group_key] = BenchmarkGroup()
 
@@ -189,13 +190,13 @@ if _is_fmdbzp && INCLUDE_BATCH_FFT_CROSSOVER
             if plan.col_batch_fft_plan !== nothing
                 batch_plan = plan.col_batch_fft_plan
                 SUITE["BatchFFTCrossover"][group_key]["batched"] =
-                    @benchmarkable mul!($cim, $batch_plan, $cim)
+                    @benchmarkable mul!($tile, $batch_plan, $tile)
             end
 
             col_plan = plan.col_fft_plan
             SUITE["BatchFFTCrossover"][group_key]["individual"] = @benchmarkable begin
-                for c in 1:$spc
-                    copyto!($col_buf, 1, $cim, (c - 1) * $ndop + 1, $ndop)
+                for c in 1:$bsize
+                    copyto!($col_buf, 1, $tile, (c - 1) * $ndop + 1, $ndop)
                     mul!($col_buf, $col_plan, $col_buf)
                 end
             end

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -165,12 +165,13 @@ run with more threads, restart Julia with the desired thread count before callin
 
 The per-thread scratch is small: the acquisition pipeline is *tiled*, producing and
 reducing the correlation surface one `num_doppler_bins × block_size` column block at a
-time, so no per-thread buffer scales with `samples_per_code`. The full Doppler ×
-code-phase power surface is only materialised when you ask for it
-(`store_power_bins = true`, one cached buffer per PRN) or when
-`num_noncoherent_accumulations > 1` (one accumulation matrix per PRN, shared across
-threads). Adding threads therefore adds only tile-sized scratch, not full search
-surfaces.
+time, so at `num_noncoherent_accumulations = 1` no per-thread buffer scales with
+`samples_per_code` at all. The full Doppler × code-phase power surface is only
+materialised when you ask for it (`store_power_bins = true`, one cached buffer per
+PRN) or when `num_noncoherent_accumulations > 1` — and even then the PRN loop runs
+PRN-outer, so only `min(threads, cores, #PRNs)` accumulation surfaces exist, never
+one per PRN. The multistep path additionally caches the signal-block FFTs of all
+segments (16 bytes per signal sample) so no work is recomputed across PRNs.
 
 ## Non-coherent Integration
 

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -163,6 +163,15 @@ of threads available when `plan_acquire` is called. If you create the plan and l
 run with more threads, restart Julia with the desired thread count before calling
 `plan_acquire`.
 
+The per-thread scratch is small: the acquisition pipeline is *tiled*, producing and
+reducing the correlation surface one `num_doppler_bins × block_size` column block at a
+time, so no per-thread buffer scales with `samples_per_code`. The full Doppler ×
+code-phase power surface is only materialised when you ask for it
+(`store_power_bins = true`, one cached buffer per PRN) or when
+`num_noncoherent_accumulations > 1` (one accumulation matrix per PRN, shared across
+threads). Adding threads therefore adds only tile-sized scratch, not full search
+surfaces.
+
 ## Non-coherent Integration
 
 At low CN0, accumulate power across multiple successive signal segments:

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -368,9 +368,9 @@ The reason is that acquisition has two FFT stages with opposite scaling in
   `num_doppler_bins = num_coherently_integrated_code_periods × num_blocks`.
   Total work scales as
   `samples_per_code × num_doppler_bins × log₂(num_doppler_bins)` — it grows
-  roughly *linearly* (× log) in `num_blocks`. The non-coherent accumulation
-  matrix is `num_doppler_bins × samples_per_code`, so its memory traffic
-  scales with `num_blocks` as well.
+  roughly *linearly* (× log) in `num_blocks`. The power reduction sweeps
+  `num_doppler_bins × samples_per_code` cells (streamed tile by tile), so its
+  work scales with `num_blocks` as well.
 
 A concrete comparison at 4 MHz, `num_coherently_integrated_code_periods = 1`:
 
@@ -416,7 +416,9 @@ As a rule of thumb for GPS L1 C/A:
   nearby smooth sizes.
 
 Measured per-PRN `acquire!` times on a Ryzen 7 PRO 5850U (16 threads), GPS
-L1 C/A, `min_doppler_coverage = 10 000 Hz`:
+L1 C/A, `min_doppler_coverage = 10 000 Hz` (measured before the tiled
+pipeline — absolute times are lower now, but the smooth-vs-prime ratios the
+table illustrates are unchanged):
 
 | Sampling freq | `samples_per_code` (factors) | 1 ms coherent | 20 ms coherent |
 |---|---|---|---|
@@ -549,16 +551,23 @@ result_interp = acquire(system, signal, sampling_freq, 1;
 ```
 
 The fit is only applied when the neighbouring bins exceed `√noise_power`
-(so it doesn't chase noise on non-detections), and it costs four extra
-array reads per PRN — negligible compared to the acquisition itself.
+(so it doesn't chase noise on non-detections). With `store_power_bins = true`
+the neighbour cells are read back from the stored surface; without it they are
+recomputed on demand for the up-to-three columns involved — about
+`1/block_size` of one PRN's work, once per PRN. Either way the cost is
+negligible compared to the acquisition itself.
 
 ### Storing the Power Surface
 
 Pass `store_power_bins = true` to keep the full Doppler × code-phase
 correlation matrix in the returned result. It's required for plotting
-(see [Plotting Results](#Plotting-Results)) and useful for post-hoc analysis;
-without it the `power_bins` field is `nothing` and the plan's internal buffer
-is reused across calls to keep acquisitions allocation-free.
+(see [Plotting Results](#Plotting-Results)) and useful for post-hoc analysis.
+Without it the `power_bins` field is `nothing` — and at
+`num_noncoherent_accumulations = 1` the surface is never even computed: the
+peak and noise statistics are reduced on the fly while the pipeline streams
+through the search grid one column block at a time. Opting in allocates one
+cached buffer per PRN on first use, which subsequent calls reuse in place, so
+repeated stored acquisitions stay allocation-free too.
 
 ```julia
 result = acquire!(plan, signal, [1]; store_power_bins = true)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,15 +41,22 @@ This library implements the **FM-DBZP** algorithm from Heckler & Garrison (2009)
 
 The signal segment of length `N = num_coherently_integrated_code_periods × samples_per_code`
 is divided into `num_blocks` equal sub-blocks. A row-wise inverse FFT performs circular
-correlation against each PRN sub-block, filling a 2D coherent integration matrix
+correlation against each PRN sub-block, forming a 2D coherent integration surface
 `(num_doppler_bins × samples_per_code)`. A column-wise FFT then resolves the Doppler
 dimension, producing a power surface that is peak-searched for acquisition.
+
+The implementation never materialises these surfaces: it processes one
+`num_doppler_bins × block_size` column-block tile at a time and reduces the power
+cells on the fly, so memory stays tile-sized (cache-resident) no matter how large
+the search grid is. The full power surface only exists if you request it with
+`store_power_bins = true`.
 
 ## Features
 
 - **FM-DBZP algorithm**: Joint code-phase and Doppler search via 2-D FFT structure
 - **Pre-computed plans**: Reuse FFT plans and buffers across acquisitions with [`plan_acquire`](@ref)
-- **Multi-threaded**: PRNs processed in parallel — start Julia with `-t N` to use N threads
+- **Streaming, tile-based reduction**: The search surface is processed one cache-resident column block at a time — plan memory stays in the MiB range even for wide searches, and the full power surface is only materialised on request (`store_power_bins = true`)
+- **Multi-threaded**: PRNs processed in parallel — start Julia with `-t N` to use N threads; extra threads cost only tile-sized scratch
 - **Non-coherent integration**: Accumulate power across multiple signal segments to improve sensitivity at low CN0
 - **Data bit handling**: Bit-edge search and sign-combination search for coherent integration spanning multiple data bits
 - **Sub-sample interpolation**: Parabolic interpolation for Doppler and code-phase refinement below grid resolution

--- a/src/Acquisition.jl
+++ b/src/Acquisition.jl
@@ -54,7 +54,10 @@ Results from GNSS signal acquisition for a single PRN.
     (`peak_power / noise_power`). Compare against [`cfar_threshold`](@ref) to decide
     if a satellite is present.
   - `num_noncoherent_integrations::Int`: Number of non-coherent integrations performed
-  - `power_bins::Matrix{T}`: Correlation power over Doppler × code phase (for plotting)
+  - `power_bins::Union{Matrix{T}, Nothing}`: Correlation power over Doppler × code phase
+    (for plotting). Only populated when `acquire!` was called with
+    `store_power_bins = true`; `nothing` otherwise — by default the pipeline
+    streams the reduction and never materialises this surface.
   - `dopplers`: Doppler frequencies searched
   - `num_blocks::Int`: FM-DBZP number of blocks per code period
   - `block_size::Int`: FM-DBZP samples per block

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -12,46 +12,12 @@ function _parabolic_interp(left::Real, peak::Real, right::Real)
     (right - left) / denom
 end
 
-function _acquire_prn!(plan::AcquisitionPlan, scratch, prn::Int, accumulation_step_index::Int)
-    prn_idx = findfirst(==(prn), plan.avail_prns)
-    # plan.signal_block_ffts is filled by _precompute_signal_block_ffts! in acquire!
-    # before this loop fires. The build+reduce runs tiled — one FM-DBZP column
-    # block at a time — so the full coherent integration matrix never exists.
-    _accumulate_prn_step_tiled!(
-        plan.noncoherent_integration_matrices[prn_idx],
-        plan,
-        scratch,
-        prn,
-        accumulation_step_index,
-    )
-end
-
-function _acquire_step_threaded!(plan::AcquisitionPlan, prns, accumulation_step_index::Int)
-    @batch per=core for i in eachindex(prns)
-        prn = @inbounds prns[i]
-        scratch, slot = _claim_scratch!(plan)
-        try
-            _acquire_prn!(plan, scratch, prn, accumulation_step_index)
-        finally
-            _release_scratch!(plan, slot)
-        end
-    end
-end
-
-function _acquire_step!(plan::AcquisitionPlan, prns, accumulation_step_index::Int)
-    if length(prns) > 1 && Threads.nthreads() > 1
-        _acquire_step_threaded!(plan, prns, accumulation_step_index)
-    else
-        # Single-threaded: one scratch serves the whole PRN loop.
-        scratch, slot = _claim_scratch!(plan)
-        try
-            for prn in prns
-                _acquire_prn!(plan, scratch, prn, accumulation_step_index)
-            end
-        finally
-            _release_scratch!(plan, slot)
-        end
-    end
+# The (double_block_size, num_coh*num_blocks) slice of the plan's all-segment
+# signal-block FFT cache belonging to 1-based accumulation step `step_idx`.
+@inline function _signal_block_ffts_for_step(plan::AcquisitionPlan, step_idx::Int)
+    cols_per_segment = plan.num_coherently_integrated_code_periods * plan.num_blocks
+    view(plan.signal_block_ffts, :,
+        (step_idx - 1) * cols_per_segment + 1 : step_idx * cols_per_segment)
 end
 
 """
@@ -137,30 +103,26 @@ function _downconvert!(sig_buf, signal, seg_start, segment_length, interm_freq_h
     end
 end
 
-# Multistep path (current pre-slice-4 behaviour, factored out unchanged).
+# Multistep path (N_nc > 1), PRN-outer: the per-segment signal-block FFTs are
+# precomputed once for ALL segments (same total FFT work as the former
+# per-segment cache — no recompute anywhere), then each parallel chunk carries
+# one PRN through every accumulation step against its claimed scratch slot's
+# accumulator and extracts the result before moving to the next PRN. This
+# bounds the number of live power surfaces by `min(nthreads, num_cores,
+# num_prns)` instead of one per PRN, and removes the per-step thread barriers
+# the former segment-outer loop needed.
 function _acquire_multistep!(plan, signal, prns, segment_length, interm_freq_hz,
                               sampling_freq_hz, subsample_interpolation, store_power_bins)
-    # Reset per-PRN noncoherent accumulators for the requested PRNs.
-    for prn in prns
-        prn_idx = findfirst(==(prn), plan.avail_prns)
-        fill!(plan.noncoherent_integration_matrices[prn_idx], 0f0)
-    end
-
-    # The downconverted segment lives in the plan's single `sig_buf` (it is
-    # filled before the per-PRN parallel loop, so one instance suffices); the
-    # per-FFT temp comes from thread 1's scratch slot — `_default_scratch(plan)`
-    # names that convention.
+    # Fill the all-segment signal-block FFT cache. The downconverted segment
+    # lives in the plan's single `sig_buf`; the per-FFT temp comes from thread
+    # 1's scratch slot — `_default_scratch(plan)` names that convention.
     main_scratch = _default_scratch(plan)
     sig_buf = plan.sig_buf
-
     for step_idx in 1:plan.num_noncoherent_accumulations
         seg_start = (step_idx - 1) * segment_length + 1
         _downconvert!(sig_buf, signal, seg_start, segment_length, interm_freq_hz, sampling_freq_hz)
-        # Precompute signal-block FFTs once per dwell. They do not depend on
-        # PRN, so the per-PRN inner loop reads from `plan.signal_block_ffts`
-        # instead of redoing this O(num_coh*num_blocks) FFT batch per PRN.
         _precompute_signal_block_ffts!(
-            plan.signal_block_ffts,
+            _signal_block_ffts_for_step(plan, step_idx),
             sig_buf,
             plan.samples_per_code,
             plan.num_blocks,
@@ -169,7 +131,6 @@ function _acquire_multistep!(plan, signal, prns, segment_length, interm_freq_hz,
             main_scratch.double_block_buf,
             plan.double_block_fft_plan,
         )
-        _acquire_step!(plan, prns, step_idx - 1)
     end
 
     results = resize!(plan.acq_results_buf, length(prns))
@@ -181,10 +142,16 @@ function _acquire_multistep!(plan, signal, prns, segment_length, interm_freq_hz,
     @batch per=core for result_idx in eachindex(prns)
         prn = @inbounds prns[result_idx]
         prn_idx = findfirst(==(prn), plan.avail_prns)
-        power_bins = plan.noncoherent_integration_matrices[prn_idx]
         scratch, slot = _claim_scratch!(plan)
         try
-            results[result_idx] = _extract_result!(plan, scratch, prn, prn_idx, power_bins,
+            accumulator = scratch.noncoherent_accumulator
+            fill!(accumulator, 0f0)
+            for step_idx in 1:plan.num_noncoherent_accumulations
+                _accumulate_prn_step_tiled!(accumulator,
+                    _signal_block_ffts_for_step(plan, step_idx),
+                    plan, scratch, prn, step_idx - 1)
+            end
+            results[result_idx] = _extract_result!(plan, scratch, prn, prn_idx, accumulator,
                 signal, interm_freq_hz,
                 sampling_freq_hz, code_freq_hz, code_length, code_period,
                 num_doppler_bins, doppler_step, subsample_interpolation, store_power_bins)

--- a/src/acquire.jl
+++ b/src/acquire.jl
@@ -14,25 +14,11 @@ end
 
 function _acquire_prn!(plan::AcquisitionPlan, scratch, prn::Int, accumulation_step_index::Int)
     prn_idx = findfirst(==(prn), plan.avail_prns)
-    prn_fft_matrix = plan.prn_conj_ffts[prn]
-
     # plan.signal_block_ffts is filled by _precompute_signal_block_ffts! in acquire!
-    # before this loop fires; we read from it here.
-    _build_coherent_integration_matrix!(
-        scratch.coherent_integration_matrix,
-        plan.signal_block_ffts,
-        prn_fft_matrix,
-        plan.samples_per_code,
-        plan.num_blocks,
-        plan.block_size,
-        plan.num_coherently_integrated_code_periods,
-        scratch.corr_buf,
-        plan.double_block_bfft_plan,
-    )
-
-    _accumulate_noncoherent_integration_step!(
+    # before this loop fires. The build+reduce runs tiled — one FM-DBZP column
+    # block at a time — so the full coherent integration matrix never exists.
+    _accumulate_prn_step_tiled!(
         plan.noncoherent_integration_matrices[prn_idx],
-        scratch.coherent_integration_matrix,
         plan,
         scratch,
         prn,
@@ -122,10 +108,11 @@ function acquire!(
     interm_freq_hz = ustrip(Hz, interm_freq)
     sampling_freq_hz = ustrip(Hz, plan.sampling_freq)
 
-    # The N_nc==1 case fuses build → accumulate → extract per PRN against a
-    # single per-thread accumulator, dropping the 32-PRN-wide noncoherent matrix
-    # vector. The multistep path (N_nc>1) still needs that vector because the
-    # accumulator carries state across signal segments shared between PRNs.
+    # The N_nc==1 case streams build → reduce → extract per PRN: result
+    # statistics are reduced tile by tile and no power surface is materialised
+    # (unless the caller opts in via store_power_bins). The multistep path
+    # (N_nc>1) keeps per-PRN accumulation matrices because the surface carries
+    # state across signal segments.
     if plan.num_noncoherent_accumulations == 1
         _acquire_sequential!(plan, signal, prns, segment_length, interm_freq_hz,
             sampling_freq_hz, subsample_interpolation, store_power_bins)
@@ -159,10 +146,12 @@ function _acquire_multistep!(plan, signal, prns, segment_length, interm_freq_hz,
         fill!(plan.noncoherent_integration_matrices[prn_idx], 0f0)
     end
 
-    # The dwell-level scratch (downconverted segment + per-FFT temp) lives in
-    # thread 1's slot — `_default_scratch(plan)` names that convention.
+    # The downconverted segment lives in the plan's single `sig_buf` (it is
+    # filled before the per-PRN parallel loop, so one instance suffices); the
+    # per-FFT temp comes from thread 1's scratch slot — `_default_scratch(plan)`
+    # names that convention.
     main_scratch = _default_scratch(plan)
-    sig_buf = main_scratch.sig_buf
+    sig_buf = plan.sig_buf
 
     for step_idx in 1:plan.num_noncoherent_accumulations
         seg_start = (step_idx - 1) * segment_length + 1
@@ -206,12 +195,16 @@ function _acquire_multistep!(plan, signal, prns, segment_length, interm_freq_hz,
     return results
 end
 
-# Sequential path used when num_noncoherent_accumulations == 1: one segment,
-# per-PRN fused build → accumulate → extract against a per-thread accumulator.
+# Sequential path used when num_noncoherent_accumulations == 1: per PRN, the
+# tiled build+reduce streams the power cells straight into the result
+# statistics (global peak, per-row sums for the noise estimate) — the
+# (num_doppler_bins × samples_per_code_eff) power surface is only materialised
+# into the per-PRN result buffer when the caller requests it via
+# `store_power_bins = true`.
 function _acquire_sequential!(plan, signal, prns, segment_length, interm_freq_hz,
                                sampling_freq_hz, subsample_interpolation, store_power_bins)
     main_scratch = _default_scratch(plan)
-    sig_buf = main_scratch.sig_buf
+    sig_buf = plan.sig_buf
 
     _downconvert!(sig_buf, signal, 1, segment_length, interm_freq_hz, sampling_freq_hz)
     _precompute_signal_block_ffts!(
@@ -232,59 +225,297 @@ function _acquire_sequential!(plan, signal, prns, segment_length, interm_freq_hz
     num_doppler_bins = length(plan.doppler_freqs)
     doppler_step = step(plan.doppler_freqs)
 
-    # When the simple/pilot routing applies, fuse the column FFT + |x|² + fftshift
-    # row permutation into one pass directly into the accumulator — see
-    # `_accumulate_fftshifted_power_pilot!`. Otherwise (bit edge / data bit search
-    # or secondary-code rotation search) fall back to the unfused
-    # `_accumulate_noncoherent_integration_step!`.
-    rotation_search_active = plan.num_secondary_rotations > 1 &&
-                             plan.num_coherently_integrated_code_periods > 1
-    simple_path = plan.num_data_bits == 1 && plan.bit_edge_search_steps == 1 &&
-                  !rotation_search_active
     @batch per=core for result_idx in eachindex(prns)
         prn = @inbounds prns[result_idx]
         prn_idx = findfirst(==(prn), plan.avail_prns)
         scratch, slot = _claim_scratch!(plan)
         try
-            accumulator = scratch.noncoherent_integration_accumulator
-            fill!(accumulator, 0f0)
+            store_buf = store_power_bins ? _get_result_buffer!(plan, prn_idx) : nothing
 
-            _build_coherent_integration_matrix!(
-                scratch.coherent_integration_matrix,
-                plan.signal_block_ffts,
-                plan.prn_conj_ffts[prn],
-                plan.samples_per_code,
-                plan.num_blocks,
-                plan.block_size,
-                plan.num_coherently_integrated_code_periods,
-                scratch.corr_buf,
-                plan.double_block_bfft_plan,
-            )
-            if simple_path
-                if num_doppler_bins <= BATCH_FFT_THRESHOLD
-                    _accumulate_fftshifted_power_pilot_batched!(
-                        accumulator, scratch.coherent_integration_matrix,
-                        plan.col_batch_fft_plan, plan.samples_per_code, num_doppler_bins)
-                else
-                    _accumulate_fftshifted_power_pilot!(
-                        accumulator, scratch.coherent_integration_matrix,
-                        scratch.col_buf, plan.col_fft_plan,
-                        plan.samples_per_code, num_doppler_bins)
-                end
-            else
-                _accumulate_noncoherent_integration_step!(accumulator, scratch.coherent_integration_matrix,
-                    plan, scratch, prn, 0)
-            end
+            peak_power, peak_doppler_bin, peak_col =
+                _acquire_prn_streamed!(plan, scratch, prn, store_buf)
 
-            results[result_idx] = _extract_result!(plan, scratch, prn, prn_idx, accumulator,
+            results[result_idx] = _extract_result_streamed!(plan, scratch, prn,
+                peak_power, peak_doppler_bin, peak_col, store_buf,
                 signal, interm_freq_hz,
                 sampling_freq_hz, code_freq_hz, code_length, code_period,
-                num_doppler_bins, doppler_step, subsample_interpolation, store_power_bins)
+                num_doppler_bins, doppler_step, subsample_interpolation)
         finally
             _release_scratch!(plan, slot)
         end
     end
     return results
+end
+
+# Fetch (allocating on first use) the cached per-PRN power-surface buffer used
+# when the caller opts in via `store_power_bins = true`. This is the ONLY place
+# the full (num_doppler_bins × samples_per_code_eff) surface is materialised on
+# the sequential path.
+function _get_result_buffer!(plan::AcquisitionPlan, prn_idx::Int)
+    cached = plan.result_buffers[prn_idx]
+    buf = cached === nothing ?
+        Matrix{Float32}(undef, length(plan.doppler_freqs), plan.samples_per_code_eff) :
+        cached
+    plan.result_buffers[prn_idx] = buf
+    return buf
+end
+
+# Streamed per-PRN pipeline for the sequential (N_nc == 1) path: build each
+# coherent tile, transform its columns to the Doppler domain, and reduce every
+# power cell on the fly — global peak (value, row, column), per-row power sums
+# (feeding the OppositeRow noise estimate) and, when the plan's estimator needs
+# them, per-column sums (GlobalMean). Cell values are written out only when
+# `store_buf` is provided. Row/column iteration order matches the sorted-order
+# scan of `_findmax_and_colsums!` exactly, so peak tie-breaking and Float32
+# accumulation order are bit-identical to reducing a materialised surface.
+#
+# Returns `(peak_power, peak_doppler_bin, peak_col)` with `peak_doppler_bin` in
+# sorted-Doppler row order and `peak_col` indexing the effective cp axis
+# (including the rotation-slice offset).
+function _acquire_prn_streamed!(
+    plan::AcquisitionPlan,
+    scratch,
+    prn::Int,
+    store_buf::Union{Nothing,Matrix{Float32}},
+)
+    num_doppler_bins = length(plan.doppler_freqs)
+    block_size = plan.block_size
+    rotation_active = plan.num_secondary_rotations > 1 &&
+                      plan.num_coherently_integrated_code_periods > 1
+    simple_path = plan.num_data_bits == 1 && plan.bit_edge_search_steps == 1 &&
+                  !rotation_active
+    row_sums = scratch.row_sums_buf
+    fill!(row_sums, 0f0)
+    col_sums = scratch.col_sums_buf
+    collect_col_sums = !isempty(col_sums)
+    prn_conj_fft = plan.prn_conj_ffts[prn]
+    tile = scratch.coherent_tile
+
+    peak_power = -Inf32
+    peak_doppler_bin = 1
+    peak_col = 1
+
+    if simple_path
+        batched = num_doppler_bins <= BATCH_FFT_THRESHOLD
+        for col_block_idx in 0:plan.num_blocks-1
+            _build_coherent_tile!(tile, plan.signal_block_ffts, prn_conj_fft,
+                col_block_idx, plan.num_blocks, block_size,
+                plan.num_coherently_integrated_code_periods,
+                scratch.corr_buf, plan.double_block_bfft_plan)
+            dest_col_offset = col_block_idx * block_size
+            if batched
+                mul!(tile, plan.col_batch_fft_plan, tile)
+                for local_col in 1:block_size
+                    peak_power, peak_doppler_bin, peak_col = _stream_power_column!(
+                        row_sums, col_sums, collect_col_sums, store_buf,
+                        view(tile, :, local_col), dest_col_offset + local_col,
+                        num_doppler_bins, peak_power, peak_doppler_bin, peak_col)
+                end
+            else
+                col_buf = scratch.col_buf
+                for local_col in 1:block_size
+                    copyto!(col_buf, 1, tile, (local_col - 1) * num_doppler_bins + 1, num_doppler_bins)
+                    mul!(col_buf, plan.col_fft_plan, col_buf)
+                    peak_power, peak_doppler_bin, peak_col = _stream_power_column!(
+                        row_sums, col_sums, collect_col_sums, store_buf,
+                        col_buf, dest_col_offset + local_col,
+                        num_doppler_bins, peak_power, peak_doppler_bin, peak_col)
+                end
+            end
+        end
+    else
+        stage = scratch.stage_buf
+        num_slices = size(stage, 2)
+        samples_per_code = plan.samples_per_code
+        num_data_combos = 1 << (plan.num_data_bits - 1)
+        bit_period_codes = plan.num_coherently_integrated_code_periods ÷ plan.num_data_bits
+        edge_step = bit_period_codes * plan.num_blocks ÷ plan.bit_edge_search_steps
+        use_max = num_data_combos > 1 || plan.bit_edge_search_steps > 1
+        patterns = plan.sign_patterns_by_prn[prn]
+        tiled_re = rotation_active ? plan.tiled_phase_patterns_re_by_prn[prn] :
+            _EMPTY_TILED_PATTERNS
+        tiled_im = rotation_active ? plan.tiled_phase_patterns_im_by_prn[prn] :
+            _EMPTY_TILED_PATTERNS
+        for col_block_idx in 0:plan.num_blocks-1
+            _build_coherent_tile!(tile, plan.signal_block_ffts, prn_conj_fft,
+                col_block_idx, plan.num_blocks, block_size,
+                plan.num_coherently_integrated_code_periods,
+                scratch.corr_buf, plan.double_block_bfft_plan)
+            for local_col in 1:block_size
+                cp_col = col_block_idx * block_size + local_col
+                fill!(stage, 0f0)
+                _fill_sign_stage_column!(stage, tile, local_col, cp_col, plan, scratch,
+                    patterns, tiled_re, tiled_im, rotation_active, num_data_combos,
+                    edge_step, use_max)
+                for s in 0:num_slices-1
+                    peak_power, peak_doppler_bin, peak_col = _stream_stage_column!(
+                        row_sums, col_sums, collect_col_sums, store_buf,
+                        view(stage, :, s + 1), cp_col + s * samples_per_code,
+                        num_doppler_bins, peak_power, peak_doppler_bin, peak_col)
+                end
+            end
+        end
+    end
+    return peak_power, peak_doppler_bin, peak_col
+end
+
+# Reduce one Doppler-domain column (raw FFT row order) into the streaming
+# statistics, folding the fftshift row permutation inline. Iterates destination
+# rows in ascending sorted order — first half [1, shift] from raw bins
+# [front+1, N], second half from [1, front] — so peak tie-breaking and the
+# Float32 order of `col_sum`/`row_sums` additions are identical to scanning a
+# materialised, fftshifted surface row by row.
+@inline function _stream_power_column!(
+    row_sums::Vector{Float32},
+    col_sums::Vector{Float32},
+    collect_col_sums::Bool,
+    store_buf::Union{Nothing,Matrix{Float32}},
+    x::AbstractVector{ComplexF32},
+    dest_col::Int,
+    num_doppler_bins::Int,
+    peak_power::Float32,
+    peak_doppler_bin::Int,
+    peak_col::Int,
+)
+    shift = num_doppler_bins ÷ 2
+    front = num_doppler_bins - shift
+    col_sum = 0f0
+    col_max = -Inf32
+    col_max_row = 1
+    @inbounds for r in front+1:num_doppler_bins
+        v = abs2(x[r])
+        dst = r - front
+        row_sums[dst] += v
+        col_sum += v
+        if v > col_max
+            col_max = v
+            col_max_row = dst
+        end
+    end
+    @inbounds for r in 1:front
+        v = abs2(x[r])
+        dst = r + shift
+        row_sums[dst] += v
+        col_sum += v
+        if v > col_max
+            col_max = v
+            col_max_row = dst
+        end
+    end
+    collect_col_sums && (col_sums[dest_col] = col_sum)
+    if store_buf !== nothing
+        @inbounds for r in front+1:num_doppler_bins
+            store_buf[r - front, dest_col] = abs2(x[r])
+        end
+        @inbounds for r in 1:front
+            store_buf[r + shift, dest_col] = abs2(x[r])
+        end
+    end
+    if col_max > peak_power
+        return col_max, col_max_row, dest_col
+    end
+    return peak_power, peak_doppler_bin, peak_col
+end
+
+# Streaming consumer for one sign-search stage column (already |x|² in sorted
+# row order): same statistics update as `_stream_power_column!` without the
+# fftshift fold.
+@inline function _stream_stage_column!(
+    row_sums::Vector{Float32},
+    col_sums::Vector{Float32},
+    collect_col_sums::Bool,
+    store_buf::Union{Nothing,Matrix{Float32}},
+    stage_col::AbstractVector{Float32},
+    dest_col::Int,
+    num_doppler_bins::Int,
+    peak_power::Float32,
+    peak_doppler_bin::Int,
+    peak_col::Int,
+)
+    col_sum = 0f0
+    col_max = -Inf32
+    col_max_row = 1
+    @inbounds for r in 1:num_doppler_bins
+        v = stage_col[r]
+        row_sums[r] += v
+        col_sum += v
+        if v > col_max
+            col_max = v
+            col_max_row = r
+        end
+    end
+    collect_col_sums && (col_sums[dest_col] = col_sum)
+    if store_buf !== nothing
+        @inbounds for r in 1:num_doppler_bins
+            store_buf[r, dest_col] = stage_col[r]
+        end
+    end
+    if col_max > peak_power
+        return col_max, col_max_row, dest_col
+    end
+    return peak_power, peak_doppler_bin, peak_col
+end
+
+# Recompute the Doppler-power column `global_col` (index into the effective cp
+# axis, i.e. including the rotation-slice offset) into `dest`, in sorted-Doppler
+# row order. Rebuilds the one tile the column lives in — num_doppler_bins
+# double-block IFFTs plus one column reduction, ~1/block_size of a full PRN
+# pass — so subsample interpolation can read peak-neighbour cells without the
+# power surface ever having been materialised. Used only when store_power_bins
+# is off (otherwise the neighbours are read back from the stored buffer).
+function _recompute_column_power!(
+    dest::Vector{Float32},
+    plan::AcquisitionPlan,
+    scratch,
+    prn::Int,
+    global_col::Int,
+)
+    num_doppler_bins = length(plan.doppler_freqs)
+    samples_per_code = plan.samples_per_code
+    block_size = plan.block_size
+    cp_col0 = (global_col - 1) % samples_per_code       # 0-based cp column
+    rotation_idx = (global_col - 1) ÷ samples_per_code
+    col_block_idx = cp_col0 ÷ block_size
+    local_col = cp_col0 % block_size + 1
+    tile = scratch.coherent_tile
+    _build_coherent_tile!(tile, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+        col_block_idx, plan.num_blocks, block_size,
+        plan.num_coherently_integrated_code_periods,
+        scratch.corr_buf, plan.double_block_bfft_plan)
+    rotation_active = plan.num_secondary_rotations > 1 &&
+                      plan.num_coherently_integrated_code_periods > 1
+    simple_path = plan.num_data_bits == 1 && plan.bit_edge_search_steps == 1 &&
+                  !rotation_active
+    if simple_path
+        col_buf = scratch.col_buf
+        copyto!(col_buf, 1, tile, (local_col - 1) * num_doppler_bins + 1, num_doppler_bins)
+        mul!(col_buf, plan.col_fft_plan, col_buf)
+        shift = num_doppler_bins ÷ 2
+        front = num_doppler_bins - shift
+        @inbounds for r in front+1:num_doppler_bins
+            dest[r - front] = abs2(col_buf[r])
+        end
+        @inbounds for r in 1:front
+            dest[r + shift] = abs2(col_buf[r])
+        end
+    else
+        stage = scratch.stage_buf
+        fill!(stage, 0f0)
+        num_data_combos = 1 << (plan.num_data_bits - 1)
+        bit_period_codes = plan.num_coherently_integrated_code_periods ÷ plan.num_data_bits
+        edge_step = bit_period_codes * plan.num_blocks ÷ plan.bit_edge_search_steps
+        use_max = num_data_combos > 1 || plan.bit_edge_search_steps > 1
+        patterns = plan.sign_patterns_by_prn[prn]
+        tiled_re = rotation_active ? plan.tiled_phase_patterns_re_by_prn[prn] :
+            _EMPTY_TILED_PATTERNS
+        tiled_im = rotation_active ? plan.tiled_phase_patterns_im_by_prn[prn] :
+            _EMPTY_TILED_PATTERNS
+        _fill_sign_stage_column!(stage, tile, local_col, cp_col0 + 1, plan, scratch,
+            patterns, tiled_re, tiled_im, rotation_active, num_data_combos,
+            edge_step, use_max)
+        dest .= view(stage, :, rotation_idx + 1)
+    end
+    return dest
 end
 
 # Exact secondary-code phase estimate. The FM-DBZP rotation index (`rotation_block`)
@@ -427,10 +658,7 @@ function _extract_result!(plan, scratch, prn, prn_idx, power_bins, signal, inter
     end
 
     result_buf = if store_power_bins
-        cached = plan.result_buffers[prn_idx]
-        buf = cached === nothing ? similar(power_bins) : cached
-        plan.result_buffers[prn_idx] = buf
-        copyto!(buf, power_bins)
+        copyto!(_get_result_buffer!(plan, prn_idx), power_bins)
     else
         nothing
     end
@@ -447,6 +675,114 @@ function _extract_result!(plan, scratch, prn, prn_idx, power_bins, signal, inter
         Float32(peak_to_noise),
         plan.num_noncoherent_accumulations,
         result_buf,
+        plan.doppler_freqs,
+        plan.num_blocks,
+        plan.block_size,
+        plan.num_secondary_rotations,
+    )
+end
+
+# Streamed-path counterpart of `_extract_result!`: assembles an
+# AcquisitionResults from the statistics reduced on the fly by
+# `_acquire_prn_streamed!` — no power surface is read. The noise power comes
+# from the streamed per-row sums (OppositeRow: mean of the row half the grid
+# away from the peak) or per-column sums (GlobalMean); peak-neighbour cells for
+# subsample interpolation are read back from the stored buffer when available,
+# else recomputed on demand for the up-to-three columns involved
+# (`_recompute_column_power!`).
+function _extract_result_streamed!(plan, scratch, prn,
+                                   peak_power, peak_doppler_bin, peak_col,
+                                   store_buf, signal, interm_freq_hz,
+                                   sampling_freq_hz, code_freq_hz, code_length, code_period,
+                                   num_doppler_bins, doppler_step, subsample_interpolation)
+    num_cp_cols = plan.samples_per_code_eff
+    noise_power = if plan.noise_estimator isa GlobalMeanNoiseEstimator
+        samples_per_chip = floor(Int, sampling_freq_hz / code_freq_hz)
+        _global_mean_from_colsums(scratch.col_sums_buf, num_doppler_bins,
+            peak_col, samples_per_chip)
+    else
+        # OppositeRow: mean of the Doppler row exactly half the search grid away
+        # from the peak — noise-only by construction (see est_signal_noise_power).
+        opp_row = mod(peak_doppler_bin - 1 + num_doppler_bins ÷ 2, num_doppler_bins) + 1
+        scratch.row_sums_buf[opp_row] / Float32(num_cp_cols)
+    end
+    signal_power = peak_power - noise_power
+
+    peak_to_noise = (signal_power + noise_power) / noise_power
+    CN0 = 10 * log10(signal_power / noise_power / code_period / 1.0Hz)
+
+    # Decode the effective-cp-axis peak column into (cp_within, rotation) — see
+    # `_extract_result!` for the layout.
+    samples_per_code = plan.samples_per_code
+    rotation_block = (peak_col - 1) ÷ samples_per_code
+    scrambled_col = (peak_col - 1) % samples_per_code
+    delay_samples = _fmdbzp_column_to_tau(scrambled_col, plan.num_blocks, plan.block_size)
+    code_phase = mod(-delay_samples * code_freq_hz / sampling_freq_hz, code_length)
+
+    doppler = plan.doppler_freqs[peak_doppler_bin]
+
+    if subsample_interpolation
+        # Neighbouring columns must stay within the SAME rotation block
+        # (different blocks correspond to different secondary-code hypotheses
+        # and aren't physically adjacent in cp).
+        num_code_bins = samples_per_code
+        col_left  = mod(scrambled_col - 1, num_code_bins) + rotation_block * samples_per_code
+        col_right = mod(scrambled_col + 1, num_code_bins) + rotation_block * samples_per_code
+        dop_row_left  = peak_doppler_bin == 1 ? num_doppler_bins : peak_doppler_bin - 1
+        dop_row_right = peak_doppler_bin == num_doppler_bins ? 1 : peak_doppler_bin + 1
+        local power_left::Float32, power_right::Float32
+        local dop_left::Float32, dop_right::Float32
+        if store_buf !== nothing
+            power_left  = store_buf[peak_doppler_bin, col_left + 1]
+            power_right = store_buf[peak_doppler_bin, col_right + 1]
+            dop_left  = store_buf[dop_row_left, peak_col]
+            dop_right = store_buf[dop_row_right, peak_col]
+        else
+            col_power = scratch.col_power_buf
+            _recompute_column_power!(col_power, plan, scratch, prn, peak_col)
+            dop_left  = col_power[dop_row_left]
+            dop_right = col_power[dop_row_right]
+            power_left  = _recompute_column_power!(col_power, plan, scratch, prn, col_left + 1)[peak_doppler_bin]
+            power_right = _recompute_column_power!(col_power, plan, scratch, prn, col_right + 1)[peak_doppler_bin]
+        end
+        if max(power_left, power_right) > sqrt(noise_power)
+            fractional_col_offset = _parabolic_interp(power_left, peak_power, power_right)
+            delay_samples_interp = delay_samples + fractional_col_offset
+            code_phase = mod(-delay_samples_interp * code_freq_hz / sampling_freq_hz, code_length)
+        end
+        if max(dop_left, dop_right) > sqrt(noise_power)
+            fractional_doppler_offset = _parabolic_interp(dop_left, peak_power, dop_right)
+            doppler = doppler + fractional_doppler_offset * doppler_step
+        end
+    end
+
+    # Exact secondary-code phase — same gate and estimator as `_extract_result!`.
+    secondary_code_phase = if plan.num_secondary_rotations > 1
+        num_cells = num_doppler_bins * plan.samples_per_code * plan.num_secondary_rotations
+        threshold = cfar_threshold(0.01, num_cells;
+            num_noncoherent_integrations = plan.num_noncoherent_accumulations)
+        if peak_to_noise > threshold
+            _estimate_secondary_code_phase(plan, prn, signal, interm_freq_hz,
+                sampling_freq_hz, code_phase, ustrip(Hz, doppler))
+        else
+            nothing
+        end
+    else
+        nothing
+    end
+
+    return AcquisitionResults(
+        plan.system,
+        prn,
+        plan.sampling_freq,
+        doppler,
+        code_phase,
+        secondary_code_phase,
+        CN0,
+        Float32(noise_power),
+        Float32(peak_to_noise),
+        plan.num_noncoherent_accumulations,
+        store_buf,
         plan.doppler_freqs,
         plan.num_blocks,
         plan.block_size,

--- a/src/coherent_integration.jl
+++ b/src/coherent_integration.jl
@@ -49,7 +49,9 @@ end
 
 Fill `coherent_integration_matrix` (size `(num_coherently_integrated_code_periods*num_blocks, samples_per_code)`) with double-block correlation results, given precomputed signal-block FFTs.
 
-This is the per-PRN inner kernel. Signal FFTs do not depend on PRN, so they
+Reference/test form of the per-PRN build: the production pipeline builds and
+consumes one column-block tile at a time via [`_build_coherent_tile!`](@ref)
+instead of materialising this matrix. Signal FFTs do not depend on PRN, so they
 are computed once per `acquire!` call by [`_precompute_signal_block_ffts!`](@ref)
 and reused across all PRNs.
 
@@ -75,7 +77,7 @@ column index `pc` (0-indexed) satisfies:
     tau_samples = (num_blocks - pc ÷ block_size) mod num_blocks * block_size + pc mod block_size
 """
 function _build_coherent_integration_matrix!(
-    coherent_integration_matrix::Matrix{ComplexF32},
+    coherent_integration_matrix::AbstractMatrix{ComplexF32},
     signal_block_ffts::Matrix{ComplexF32},  # (double_block_size, num_coh*num_blocks) — precomputed
     prn_conj_fft_matrix::Matrix{ComplexF32},  # (double_block_size, num_blocks), already conjugated
     samples_per_code::Int,
@@ -85,33 +87,71 @@ function _build_coherent_integration_matrix!(
     corr_buf::Vector{ComplexF32},
     bfft_plan,
 )
+    # Reference/test entry point: materialises the full matrix by looping the
+    # tiled builder over every column block. The production pipeline never
+    # calls this — it builds one (num_doppler_bins, block_size) tile at a time
+    # via `_build_coherent_tile!` and reduces it immediately.
+    for col_block_idx in 0:num_blocks-1
+        col_start = col_block_idx * block_size + 1
+        tile = view(coherent_integration_matrix, :, col_start:col_start + block_size - 1)
+        _build_coherent_tile!(tile, signal_block_ffts, prn_conj_fft_matrix,
+            col_block_idx, num_blocks, block_size,
+            num_coherently_integrated_code_periods, corr_buf, bfft_plan)
+    end
+    return coherent_integration_matrix
+end
+
+"""
+    _build_coherent_tile!(tile, signal_block_ffts, prn_conj_fft_matrix, col_block_idx,
+                          num_blocks, block_size, num_coherently_integrated_code_periods,
+                          corr_buf, bfft_plan)
+
+Fill `tile` (size `(num_coh*num_blocks, block_size)`) with column block
+`col_block_idx` (0-based) of the coherent integration matrix — i.e. columns
+`col_block_idx*block_size+1 .. (col_block_idx+1)*block_size` of the full
+surface. Row `global_block_idx + 1` holds the first `block_size` lags of the
+correlation of signal double-block `global_block_idx` with PRN sub-block
+`(block_idx + col_block_idx) mod num_blocks` (see
+[`_build_coherent_integration_matrix!`](@ref) for the full structure and delay
+recovery).
+
+This is the unit of work of the tiled pipeline: every downstream consumer
+(column FFT, sign search, rotation search) is column-oriented, so the full
+`(num_doppler_bins, samples_per_code)` matrix never needs to exist — each tile
+is built, reduced, and overwritten by the next one. The tile is `num_blocks`×
+smaller than the full matrix and typically L2-cache resident, which also spares
+the column FFTs a round-trip through DRAM.
+"""
+function _build_coherent_tile!(
+    tile::AbstractMatrix{ComplexF32},         # (num_coh*num_blocks, block_size)
+    signal_block_ffts::Matrix{ComplexF32},    # (double_block_size, num_coh*num_blocks) — precomputed
+    prn_conj_fft_matrix::Matrix{ComplexF32},  # (double_block_size, num_blocks), already conjugated
+    col_block_idx::Int,                       # 0-based column block index
+    num_blocks::Int,
+    block_size::Int,
+    num_coherently_integrated_code_periods::Int,
+    corr_buf::Vector{ComplexF32},
+    bfft_plan,
+)
     double_block_size = 2 * block_size
     inverse_double_block_size = 1f0 / double_block_size
 
-    # No fill!: every cell of `coherent_integration_matrix` is written exactly
-    # once. Outer loops cover all `num_coh × num_blocks` rows, the column loop
-    # tiles all `num_blocks × block_size = samples_per_code` columns.
-
+    # No fill!: every cell of `tile` is written exactly once — the row loops
+    # cover all `num_coh × num_blocks` rows and each IFFT fills a whole row.
     for code_period_idx in 0:num_coherently_integrated_code_periods-1
         for block_idx in 0:num_blocks-1
             global_block_idx = code_period_idx * num_blocks + block_idx   # 0-based
             sig_fft_col = view(signal_block_ffts, :, global_block_idx + 1)
+            prn_block = mod(block_idx + col_block_idx, num_blocks)
 
-            # For each column block: multiply precomputed signal FFT with
-            # conj(PRN sub-block (block_idx+col_block_idx) mod num_blocks).
-            for col_block_idx in 0:num_blocks-1
-                prn_block = mod(block_idx + col_block_idx, num_blocks)
+            # Multiply precomputed signal FFT with the conjugated PRN FFT.
+            corr_buf .= sig_fft_col .* view(prn_conj_fft_matrix, :, prn_block + 1)
 
-                # Multiply precomputed signal FFT with the conjugated PRN FFT.
-                corr_buf .= sig_fft_col .* view(prn_conj_fft_matrix, :, prn_block + 1)
-
-                # Inverse FFT (unnormalised), normalise, keep first block_size.
-                mul!(corr_buf, bfft_plan, corr_buf)
-                col_start = col_block_idx * block_size + 1
-                row = global_block_idx + 1
-                coherent_integration_matrix[row, col_start:col_start + block_size - 1] .=
-                    view(corr_buf, 1:block_size) .* inverse_double_block_size
-            end
+            # Inverse FFT (unnormalised), normalise, keep first block_size lags.
+            mul!(corr_buf, bfft_plan, corr_buf)
+            row = global_block_idx + 1
+            tile[row, 1:block_size] .= view(corr_buf, 1:block_size) .* inverse_double_block_size
         end
     end
+    return tile
 end

--- a/src/coherent_integration.jl
+++ b/src/coherent_integration.jl
@@ -10,7 +10,7 @@ Each column `global_block_idx + 1` of `signal_block_ffts` (size
 PRN loop avoids redoing the same FFT for each of the (typically 32) PRNs.
 """
 function _precompute_signal_block_ffts!(
-    signal_block_ffts::Matrix{ComplexF32},  # (double_block_size, num_coh * num_blocks)
+    signal_block_ffts::AbstractMatrix{ComplexF32},  # (double_block_size, num_coh * num_blocks) — may be one segment slice of the plan's all-segment cache
     signal_f32::Vector{ComplexF32},
     samples_per_code::Int,
     num_blocks::Int,
@@ -78,7 +78,7 @@ column index `pc` (0-indexed) satisfies:
 """
 function _build_coherent_integration_matrix!(
     coherent_integration_matrix::AbstractMatrix{ComplexF32},
-    signal_block_ffts::Matrix{ComplexF32},  # (double_block_size, num_coh*num_blocks) — precomputed
+    signal_block_ffts::AbstractMatrix{ComplexF32},  # (double_block_size, num_coh*num_blocks) — precomputed
     prn_conj_fft_matrix::Matrix{ComplexF32},  # (double_block_size, num_blocks), already conjugated
     samples_per_code::Int,
     num_blocks::Int,
@@ -124,7 +124,7 @@ the column FFTs a round-trip through DRAM.
 """
 function _build_coherent_tile!(
     tile::AbstractMatrix{ComplexF32},         # (num_coh*num_blocks, block_size)
-    signal_block_ffts::Matrix{ComplexF32},    # (double_block_size, num_coh*num_blocks) — precomputed
+    signal_block_ffts::AbstractMatrix{ComplexF32},  # (double_block_size, num_coh*num_blocks) — precomputed
     prn_conj_fft_matrix::Matrix{ComplexF32},  # (double_block_size, num_blocks), already conjugated
     col_block_idx::Int,                       # 0-based column block index
     num_blocks::Int,

--- a/src/noncoherent_integration.jl
+++ b/src/noncoherent_integration.jl
@@ -741,16 +741,18 @@ end
 const _EMPTY_TILED_PATTERNS = Array{Float32,3}(undef, 0, 0, 0)
 
 """
-    _accumulate_prn_step_tiled!(nim, plan, scratch, prn, accumulation_step_index)
+    _accumulate_prn_step_tiled!(nim, signal_block_ffts, plan, scratch, prn, accumulation_step_index)
 
 One PRN × one non-coherent step of the multistep (N_nc > 1) pipeline, tiled:
-for each FM-DBZP column block, build the coherent tile and accumulate its power
-into the per-PRN matrix `nim` — via the fused pilot kernels on the simple path
-or the per-column sign-search/rotation kernels otherwise. Code drift is folded
-into the destination columns; no intermediate surface is materialised.
+for each FM-DBZP column block, build the coherent tile from the step's
+`signal_block_ffts` slice and accumulate its power into `nim` — via the fused
+pilot kernels on the simple path or the per-column sign-search/rotation kernels
+otherwise. Code drift is folded into the destination columns; no intermediate
+surface is materialised.
 """
 function _accumulate_prn_step_tiled!(
     nim::Matrix{Float32},
+    signal_block_ffts::AbstractMatrix{ComplexF32},  # this step's (double_block_size, num_coh*num_blocks) slice
     plan::AcquisitionPlan,
     scratch,
     prn::Int,
@@ -766,7 +768,7 @@ function _accumulate_prn_step_tiled!(
     tile = scratch.coherent_tile
 
     for col_block_idx in 0:plan.num_blocks-1
-        _build_coherent_tile!(tile, plan.signal_block_ffts, prn_conj_fft,
+        _build_coherent_tile!(tile, signal_block_ffts, prn_conj_fft,
             col_block_idx, plan.num_blocks, plan.block_size,
             plan.num_coherently_integrated_code_periods,
             scratch.corr_buf, plan.double_block_bfft_plan)

--- a/src/noncoherent_integration.jl
+++ b/src/noncoherent_integration.jl
@@ -1,4 +1,20 @@
 # src/noncoherent_integration.jl
+#
+# The FM-DBZP reduction stage. Production runs TILED: the per-PRN driver
+# (`_accumulate_prn_step_tiled!` at N_nc > 1, `_acquire_prn_streamed!` at
+# N_nc == 1) builds one (num_doppler_bins, block_size) column-block tile of the
+# coherent integration surface at a time and reduces it immediately, so no
+# buffer proportional to `samples_per_code` lives in the per-thread scratch.
+# The kernels here therefore come in two granularities:
+#
+#   - per-column primitives (`_sign_search_column!`, `_rotation_column!`) and
+#     tile consumers (the fused pilot kernels, `_accumulate_sign_tile!`) — the
+#     production hot path;
+#   - full-matrix wrappers (`_sign_search_step!`,
+#     `_sign_search_step_with_rotations!`, `_accumulate_noncoherent_integration_step!`)
+#     that delegate to the primitives column by column. They preserve the
+#     historical single-call semantics for the test suite's kernel-parity
+#     checks and are NOT called from the production pipeline.
 
 """
     _accumulate_noncoherent_integration_pilot!(noncoherent_integration_matrix, coherent_integration_matrix, col_buf, col_fft_plan, samples_per_code)
@@ -6,6 +22,8 @@
 Column-wise FFT path for pilot channels and sub-bit integration (num_data_bits = 1,
 no data bit combination search). Applies fftshift so row indices map to sorted
 `doppler_freqs`, accumulates `|FFT|²` into `noncoherent_integration_matrix` (shape `(num_doppler_bins, samples_per_code)`).
+
+Reference implementation used by tests; production uses the fused kernels below.
 """
 function _accumulate_noncoherent_integration_pilot!(
     noncoherent_integration_matrix::Matrix{Float32},
@@ -25,15 +43,85 @@ function _accumulate_noncoherent_integration_pilot!(
 end
 
 """
+    _sign_search_column!(stage_col, cim, src_col, col_buf, col_fft_plan,
+                         num_doppler_bins, num_data_bits, row_offset, sub_block_ffts, patterns)
+
+Sign-pattern search for ONE code-phase column: computes the `num_data_bits`
+sub-block FFTs of column `src_col` of `cim` (a tile or a full coherent
+integration matrix — either way the column carries all `num_doppler_bins`
+rows), combines them per sign pattern, and max-reduces `|result|²` into
+`stage_col` in **sorted-Doppler row order** (fftshift folded as a top/bottom
+half swap). The caller zeroes `stage_col` once per column; calling again with a
+different `row_offset` folds further bit-edge alignments into the same max.
+
+This is the per-column core of [`_sign_search_step!`](@ref); see that docstring
+for the algorithm.
+"""
+function _sign_search_column!(
+    stage_col::AbstractVector{Float32},
+    cim::AbstractMatrix{ComplexF32},
+    src_col::Int,
+    col_buf::Vector{ComplexF32},
+    col_fft_plan,
+    num_doppler_bins::Int,
+    num_data_bits::Int,
+    row_offset::Int,
+    sub_block_ffts::Matrix{ComplexF32},  # (num_doppler_bins, ≥ num_data_bits)
+    patterns::Matrix{Float32},           # (num_coh_periods, num_patterns)
+)
+    sub_len = num_doppler_bins ÷ num_data_bits   # rows per data bit sub-block
+    num_sign_patterns = size(patterns, 2)
+    coh_per_bit = size(patterns, 1) ÷ num_data_bits
+
+    # Compute num_data_bits sub-block FFTs for this column
+    for bit_idx in 0:num_data_bits-1
+        fill!(col_buf, zero(ComplexF32))
+        for sub_row in 0:sub_len-1
+            src_row = ((row_offset + bit_idx * sub_len + sub_row) % num_doppler_bins) + 1  # 1-indexed
+            col_buf[sub_row + 1] = cim[src_row, src_col]
+        end
+        mul!(col_buf, col_fft_plan, col_buf)
+        sub_block_ffts[:, bit_idx + 1] .= col_buf   # raw FFT order; fftshift folds into the stage write below
+    end
+
+    # Iterate over precomputed sign patterns; sign per data bit from the first row
+    # of that bit's segment in `patterns`. We write directly in sorted-Doppler row
+    # order: fftshift is the top/bottom half swap, so the raw-bin range [1, half]
+    # maps to dst rows [half+1, N] and [half+1, N] maps to [1, half]. Two contiguous
+    # SIMD-friendly half-loops replace what used to be a separate scatter pass.
+    half = num_doppler_bins ÷ 2
+    for p in 1:num_sign_patterns
+        fill!(col_buf, zero(ComplexF32))
+        for bit_idx in 0:num_data_bits-1
+            bit_sign = patterns[bit_idx * coh_per_bit + 1, p]
+            col_buf .+= bit_sign .* view(sub_block_ffts, :, bit_idx + 1)
+        end
+        @inbounds for ω in 1:half
+            cell_power = abs2(col_buf[ω])
+            dst_row = ω + half
+            if cell_power > stage_col[dst_row]
+                stage_col[dst_row] = cell_power
+            end
+        end
+        @inbounds for ω in half+1:num_doppler_bins
+            cell_power = abs2(col_buf[ω])
+            dst_row = ω - half
+            if cell_power > stage_col[dst_row]
+                stage_col[dst_row] = cell_power
+            end
+        end
+    end
+    return stage_col
+end
+
+"""
     _sign_search_step!(noncoherent_integration_buf, coherent_integration_matrix, col_buf, col_fft_plan,
                        samples_per_code, num_doppler_bins, num_data_bits, row_offset, sub_block_ffts, patterns)
 
-Sign-pattern search step for one bit-edge alignment of one non-coherent block. Does *not*
-perform non-coherent accumulation across blocks — that happens at the outer level in
-`_accumulate_noncoherent_integration_step!`. The patterns to enumerate are supplied via
-`patterns` (shape `(num_coh_periods, num_patterns)`), built by [`sign_patterns`](@ref).
-Today's patterns enumerate data-bit polarities only; the same mechanism is intended to
-also enumerate secondary-code rotations in the future (see issue #55).
+Sign-pattern search step for one bit-edge alignment of one non-coherent block over a
+fully materialised coherent integration matrix. Does *not* perform non-coherent
+accumulation across blocks. The patterns to enumerate are supplied via `patterns`
+(shape `(num_coh_periods, num_patterns)`), built by [`sign_patterns`](@ref).
 
 FM-DBZP column-wise FFT for data channels (paper: N_db > 1). For each of the
 samples_per_code columns:
@@ -45,6 +133,9 @@ samples_per_code columns:
    (fftshift folded inline as a top/bottom half-row swap).
 
 `sub_block_ffts` is a pre-allocated (num_doppler_bins, num_data_bits) scratch matrix.
+
+Reference/test wrapper: delegates to [`_sign_search_column!`](@ref) column by
+column. Production consumes tiles instead and never materialises the full CIM.
 """
 function _sign_search_step!(
     noncoherent_integration_buf::Matrix{Float32},
@@ -58,50 +149,151 @@ function _sign_search_step!(
     sub_block_ffts::Matrix{ComplexF32},  # (num_doppler_bins, num_data_bits)
     patterns::Matrix{Float32},           # (num_coh_periods, num_patterns)
 )
-    sub_len = num_doppler_bins ÷ num_data_bits   # rows per data bit sub-block
-    num_sign_patterns = size(patterns, 2)
-    coh_per_bit = size(patterns, 1) ÷ num_data_bits
-
     for col_idx in 1:samples_per_code
-        # Compute num_data_bits sub-block FFTs for column col_idx
-        for bit_idx in 0:num_data_bits-1
-            fill!(col_buf, zero(ComplexF32))
-            for sub_row in 0:sub_len-1
-                src_row = ((row_offset + bit_idx * sub_len + sub_row) % num_doppler_bins) + 1  # 1-indexed
-                col_buf[sub_row + 1] = coherent_integration_matrix[src_row, col_idx]
-            end
-            mul!(col_buf, col_fft_plan, col_buf)
-            sub_block_ffts[:, bit_idx + 1] .= col_buf   # raw FFT order; output fftshift happens once in `_accumulate_noncoherent_integration_step!`
-        end
+        _sign_search_column!(view(noncoherent_integration_buf, :, col_idx),
+            coherent_integration_matrix, col_idx, col_buf, col_fft_plan,
+            num_doppler_bins, num_data_bits, row_offset, sub_block_ffts, patterns)
+    end
+end
 
-        # Iterate over precomputed sign patterns; sign per data bit from the first row
-        # of that bit's segment in `patterns`. We write directly in sorted-Doppler row
-        # order: fftshift is the top/bottom half swap, so the raw-bin range [1, half]
-        # maps to dst rows [half+1, N] and [half+1, N] maps to [1, half]. Two contiguous
-        # SIMD-friendly half-loops replace what used to be a separate scatter pass.
-        half = num_doppler_bins ÷ 2
-        for p in 1:num_sign_patterns
-            fill!(col_buf, zero(ComplexF32))
-            for bit_idx in 0:num_data_bits-1
-                bit_sign = patterns[bit_idx * coh_per_bit + 1, p]
-                col_buf .+= bit_sign .* view(sub_block_ffts, :, bit_idx + 1)
+"""
+    _rotation_column!(stage, cim, src_col, cp_col, col_buf, combine_buf_re, combine_buf_im,
+                      col_fft_plan, num_doppler_bins, num_coh_periods, num_data_combos,
+                      num_blocks, block_size, row_offset, sub_block_ffts,
+                      tiled_phase_patterns_re, tiled_phase_patterns_im, use_max)
+
+Secondary-code rotation search for ONE code-phase column: computes one sub-block
+FFT per coherent period from column `src_col` of `cim`, combines them with the
+pre-tiled complex phasors, and writes `|result|²` of each pattern into its
+rotation's column of `stage` (shape `(num_doppler_bins, ≥ num_rotations)`), in
+sorted-Doppler row order (fftshift folded).
+
+`cp_col` is the 1-based code-phase column in `[1, samples_per_code]` that
+`src_col` corresponds to — the per-column block alignment (see
+[`_sign_search_step_with_rotations!`](@ref)) depends on the code-phase, not on
+the position within the tile. With `use_max = false` (single alignment, single
+data-bit combo — the dominant case) each cell is a plain SIMD store; otherwise
+patterns max-reduce into the stage, which also folds bit-edge alignments across
+repeated calls. The caller zeroes `stage` once per column.
+
+This is the per-column core of [`_sign_search_step_with_rotations!`](@ref); see
+that docstring for the algorithm, the inter-sub-block phase ramp, and the
+per-column block alignment.
+"""
+function _rotation_column!(
+    stage::AbstractMatrix{Float32},          # (num_doppler_bins, ≥ num_rotation_blocks)
+    cim::AbstractMatrix{ComplexF32},
+    src_col::Int,
+    cp_col::Int,
+    col_buf::Vector{ComplexF32},
+    combine_buf_re::Vector{Float32},
+    combine_buf_im::Vector{Float32},
+    col_fft_plan,
+    num_doppler_bins::Int,
+    num_coh_periods::Int,
+    num_data_combos::Int,
+    num_blocks::Int,
+    block_size::Int,
+    row_offset::Int,
+    sub_block_ffts::Matrix{ComplexF32},
+    tiled_phase_patterns_re::Array{Float32,3},
+    tiled_phase_patterns_im::Array{Float32,3},
+    use_max::Bool,
+)
+    num_sign_patterns = size(tiled_phase_patterns_re, 3)
+    half_block = block_size >> 1
+
+    # Snap the sub-block partition to the primary-code wrap for this column.
+    # `wrap_sample` is the FM-DBZP delay associated with `cp_col`; rounding
+    # to the nearest multiple of block_size aligns sub-block 0 (and hence
+    # every sub-block, by uniform shift) to within ±half_block of an NH10
+    # chip boundary. Cheap (four integer ops per column) and recovers ~6 dB
+    # of coherent gain at the worst code phase.
+    pc = cp_col - 1
+    wrap_sample = ((num_blocks - div(pc, block_size)) % num_blocks) * block_size + (pc % block_size)
+    col_row_offset = div(wrap_sample + half_block, block_size) % num_blocks
+    eff_row_offset = (row_offset + col_row_offset) % num_doppler_bins
+
+    # One sub-block FFT per coherent period (sub-block size = num_blocks).
+    for k in 0:num_coh_periods-1
+        fill!(col_buf, zero(ComplexF32))
+        for sub_row in 0:num_blocks-1
+            src_row = ((eff_row_offset + k * num_blocks + sub_row) % num_doppler_bins) + 1
+            col_buf[sub_row + 1] = cim[src_row, src_col]
+        end
+        mul!(col_buf, col_fft_plan, col_buf)
+        sub_block_ffts[:, k + 1] .= col_buf   # raw FFT order; fftshift folds into the stage write below
+    end
+
+    # Combine sub-block FFTs with the precomputed (ω, p, q)-tiled phasors,
+    # then WRITE each pattern to its ROTATION's stage column in sorted-Doppler
+    # row order. Loop ordering: outer pattern q, middle sub-block p, inner ω.
+    # The complex MAC is unfused into four real `muladd`s so the compiler packs
+    # the inner loop into Float32 SIMD lanes — measured ~3× faster than the
+    # equivalent ComplexF32-storage form.
+    #
+    # fftshift is folded into the row-write here: raw bin ω∈[1, half] maps
+    # to sorted-Doppler row ω+half, and ω∈[half+1, N] maps to ω-half. Two
+    # contiguous SIMD-friendly half-loops.
+    half = num_doppler_bins ÷ 2
+    for q in 1:num_sign_patterns
+        fill!(combine_buf_re, 0f0)
+        fill!(combine_buf_im, 0f0)
+        for p in 1:num_coh_periods
+            @inbounds @simd for ω in 1:num_doppler_bins
+                ar = tiled_phase_patterns_re[ω, p, q]
+                ai = tiled_phase_patterns_im[ω, p, q]
+                br, bi = reim(sub_block_ffts[ω, p])
+                combine_buf_re[ω] = muladd(ar, br, muladd(-ai, bi, combine_buf_re[ω]))
+                combine_buf_im[ω] = muladd(ar, bi, muladd( ai, br, combine_buf_im[ω]))
             end
+        end
+        # Patterns are laid out rotation-major, data-bit-minor (see
+        # `sign_patterns`): pattern q decodes to rotation
+        # `(q-1) ÷ num_data_combos` and data-bit combo `(q-1) % num_data_combos`.
+        # ROTATIONS are distinct secondary-code phases, so each gets its own
+        # stage column (no collapse; preserves the matched-filter CFAR layout).
+        # DATA-BIT polarity is a nuisance hypothesis, so the `num_data_combos`
+        # patterns sharing a rotation are collapsed by a cell-wise MAX.
+        #
+        # `use_max == false` (single alignment, no multi-bit search) is the
+        # dominant case: each pattern is its own rotation and only one alignment
+        # writes, so cells never collide and a plain SIMD store applies. The
+        # read-compare-store max can't vectorise like the pure store, so gating
+        # it keeps the common path at full speed.
+        rotation_idx = (q - 1) ÷ num_data_combos
+        dst_col = rotation_idx + 1
+        if !use_max
+            @inbounds @simd for ω in 1:half
+                stage[ω + half, dst_col] =
+                    muladd(combine_buf_re[ω], combine_buf_re[ω],
+                           combine_buf_im[ω] * combine_buf_im[ω])
+            end
+            @inbounds @simd for ω in half+1:num_doppler_bins
+                stage[ω - half, dst_col] =
+                    muladd(combine_buf_re[ω], combine_buf_re[ω],
+                           combine_buf_im[ω] * combine_buf_im[ω])
+            end
+        else
             @inbounds for ω in 1:half
-                cell_power = abs2(col_buf[ω])
-                dst_row = ω + half
-                if cell_power > noncoherent_integration_buf[dst_row, col_idx]
-                    noncoherent_integration_buf[dst_row, col_idx] = cell_power
+                cell_power = muladd(combine_buf_re[ω], combine_buf_re[ω],
+                                    combine_buf_im[ω] * combine_buf_im[ω])
+                dst = ω + half
+                if cell_power > stage[dst, dst_col]
+                    stage[dst, dst_col] = cell_power
                 end
             end
             @inbounds for ω in half+1:num_doppler_bins
-                cell_power = abs2(col_buf[ω])
-                dst_row = ω - half
-                if cell_power > noncoherent_integration_buf[dst_row, col_idx]
-                    noncoherent_integration_buf[dst_row, col_idx] = cell_power
+                cell_power = muladd(combine_buf_re[ω], combine_buf_re[ω],
+                                    combine_buf_im[ω] * combine_buf_im[ω])
+                dst = ω - half
+                if cell_power > stage[dst, dst_col]
+                    stage[dst, dst_col] = cell_power
                 end
             end
         end
     end
+    return stage
 end
 
 """
@@ -112,11 +304,11 @@ end
                                       tiled_phase_patterns_re, tiled_phase_patterns_im)
 
 Sign-pattern search step for one bit-edge alignment when per-coherent-period signs vary
-(secondary-code rotation search). Splits each column into `num_coh_periods` sub-blocks of
-`num_blocks` rows each (one per coherent code period) and computes one column FFT per
-sub-block. Then, for each pattern column, accumulates
-`tiled_phase_patterns[ω, p, q] * sub_block_FFT_p[ω]` over the `num_coh_periods` sub-blocks
-and writes `|result|²` into `noncoherent_integration_buf`.
+(secondary-code rotation search), over a fully materialised coherent integration matrix.
+Splits each column into `num_coh_periods` sub-blocks of `num_blocks` rows each (one per
+coherent code period) and computes one column FFT per sub-block. Then, for each pattern
+column, accumulates `tiled_phase_patterns[ω, p, q] * sub_block_FFT_p[ω]` over the
+`num_coh_periods` sub-blocks and writes `|result|²` into `noncoherent_integration_buf`.
 
 The `num_sign_patterns` pattern columns are the Cartesian product of
 `num_secondary_rotations` secondary-code rotations and `num_data_combos = 2^(num_data_bits−1)`
@@ -124,9 +316,7 @@ data-bit polarities (rotation-major, data-minor; see [`sign_patterns`](@ref)). E
 is a distinct code phase and gets its own `samples_per_code`-wide cp slice; the
 `num_data_combos` polarities sharing a rotation are collapsed into that slice by a cell-wise
 max (the data sign is a nuisance hypothesis). The buffer's cp axis must therefore be at least
-`(num_sign_patterns ÷ num_data_combos) * samples_per_code` wide. (Before this was fixed the
-kernel wrote one slice per *pattern* into a buffer sized for one slice per *rotation*, which
-overran the buffer whenever `num_data_combos > 1`, i.e. N ≥ 2·L — a segfault.)
+`(num_sign_patterns ÷ num_data_combos) * samples_per_code` wide.
 
 This is the generalisation of [`_sign_search_step!`](@ref) — that kernel groups consecutive
 coherent periods into one sub-block per data bit (`num_data_bits` sub-blocks total) and is
@@ -178,6 +368,9 @@ relationship is preserved (the overall phase factor — even with the complex co
 phasor — vanishes in `|·|²` because it factors out of the sum over `p`).
 
 `sub_block_ffts` must have at least `num_coh_periods` columns.
+
+Reference/test wrapper: delegates to [`_rotation_column!`](@ref) column by
+column. Production consumes tiles instead and never materialises the full CIM.
 """
 function _sign_search_step_with_rotations!(
     noncoherent_integration_buf::Matrix{Float32},
@@ -214,113 +407,16 @@ function _sign_search_step_with_rotations!(
         "tiled_phase_patterns_im shape $(size(tiled_phase_patterns_im)) ≠ tiled_phase_patterns_re shape $(size(tiled_phase_patterns_re))"))
     length(combine_buf_re) == num_doppler_bins && length(combine_buf_im) == num_doppler_bins ||
         throw(ArgumentError("combine_buf_re/im must each have length num_doppler_bins=$num_doppler_bins"))
-    half_block = block_size >> 1
     for col_idx in 1:samples_per_code
-        # Snap the sub-block partition to the primary-code wrap for this column.
-        # `wrap_sample` is the FM-DBZP delay associated with `col_idx`; rounding
-        # to the nearest multiple of block_size aligns sub-block 0 (and hence
-        # every sub-block, by uniform shift) to within ±half_block of an NH10
-        # chip boundary. Cheap (four integer ops per column) and recovers ~6 dB
-        # of coherent gain at the worst code phase.
-        pc = col_idx - 1
-        wrap_sample = ((num_blocks - div(pc, block_size)) % num_blocks) * block_size + (pc % block_size)
-        col_row_offset = div(wrap_sample + half_block, block_size) % num_blocks
-        eff_row_offset = (row_offset + col_row_offset) % num_doppler_bins
-
-        # One sub-block FFT per coherent period (sub-block size = num_blocks).
-        for k in 0:num_coh_periods-1
-            fill!(col_buf, zero(ComplexF32))
-            for sub_row in 0:num_blocks-1
-                src_row = ((eff_row_offset + k * num_blocks + sub_row) % num_doppler_bins) + 1
-                col_buf[sub_row + 1] = coherent_integration_matrix[src_row, col_idx]
-            end
-            mul!(col_buf, col_fft_plan, col_buf)
-            sub_block_ffts[:, k + 1] .= col_buf   # raw FFT order; output fftshift happens once in `_accumulate_noncoherent_integration_step!`
-        end
-
-        # Combine sub-block FFTs with the precomputed (ω, p, q)-tiled phasors,
-        # then WRITE each pattern to its ROTATION's cp slice of the noncoherent
-        # buffer in sorted-Doppler row order. Rotations get their own cells (no
-        # collapse) so the CFAR statistics match LongL5I's matched-filter layout,
-        # recovering the ~5 dB noise-floor inflation that collapsing distinct code
-        # phases would cost; the `num_data_combos` data-bit polarities that share a
-        # rotation ARE collapsed by cell-wise max (nuisance hypothesis — see the
-        # dest_col block below). Loop ordering: outer pattern q, middle sub-block
-        # p, inner ω. The complex MAC is unfused
-        # into four real `muladd`s so the compiler packs the inner loop into
-        # Float32 SIMD lanes — measured ~3× faster than the equivalent
-        # ComplexF32-storage form.
-        #
-        # fftshift is folded into the row-write here: raw bin ω∈[1, half] maps
-        # to sorted-Doppler row ω+half, and ω∈[half+1, N] maps to ω-half. Two
-        # contiguous SIMD-friendly half-loops replace what used to be a
-        # separate `_scatter_fftshift_accumulate!` pass over the whole
-        # `(num_doppler_bins, samples_per_code_eff)` buffer per non-coherent
-        # step. The compute pass over `combine_buf_re/im` stays in raw bin
-        # order — it reads `tiled_phase_patterns[ω, …]` contiguously.
-        half = num_doppler_bins ÷ 2
-        for q in 1:num_sign_patterns
-            fill!(combine_buf_re, 0f0)
-            fill!(combine_buf_im, 0f0)
-            for p in 1:num_coh_periods
-                @inbounds @simd for ω in 1:num_doppler_bins
-                    ar = tiled_phase_patterns_re[ω, p, q]
-                    ai = tiled_phase_patterns_im[ω, p, q]
-                    br, bi = reim(sub_block_ffts[ω, p])
-                    combine_buf_re[ω] = muladd(ar, br, muladd(-ai, bi, combine_buf_re[ω]))
-                    combine_buf_im[ω] = muladd(ar, bi, muladd( ai, br, combine_buf_im[ω]))
-                end
-            end
-            # Patterns are laid out rotation-major, data-bit-minor (see
-            # `sign_patterns`): pattern q decodes to rotation
-            # `(q-1) ÷ num_data_combos` and data-bit combo `(q-1) % num_data_combos`.
-            # ROTATIONS are distinct secondary-code phases — distinct code phases
-            # in the LongL5I sense — so each gets its own samples_per_code-wide
-            # slice of the cp axis (no collapse; preserves the matched-filter CFAR
-            # layout the noise floor is calibrated against). DATA-BIT polarity, by
-            # contrast, is a nuisance hypothesis (the unknown data sign), so the
-            # `num_data_combos` patterns sharing a rotation are collapsed by a
-            # cell-wise MAX into that rotation's slice — exactly as the non-rotation
-            # `_sign_search_step!` maxes data combos. Result extraction decodes via
-            # `(col-1) ÷ samples_per_code → rotation_idx`.
-            #
-            # `num_data_combos == 1` (no multi-bit search) is the dominant case: each
-            # pattern is its own rotation, so dest_col cells never collide and we use a
-            # plain SIMD store. Only when combos > 1 do the loops read-then-max — that
-            # read-compare-store can't vectorise like the pure store, so gating it keeps
-            # the common path at the pre-fix speed (see the fold-fftshift kernel).
-            rotation_idx = (q - 1) ÷ num_data_combos
-            dest_col = col_idx + rotation_idx * samples_per_code
-            if num_data_combos == 1
-                @inbounds @simd for ω in 1:half
-                    noncoherent_integration_buf[ω + half, dest_col] =
-                        muladd(combine_buf_re[ω], combine_buf_re[ω],
-                               combine_buf_im[ω] * combine_buf_im[ω])
-                end
-                @inbounds @simd for ω in half+1:num_doppler_bins
-                    noncoherent_integration_buf[ω - half, dest_col] =
-                        muladd(combine_buf_re[ω], combine_buf_re[ω],
-                               combine_buf_im[ω] * combine_buf_im[ω])
-                end
-            else
-                @inbounds for ω in 1:half
-                    cell_power = muladd(combine_buf_re[ω], combine_buf_re[ω],
-                                        combine_buf_im[ω] * combine_buf_im[ω])
-                    dst = ω + half
-                    if cell_power > noncoherent_integration_buf[dst, dest_col]
-                        noncoherent_integration_buf[dst, dest_col] = cell_power
-                    end
-                end
-                @inbounds for ω in half+1:num_doppler_bins
-                    cell_power = muladd(combine_buf_re[ω], combine_buf_re[ω],
-                                        combine_buf_im[ω] * combine_buf_im[ω])
-                    dst = ω - half
-                    if cell_power > noncoherent_integration_buf[dst, dest_col]
-                        noncoherent_integration_buf[dst, dest_col] = cell_power
-                    end
-                end
-            end
-        end
+        # Each rotation's cp slice column for this code phase: col_idx + r*spc.
+        stage = view(noncoherent_integration_buf, :,
+            range(col_idx, step = samples_per_code, length = num_rotation_blocks))
+        _rotation_column!(stage, coherent_integration_matrix, col_idx, col_idx,
+            col_buf, combine_buf_re, combine_buf_im, col_fft_plan,
+            num_doppler_bins, num_coh_periods, num_data_combos,
+            num_blocks, block_size, row_offset, sub_block_ffts,
+            tiled_phase_patterns_re, tiled_phase_patterns_im,
+            num_data_combos > 1)
     end
 end
 
@@ -333,18 +429,21 @@ code-phase walk-off caused by carrier Doppler during coherent integration.
 `accumulation_step_index` is the 0-based incoherent step index (0 → no shift).
 `S_CD[w] = round(doppler_hz[w] * accumulation_step_index * T_coherent * sampling_freq_hz / carrier_freq_hz)`
 
-The buffer is in **sorted-Doppler row order** (the sign-search kernels now fold
-fftshift into their cell-write loops). So `doppler_freqs[w]` directly gives the
-frequency for row `w` — no `fftshift_perm` indirection needed here anymore.
+The buffer is in **sorted-Doppler row order**, so `doppler_freqs[w]` directly
+gives the frequency for row `w`.
+
+Reference implementation (allocates its row scratch locally): production folds
+the drift shift into the per-column destination scatter — see
+[`_accumulate_sign_tile!`](@ref) and the fused drift pilot kernels — so this
+function is only exercised by tests and the full-matrix
+[`_accumulate_noncoherent_integration_step!`](@ref) shim.
 """
-function _apply_code_drift!(noncoherent_integration_buf::Matrix{Float32}, plan::AcquisitionPlan, scratch, accumulation_step_index::Int)
+function _apply_code_drift!(noncoherent_integration_buf::Matrix{Float32}, plan::AcquisitionPlan, accumulation_step_index::Int)
     accumulation_step_index == 0 && return  # no drift on first step
     num_doppler_bins = size(noncoherent_integration_buf, 1)
     sampling_freq_hz = ustrip(Hz, plan.sampling_freq)
     carrier_freq_hz = ustrip(Hz, get_center_frequency(plan.system))
     coherent_duration_s = plan.num_coherently_integrated_code_periods * plan.samples_per_code / sampling_freq_hz
-    row_buf = scratch.row_buf
-    row_shift_buf = scratch.row_shift_buf
     # On the rotation path the cp axis is `samples_per_code_eff` =
     # `samples_per_code * num_secondary_rotations` wide, with each rotation
     # hypothesis occupying its own `samples_per_code`-wide block. Drift is
@@ -355,6 +454,8 @@ function _apply_code_drift!(noncoherent_integration_buf::Matrix{Float32}, plan::
     # single-circshift form.
     samples_per_code = plan.samples_per_code
     num_rotation_blocks = size(noncoherent_integration_buf, 2) ÷ samples_per_code
+    row_buf = zeros(Float32, samples_per_code)
+    row_shift_buf = zeros(Float32, samples_per_code)
     for doppler_row in 1:num_doppler_bins
         doppler_hz = ustrip(Hz, plan.doppler_freqs[doppler_row])
         shift = round(Int, doppler_hz * accumulation_step_index * coherent_duration_s * sampling_freq_hz / carrier_freq_hz)
@@ -367,17 +468,12 @@ function _apply_code_drift!(noncoherent_integration_buf::Matrix{Float32}, plan::
         end
     end
 end
-# Single-argument scratch convenience: used by tests and code-drift testset directly
-_apply_code_drift!(buf::Matrix{Float32}, plan::AcquisitionPlan, accumulation_step_index::Int) =
-    _apply_code_drift!(buf, plan, _default_scratch(plan), accumulation_step_index)
 
 # Per-column FFT followed by `|x|²` accumulation into `accumulator`, with the
-# row written at its fftshift-permuted position. Folds two passes
-# (`_accumulate_noncoherent_integration_pilot!` + `_scatter_fftshift_accumulate!`)
-# into one, dropping the full-matrix-size `noncoherent_integration_buf`
-# intermediate. Valid only at num_noncoherent_accumulations == 1 simple/pilot
-# path: code-drift correction is a no-op at step 0 and there is no bit-edge max
-# search to reuse the buf across alignments.
+# row written at its fftshift-permuted position. `cim` may be one column-block
+# tile of the surface; `dest_col_offset` places its columns at their global
+# code-phase positions in the accumulator. Valid only when code drift rounds
+# to zero for every row (step 0, or any step whose rounded drift is zero).
 #
 # The fftshift permutation is a fixed rotation by `shift = N ÷ 2` rows:
 #   src rows 1..N-shift    → dst rows 1+shift..N      (advance)
@@ -385,76 +481,79 @@ _apply_code_drift!(buf::Matrix{Float32}, plan::AcquisitionPlan, accumulation_ste
 # Two contiguous loops express both halves so the compiler can SIMD.
 function _accumulate_fftshifted_power_pilot!(
     accumulator::Matrix{Float32},
-    coherent_integration_matrix::Matrix{ComplexF32},
+    cim::Matrix{ComplexF32},
     col_buf::Vector{ComplexF32},
     col_fft_plan,
     samples_per_code::Int,
     num_doppler_bins::Int,
+    dest_col_offset::Int = 0,
 )
     shift = num_doppler_bins ÷ 2
     front = num_doppler_bins - shift
-    @inbounds for col_idx in 1:samples_per_code
-        copyto!(col_buf, 1, coherent_integration_matrix, (col_idx - 1) * num_doppler_bins + 1, num_doppler_bins)
+    @inbounds for src_col in 1:size(cim, 2)
+        copyto!(col_buf, 1, cim, (src_col - 1) * num_doppler_bins + 1, num_doppler_bins)
         mul!(col_buf, col_fft_plan, col_buf)
+        dst_col = dest_col_offset + src_col
         @simd for doppler_bin in 1:front
-            accumulator[doppler_bin + shift, col_idx] += abs2(col_buf[doppler_bin])
+            accumulator[doppler_bin + shift, dst_col] += abs2(col_buf[doppler_bin])
         end
         @simd for doppler_bin in 1:shift
-            accumulator[doppler_bin, col_idx] += abs2(col_buf[doppler_bin + front])
+            accumulator[doppler_bin, dst_col] += abs2(col_buf[doppler_bin + front])
         end
     end
 end
 
-# Batched-FFT counterpart: FFT all columns at once in-place on the CIM, then
+# Batched-FFT counterpart: FFT all of `cim`'s columns at once in-place, then
 # accumulate `|x|²` into `accumulator` with the fftshift row permutation.
+# In production `cim` is the (num_doppler_bins, block_size) tile and the plan
+# is tile-shaped.
 function _accumulate_fftshifted_power_pilot_batched!(
     accumulator::Matrix{Float32},
-    coherent_integration_matrix::Matrix{ComplexF32},
+    cim::Matrix{ComplexF32},
     col_batch_fft_plan,
     samples_per_code::Int,
     num_doppler_bins::Int,
+    dest_col_offset::Int = 0,
 )
-    mul!(coherent_integration_matrix, col_batch_fft_plan, coherent_integration_matrix)
+    mul!(cim, col_batch_fft_plan, cim)
     shift = num_doppler_bins ÷ 2
     front = num_doppler_bins - shift
-    @inbounds for col_idx in 1:samples_per_code
+    @inbounds for src_col in 1:size(cim, 2)
+        dst_col = dest_col_offset + src_col
         @simd for doppler_bin in 1:front
-            accumulator[doppler_bin + shift, col_idx] += abs2(coherent_integration_matrix[doppler_bin, col_idx])
+            accumulator[doppler_bin + shift, dst_col] += abs2(cim[doppler_bin, src_col])
         end
         @simd for doppler_bin in 1:shift
-            accumulator[doppler_bin, col_idx] += abs2(coherent_integration_matrix[doppler_bin + front, col_idx])
+            accumulator[doppler_bin, dst_col] += abs2(cim[doppler_bin + front, src_col])
         end
     end
 end
 
 # Per-column FFT followed by `|x|²` accumulation with per-row code-drift column
-# shift AND fftshift row permutation, folded into one pass. Extends the slice-5
-# fusion (`_accumulate_fftshifted_power_pilot!`) to the multistep simple path
-# (Issue #62): drops the `noncoherent_integration_buf` intermediate that the
-# unfused pipeline (`pilot! → _apply_code_drift! → _scatter_fftshift_accumulate!`)
-# materialises and traverses twice per step.
+# shift AND fftshift row permutation, folded into one pass (Issue #62).
 #
 # `code_drift_shifts[r]` is the row-r column shift, pre-normalised to
 # `[0, samples_per_code)` by `_fill_code_drift_shifts!`. That lets the inner
 # loop replace `mod(c-1+shift_r, spc)+1` with a single conditional subtract.
-# The caller must dispatch to the non-drift slice-5 kernel when every row's
-# drift rounds to 0 (step 0, or any step whose rounded drift is zero — at the
+# The caller must dispatch to the non-drift kernel when every row's drift
+# rounds to 0 (step 0, or any step whose rounded drift is zero — at the
 # L1CA / 5 MHz / N_coh=1 grid that's true for every step up to N_nc≈8, so the
 # early-exit covers the dominant simple-path case).
 function _accumulate_fftshifted_power_drift_pilot!(
     accumulator::Matrix{Float32},
-    coherent_integration_matrix::Matrix{ComplexF32},
+    cim::Matrix{ComplexF32},
     col_buf::Vector{ComplexF32},
     col_fft_plan,
     samples_per_code::Int,
     num_doppler_bins::Int,
     fftshift_perm::Vector{Int},
     code_drift_shifts::Vector{Int},
+    dest_col_offset::Int = 0,
 )
-    @inbounds for col_idx in 1:samples_per_code
-        copyto!(col_buf, 1, coherent_integration_matrix, (col_idx - 1) * num_doppler_bins + 1, num_doppler_bins)
+    @inbounds for src_col in 1:size(cim, 2)
+        copyto!(col_buf, 1, cim, (src_col - 1) * num_doppler_bins + 1, num_doppler_bins)
         mul!(col_buf, col_fft_plan, col_buf)
-        c_minus_1 = col_idx - 1
+        c_minus_1 = dest_col_offset + src_col - 1
         for r in 1:num_doppler_bins
             sum = c_minus_1 + code_drift_shifts[r]
             dst_col = (sum >= samples_per_code ? sum - samples_per_code : sum) + 1
@@ -466,30 +565,31 @@ end
 # Batched-FFT counterpart of `_accumulate_fftshifted_power_drift_pilot!`.
 function _accumulate_fftshifted_power_drift_pilot_batched!(
     accumulator::Matrix{Float32},
-    coherent_integration_matrix::Matrix{ComplexF32},
+    cim::Matrix{ComplexF32},
     col_batch_fft_plan,
     samples_per_code::Int,
     num_doppler_bins::Int,
     fftshift_perm::Vector{Int},
     code_drift_shifts::Vector{Int},
+    dest_col_offset::Int = 0,
 )
-    mul!(coherent_integration_matrix, col_batch_fft_plan, coherent_integration_matrix)
-    @inbounds for col_idx in 1:samples_per_code
-        c_minus_1 = col_idx - 1
+    mul!(cim, col_batch_fft_plan, cim)
+    @inbounds for src_col in 1:size(cim, 2)
+        c_minus_1 = dest_col_offset + src_col - 1
         for r in 1:num_doppler_bins
             sum = c_minus_1 + code_drift_shifts[r]
             dst_col = (sum >= samples_per_code ? sum - samples_per_code : sum) + 1
-            accumulator[fftshift_perm[r], dst_col] += abs2(coherent_integration_matrix[r, col_idx])
+            accumulator[fftshift_perm[r], dst_col] += abs2(cim[r, src_col])
         end
     end
 end
 
 # Fill `shifts[r]` with the row-r column shift from `_apply_code_drift!`,
-# normalised to `[0, samples_per_code)` so the hot loop in the fused kernel
-# can drop `mod` for a single conditional subtract. Returns `true` if any
-# shift rounded to non-zero (caller dispatches to the fused-drift kernel) or
-# `false` if every row's drift rounds to 0 (caller uses the cheaper non-drift
-# slice-5 kernel — the typical case at low-fs / short-T_coh grids).
+# normalised to `[0, samples_per_code)` so the hot loops can drop `mod` for a
+# single conditional subtract. Returns `true` if any shift rounded to non-zero
+# (caller dispatches to the drift-folded kernels) or `false` if every row's
+# drift rounds to 0 (caller uses the cheaper non-drift kernels — the typical
+# case at low-fs / short-T_coh grids).
 function _fill_code_drift_shifts!(shifts::Vector{Int}, plan::AcquisitionPlan, accumulation_step_index::Int)
     if accumulation_step_index == 0
         fill!(shifts, 0)
@@ -537,6 +637,171 @@ function _scatter_fftshift_accumulate!(dst::Matrix{Float32}, src::Matrix{Float32
     return dst
 end
 
+# Fill `stage` (num_doppler_bins × num_stage_slices) with the sign-search power
+# of ONE code-phase column, max-reduced across bit-edge alignments (and, within
+# each rotation slice, across data-bit polarities). `src_col` indexes into
+# `cim` (a tile or a full matrix); `cp_col` is the 1-based code-phase column in
+# [1, samples_per_code] it corresponds to. The caller zeroes `stage` first.
+# Pattern matrices are passed in (hoisted out of the per-column loop) so no
+# Dict lookup happens per column.
+@inline function _fill_sign_stage_column!(
+    stage::AbstractMatrix{Float32},
+    cim::AbstractMatrix{ComplexF32},
+    src_col::Int,
+    cp_col::Int,
+    plan::AcquisitionPlan,
+    scratch,
+    patterns::Matrix{Float32},
+    tiled_re::Array{Float32,3},
+    tiled_im::Array{Float32,3},
+    rotation_active::Bool,
+    num_data_combos::Int,
+    edge_step::Int,
+    use_max::Bool,
+)
+    num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks
+    for bit_edge_search_idx in 0:plan.bit_edge_search_steps-1
+        row_offset = bit_edge_search_idx * edge_step
+        if rotation_active
+            _rotation_column!(stage, cim, src_col, cp_col,
+                scratch.col_buf, scratch.combine_buf_re, scratch.combine_buf_im,
+                plan.col_fft_plan, num_doppler_bins,
+                plan.num_coherently_integrated_code_periods, num_data_combos,
+                plan.num_blocks, plan.block_size, row_offset,
+                scratch.sub_block_ffts, tiled_re, tiled_im, use_max)
+        else
+            _sign_search_column!(view(stage, :, 1), cim, src_col,
+                scratch.col_buf, plan.col_fft_plan, num_doppler_bins,
+                plan.num_data_bits, row_offset, scratch.sub_block_ffts, patterns)
+        end
+    end
+    return stage
+end
+
+# Sign-search consumer for one tile on the multistep (N_nc > 1) path: for each
+# tile column, fill the per-column stage and scatter it into the per-PRN
+# accumulator with the code-drift column shift folded in. Replaces the
+# full-surface `noncoherent_integration_buf` → `_apply_code_drift!` →
+# max/accumulate pipeline with a column-local one. The drift shift is identical
+# across bit-edge alignments and data combos (it depends only on Doppler row
+# and step), so max-then-shift equals shift-then-max.
+function _accumulate_sign_tile!(
+    nim::Matrix{Float32},
+    tile::Matrix{ComplexF32},
+    col_block_idx::Int,
+    plan::AcquisitionPlan,
+    scratch,
+    prn::Int,
+    has_drift::Bool,
+)
+    block_size = plan.block_size
+    samples_per_code = plan.samples_per_code
+    num_doppler_bins = size(nim, 1)
+    stage = scratch.stage_buf
+    num_slices = size(stage, 2)
+    shifts = scratch.code_drift_shifts
+    rotation_active = plan.num_secondary_rotations > 1 &&
+                      plan.num_coherently_integrated_code_periods > 1
+    num_data_combos = 1 << (plan.num_data_bits - 1)
+    bit_period_codes = plan.num_coherently_integrated_code_periods ÷ plan.num_data_bits
+    edge_step = bit_period_codes * plan.num_blocks ÷ plan.bit_edge_search_steps
+    use_max = num_data_combos > 1 || plan.bit_edge_search_steps > 1
+    patterns = plan.sign_patterns_by_prn[prn]
+    tiled_re = rotation_active ? plan.tiled_phase_patterns_re_by_prn[prn] :
+        _EMPTY_TILED_PATTERNS
+    tiled_im = rotation_active ? plan.tiled_phase_patterns_im_by_prn[prn] :
+        _EMPTY_TILED_PATTERNS
+
+    for local_col in 1:block_size
+        cp_col = col_block_idx * block_size + local_col
+        fill!(stage, 0f0)
+        _fill_sign_stage_column!(stage, tile, local_col, cp_col, plan, scratch,
+            patterns, tiled_re, tiled_im, rotation_active, num_data_combos,
+            edge_step, use_max)
+        if has_drift
+            @inbounds for s in 0:num_slices-1
+                base = s * samples_per_code
+                for r in 1:num_doppler_bins
+                    shifted = (cp_col - 1) + shifts[r]
+                    shifted >= samples_per_code && (shifted -= samples_per_code)
+                    nim[r, base + shifted + 1] += stage[r, s + 1]
+                end
+            end
+        else
+            @inbounds for s in 0:num_slices-1
+                base = s * samples_per_code
+                @simd for r in 1:num_doppler_bins
+                    nim[r, base + cp_col] += stage[r, s + 1]
+                end
+            end
+        end
+    end
+end
+
+const _EMPTY_TILED_PATTERNS = Array{Float32,3}(undef, 0, 0, 0)
+
+"""
+    _accumulate_prn_step_tiled!(nim, plan, scratch, prn, accumulation_step_index)
+
+One PRN × one non-coherent step of the multistep (N_nc > 1) pipeline, tiled:
+for each FM-DBZP column block, build the coherent tile and accumulate its power
+into the per-PRN matrix `nim` — via the fused pilot kernels on the simple path
+or the per-column sign-search/rotation kernels otherwise. Code drift is folded
+into the destination columns; no intermediate surface is materialised.
+"""
+function _accumulate_prn_step_tiled!(
+    nim::Matrix{Float32},
+    plan::AcquisitionPlan,
+    scratch,
+    prn::Int,
+    accumulation_step_index::Int,
+)
+    num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks
+    rotation_active = plan.num_secondary_rotations > 1 &&
+                      plan.num_coherently_integrated_code_periods > 1
+    simple_path = plan.num_data_bits == 1 && plan.bit_edge_search_steps == 1 &&
+                  !rotation_active
+    has_drift = _fill_code_drift_shifts!(scratch.code_drift_shifts, plan, accumulation_step_index)
+    prn_conj_fft = plan.prn_conj_ffts[prn]
+    tile = scratch.coherent_tile
+
+    for col_block_idx in 0:plan.num_blocks-1
+        _build_coherent_tile!(tile, plan.signal_block_ffts, prn_conj_fft,
+            col_block_idx, plan.num_blocks, plan.block_size,
+            plan.num_coherently_integrated_code_periods,
+            scratch.corr_buf, plan.double_block_bfft_plan)
+        dest_col_offset = col_block_idx * plan.block_size
+        if simple_path
+            if !has_drift
+                if num_doppler_bins <= BATCH_FFT_THRESHOLD
+                    _accumulate_fftshifted_power_pilot_batched!(
+                        nim, tile, plan.col_batch_fft_plan,
+                        plan.samples_per_code, num_doppler_bins, dest_col_offset)
+                else
+                    _accumulate_fftshifted_power_pilot!(
+                        nim, tile, scratch.col_buf, plan.col_fft_plan,
+                        plan.samples_per_code, num_doppler_bins, dest_col_offset)
+                end
+            else
+                if num_doppler_bins <= BATCH_FFT_THRESHOLD
+                    _accumulate_fftshifted_power_drift_pilot_batched!(
+                        nim, tile, plan.col_batch_fft_plan,
+                        plan.samples_per_code, num_doppler_bins,
+                        plan.fftshift_perm, scratch.code_drift_shifts, dest_col_offset)
+                else
+                    _accumulate_fftshifted_power_drift_pilot!(
+                        nim, tile, scratch.col_buf, plan.col_fft_plan,
+                        plan.samples_per_code, num_doppler_bins,
+                        plan.fftshift_perm, scratch.code_drift_shifts, dest_col_offset)
+                end
+            end
+        else
+            _accumulate_sign_tile!(nim, tile, col_block_idx, plan, scratch, prn, has_drift)
+        end
+    end
+    return nim
+end
+
 """
     _accumulate_noncoherent_integration_step!(noncoherent_integration_matrix, coherent_integration_matrix, plan, scratch, prn, m)
 
@@ -544,20 +809,12 @@ For incoherent step `m` (0-based): run the column FFT (pilot/sub-bit or data/rot
 apply bit edge search and code drift correction, then accumulate into
 `noncoherent_integration_matrix`.
 
-For pilot channels and sub-bit integration with no rotation search
-(num_data_bits == 1, bit_edge_search_steps == 1, num_secondary_rotations == 1 or N == 1):
-uses the fast pilot path (_accumulate_noncoherent_integration_pilot!) — one column FFT per
-column, no sign search.
-
-When secondary-code rotation search is active (num_secondary_rotations > 1 and N > 1):
-uses [`_sign_search_step_with_rotations!`](@ref), which splits the column into N
-coherent-period sub-blocks (size num_blocks each) and searches across the Cartesian
-product of data-bit polarities and secondary-code rotations.
-
-For data-bit / bit-edge search without rotation
-(num_data_bits > 1 or bit_edge_search_steps > 1, num_secondary_rotations == 1):
-uses [`_sign_search_step!`](@ref) with bit_edge_search_steps candidate alignments and
-2^(num_data_bits − 1) data-bit polarity combinations.
+Reference/test dispatcher operating on a fully materialised coherent
+integration matrix; it mirrors the routing of the tiled production driver
+[`_accumulate_prn_step_tiled!`](@ref) so kernel parity can be validated from
+tests. Sign-search staging buffers are allocated locally (this entry point is
+not on the hot path). The simple path always uses the per-column fused kernels
+— the plan's batched FFT plan is tile-shaped and does not fit a full matrix.
 """
 function _accumulate_noncoherent_integration_step!(
     noncoherent_integration_matrix::Matrix{Float32},
@@ -573,63 +830,32 @@ function _accumulate_noncoherent_integration_step!(
 
     if plan.num_data_bits == 1 && plan.bit_edge_search_steps == 1 && !rotation_search_active
         # Simple/pilot path: fused FFT+|x|²+(code-drift)+fftshift kernel writes
-        # straight into `noncoherent_integration_matrix`. The drift kernel is
-        # taken only when at least one row's rounded drift is non-zero — at
-        # step 0, and at every step where the rounded drift is 0 for all rows
-        # (typical for short coherent durations / small doppler grids), the
-        # cheaper SIMD-friendly slice-5 non-drift kernel runs instead.
-        has_drift = _fill_code_drift_shifts!(scratch.code_drift_shifts, plan, accumulation_step_index)
+        # straight into `noncoherent_integration_matrix`.
+        drift_shifts = length(scratch.code_drift_shifts) == num_doppler_bins ?
+            scratch.code_drift_shifts : zeros(Int, num_doppler_bins)
+        has_drift = _fill_code_drift_shifts!(drift_shifts, plan, accumulation_step_index)
         if !has_drift
-            if num_doppler_bins <= BATCH_FFT_THRESHOLD
-                _accumulate_fftshifted_power_pilot_batched!(
-                    noncoherent_integration_matrix, coherent_integration_matrix,
-                    plan.col_batch_fft_plan, plan.samples_per_code, num_doppler_bins)
-            else
-                _accumulate_fftshifted_power_pilot!(
-                    noncoherent_integration_matrix, coherent_integration_matrix,
-                    scratch.col_buf, plan.col_fft_plan,
-                    plan.samples_per_code, num_doppler_bins)
-            end
+            _accumulate_fftshifted_power_pilot!(
+                noncoherent_integration_matrix, coherent_integration_matrix,
+                scratch.col_buf, plan.col_fft_plan,
+                plan.samples_per_code, num_doppler_bins)
         else
-            if num_doppler_bins <= BATCH_FFT_THRESHOLD
-                _accumulate_fftshifted_power_drift_pilot_batched!(
-                    noncoherent_integration_matrix, coherent_integration_matrix,
-                    plan.col_batch_fft_plan, plan.samples_per_code, num_doppler_bins,
-                    plan.fftshift_perm, scratch.code_drift_shifts)
-            else
-                _accumulate_fftshifted_power_drift_pilot!(
-                    noncoherent_integration_matrix, coherent_integration_matrix,
-                    scratch.col_buf, plan.col_fft_plan,
-                    plan.samples_per_code, num_doppler_bins,
-                    plan.fftshift_perm, scratch.code_drift_shifts)
-            end
+            _accumulate_fftshifted_power_drift_pilot!(
+                noncoherent_integration_matrix, coherent_integration_matrix,
+                scratch.col_buf, plan.col_fft_plan,
+                plan.samples_per_code, num_doppler_bins,
+                plan.fftshift_perm, drift_shifts)
         end
     else
-        noncoherent_integration_buf = scratch.noncoherent_integration_buf
-        # Sign-pattern search path. The plan pre-computed the pattern matrices
-        # per PRN at `plan_acquire` time. The rotation kernel consumes the
-        # complex-phasor-multiplied patterns (LongL5I-equivalent inter-sub-block
-        # combination); the non-rotation kernel uses the plain ±1 patterns.
-        #
-        # Pipeline since the fftshift-fold change:
-        #   - the sign-search kernels write `noncoherent_integration_buf`
-        #     directly in **sorted-Doppler row order** (fftshift inlined as a
-        #     top/bottom half-row swap);
-        #   - `_apply_code_drift!` shifts in sorted-Doppler order;
-        #   - the running max over bit-edge alignments only exists when
-        #     `bit_edge_search_steps > 1` — otherwise the loop runs once and
-        #     the buf is already the correct per-step result.
-        # The final step `noncoherent_integration_matrix .+= buf` (or `+= max_buf`)
-        # accumulates across non-coherent steps. No fftshift scatter needed.
+        # Sign-pattern search path, materialised form: kernel → code drift →
+        # (max across bit-edge alignments) → accumulate. Buffers are allocated
+        # locally — production streams this per column instead.
+        noncoherent_integration_buf =
+            zeros(Float32, num_doppler_bins, size(noncoherent_integration_matrix, 2))
         bit_period_codes = plan.num_coherently_integrated_code_periods ÷ plan.num_data_bits
         edge_step = bit_period_codes * plan.num_blocks ÷ plan.bit_edge_search_steps
-        # Number of data-bit polarity patterns per rotation (1 when num_data_bits == 1).
-        # The rotation kernel maps each tiled pattern back to its rotation via this.
         num_data_combos = 1 << (plan.num_data_bits - 1)
         if plan.bit_edge_search_steps == 1
-            # No outer max — the kernel writes the only alignment's result
-            # directly. Skip `sign_search_max_buf` (sized 0×0 in this case).
-            fill!(noncoherent_integration_buf, 0.0f0)
             if rotation_search_active
                 _sign_search_step_with_rotations!(noncoherent_integration_buf, coherent_integration_matrix,
                     scratch.col_buf, scratch.combine_buf_re, scratch.combine_buf_im,
@@ -646,11 +872,11 @@ function _accumulate_noncoherent_integration_step!(
                     plan.num_data_bits, 0, scratch.sub_block_ffts,
                     plan.sign_patterns_by_prn[prn])
             end
-            _apply_code_drift!(noncoherent_integration_buf, plan, scratch, accumulation_step_index)
+            _apply_code_drift!(noncoherent_integration_buf, plan, accumulation_step_index)
             noncoherent_integration_matrix .+= noncoherent_integration_buf
         else
-            sign_search_max_buf = scratch.sign_search_max_buf
-            fill!(sign_search_max_buf, 0.0f0)
+            sign_search_max_buf =
+                zeros(Float32, num_doppler_bins, size(noncoherent_integration_matrix, 2))
             for bit_edge_search_idx in 0:plan.bit_edge_search_steps-1
                 fill!(noncoherent_integration_buf, 0.0f0)
                 row_offset = bit_edge_search_idx * edge_step
@@ -670,7 +896,7 @@ function _accumulate_noncoherent_integration_step!(
                         plan.num_data_bits, row_offset, scratch.sub_block_ffts,
                         plan.sign_patterns_by_prn[prn])
                 end
-                _apply_code_drift!(noncoherent_integration_buf, plan, scratch, accumulation_step_index)
+                _apply_code_drift!(noncoherent_integration_buf, plan, accumulation_step_index)
                 @. sign_search_max_buf = max(sign_search_max_buf, noncoherent_integration_buf)
             end
             noncoherent_integration_matrix .+= sign_search_max_buf

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -7,34 +7,59 @@
 const BATCH_FFT_THRESHOLD = 320
 
 # Per-thread mutable scratch buffers used during acquisition.
-# Allocated once per thread in `plan_acquire` to enable multi-threaded PRN processing.
+# Allocated once per pool slot in `plan_acquire` to enable multi-threaded PRN processing.
 # Internal — not part of the public API.
+#
+# The FM-DBZP pipeline is tiled: the coherent correlation surface is produced one
+# `(num_doppler_bins, block_size)` column-block tile at a time
+# (`_build_coherent_tile!`) and reduced immediately, so NO scratch buffer scales
+# with `samples_per_code` on the hot path. The full
+# `(num_doppler_bins, samples_per_code_eff)` power surface is materialised only
+# where it is genuinely needed: the per-PRN `noncoherent_integration_matrices`
+# at `num_noncoherent_accumulations > 1` (accumulation across signal segments
+# requires the whole surface) and the per-PRN `result_buffers` when the caller
+# opts in via `store_power_bins = true`.
 struct AcquisitionScratch
     double_block_buf::Vector{ComplexF32}            # length double_block_size
     corr_buf::Vector{ComplexF32}                    # length double_block_size
-    sig_buf::Vector{ComplexF32}                     # length segment_length — downconverted signal segment (thread 1 only)
+    # One FM-DBZP column-block tile of the coherent-integration surface:
+    # (num_doppler_bins, block_size). Every consumer after the build stage is
+    # column-oriented, so the full (num_doppler_bins, samples_per_code) matrix
+    # never needs to exist — build tile → reduce tile → next tile.
+    coherent_tile::Matrix{ComplexF32}
     col_buf::Vector{ComplexF32}                     # length num_doppler_bins
-    row_buf::Vector{Float32}                        # length samples_per_code
-    row_shift_buf::Vector{Float32}                  # length samples_per_code
-    coherent_integration_matrix::Matrix{ComplexF32}         # (num_doppler_bins, samples_per_code)
-    sign_search_max_buf::Matrix{Float32}                     # (num_doppler_bins, samples_per_code) — 0x0 when simple path is taken (see plan_acquire). Running max over sign-search alignments.
-    noncoherent_integration_buf::Matrix{Float32}             # (num_doppler_bins, samples_per_code)
-    # At num_noncoherent_accumulations == 1 this matrix replaces the per-PRN
-    # `noncoherent_integration_matrices` vector: each PRN runs one build+accumulate
-    # into this per-thread buffer, then extracts its result before the next PRN
-    # overwrites it. 0x0 when N_nc > 1 (the per-PRN layout is required there).
-    noncoherent_integration_accumulator::Matrix{Float32}
-    sub_block_ffts::Matrix{ComplexF32}              # (num_doppler_bins, num_sub_blocks) — 0x0 when simple path is taken (see plan_acquire). Scratch for `_sign_search_step!`.
+    # Per-column staging for the sign-search kernels:
+    # (num_doppler_bins, num_secondary_rotations). Holds ONE code-phase column's
+    # power per rotation hypothesis, max-reduced across bit-edge alignments and
+    # data-bit polarities, before it is consumed (streamed at N_nc == 1,
+    # scattered into the per-PRN accumulator at N_nc > 1). Replaces the
+    # full-surface `noncoherent_integration_buf`/`sign_search_max_buf` pair.
+    # 0×0 when the simple/pilot path is taken.
+    stage_buf::Matrix{Float32}
+    # Streaming-reduction state at num_noncoherent_accumulations == 1: running
+    # per-row (sorted-Doppler order) power sums feeding the OppositeRow noise
+    # estimate. length num_doppler_bins; 0 on the multistep path, which reduces
+    # from the materialised per-PRN accumulator instead.
+    row_sums_buf::Vector{Float32}
+    # Single-column power scratch (length num_doppler_bins) for the on-demand
+    # column recompute used by subsample interpolation on the streamed path.
+    col_power_buf::Vector{Float32}
+    sub_block_ffts::Matrix{ComplexF32}              # (num_doppler_bins, num_sub_blocks) — 0x0 when simple path is taken (see plan_acquire). Scratch for the sign-search kernels.
     # Real/imag-split accumulator for the rotation-kernel's complex-MAC combine loop.
     # Each is length num_doppler_bins, sized 0 when the rotation kernel is not active.
     # Split storage drives Float32 SIMD on the tiled phasor inner loop —
     # ComplexF32 storage is ~3× slower because the compiler can't pack the MAC.
     combine_buf_re::Vector{Float32}
     combine_buf_im::Vector{Float32}
-    col_sums_buf::Vector{Float32}                   # length samples_per_code — scratch for est_signal_noise_power
+    # length samples_per_code_eff when per-column sums are consumed — multistep
+    # extraction via `est_signal_noise_power`, or the GlobalMean noise estimator
+    # on the streamed path. length 0 at N_nc == 1 with the (default) OppositeRow
+    # estimator, where the streaming reduction needs no column sums at all.
+    col_sums_buf::Vector{Float32}
     # Row-wise code-drift shifts pre-filled per accumulation step on the
-    # multistep simple path. length num_doppler_bins when that path is active;
-    # 0 otherwise (sequential N_nc=1 path and sign-search path don't use it).
+    # multistep path (drift is folded into the per-column destination scatter).
+    # length num_doppler_bins when N_nc > 1; 0 on the sequential path (step 0
+    # never drifts).
     code_drift_shifts::Vector{Int}
 end
 
@@ -69,10 +94,15 @@ struct AcquisitionPlan{S<:AbstractGNSSSignal,DS,P1,P2,P3,P4,R,E<:AbstractNoiseEs
     double_block_fft_plan::P1   # in-place forward FFT, size double_block_size
     double_block_bfft_plan::P2  # in-place backward FFT (unnormalised), size double_block_size
     col_fft_plan::P3            # in-place forward FFT, size num_doppler_bins = num_coherently_integrated_code_periods*num_blocks
-    col_batch_fft_plan::P4      # in-place forward FFT along dim 1 of (num_doppler_bins, samples_per_code) matrix; `nothing` when num_doppler_bins > BATCH_FFT_THRESHOLD
+    col_batch_fft_plan::P4      # in-place forward FFT along dim 1 of a (num_doppler_bins, block_size) tile; `nothing` when num_doppler_bins > BATCH_FFT_THRESHOLD
     # doppler_freqs: StepRangeLen of num_doppler_bins Hz values, sorted from -doppler_coverage_hz/2 to doppler_coverage_hz/2-doppler_bin_spacing_hz
     doppler_freqs::DS
     signal_block_ffts::Matrix{ComplexF32} # (double_block_size, num_coh*num_blocks) — precomputed once per acquire!, shared across PRNs
+    # Downconverted-segment staging (length segment_length). Filled once per
+    # accumulation step BEFORE the per-PRN parallel loop, so a single instance
+    # suffices — keeping it out of the per-thread scratch pool saves
+    # (nthreads-1) × segment_length × 8 bytes.
+    sig_buf::Vector{ComplexF32}
     noncoherent_integration_matrices::Vector{Matrix{Float32}}  # per PRN, (num_doppler_bins, samples_per_code); index i corresponds to avail_prns[i]
     fftshift_perm::Vector{Int}               # length num_doppler_bins — pre-computed fftshift row permutation
     # Per PRN: holds a copy of power_bins when the caller of `acquire!` passes
@@ -91,8 +121,11 @@ struct AcquisitionPlan{S<:AbstractGNSSSignal,DS,P1,P2,P3,P4,R,E<:AbstractNoiseEs
     # a long session when driven from `Threads.@spawn`, a risk for a 24/7 receiver.
     # All slots are built up front (the size is known here), so the plan's
     # construction footprint is its steady-state footprint — no first-`acquire!`
-    # spike. Slot 1 doubles as the ambient single-threaded scratch — see
-    # `_default_scratch`.
+    # spike. Since the pipeline is tiled, each scratch is small — its largest
+    # member is the (num_doppler_bins × block_size) tile, `num_blocks`× smaller
+    # than the coherent matrix it replaced — so the per-thread footprint no
+    # longer scales with `samples_per_code`. Slot 1 doubles as the ambient
+    # single-threaded scratch — see `_default_scratch`.
     thread_scratch::Vector{AcquisitionScratch}
     scratch_free::Vector{Int}        # indices of currently-free slots in `thread_scratch`
     scratch_lock::Threads.SpinLock   # guards `scratch_free`
@@ -208,8 +241,10 @@ Pre-compute an acquisition plan for FM-DBZP acquisition.
 
 Allocates all buffers, computes FFT plans, and pre-computes conjugated PRN FFTs.
 The returned plan can be passed to [`acquire!`](@ref) repeatedly without re-allocating.
-Per-thread scratch buffers are sized for `Threads.maxthreadid()` at the time of the call;
-start Julia with `-t N` before calling `plan_acquire` to enable multi-threaded acquisition.
+The per-thread scratch pool is sized to `min(Threads.nthreads(), num_cores)` at the
+time of the call; start Julia with `-t N` before calling `plan_acquire` to enable
+multi-threaded acquisition. Scratch buffers are tile-sized (nothing scales with
+`samples_per_code`), so extra threads cost little memory.
 
 # Arguments
 
@@ -411,8 +446,10 @@ function plan_acquire(
     # Batched column FFT plan: only allocate when num_doppler_bins is small enough
     # that the batched approach outperforms individual column FFTs (see BATCH_FFT_THRESHOLD).
     # Above the threshold, store `nothing` — the non-batched path is used instead.
+    # Sized to one (num_doppler_bins, block_size) tile — the unit the pipeline
+    # processes — not the full samples_per_code width.
     col_batch_fft_plan = if num_doppler_bins <= BATCH_FFT_THRESHOLD
-        col_batch_proto = zeros(ComplexF32, num_doppler_bins, samples_per_code)
+        col_batch_proto = zeros(ComplexF32, num_doppler_bins, block_size)
         plan_fft!(col_batch_proto, 1; flags = fft_flag)
     else
         nothing
@@ -435,11 +472,11 @@ function plan_acquire(
     # k ∈ 0..num_coh*num_blocks-1. Filled once per acquire! call before the PRN
     # loop and reused across all PRNs.
     signal_block_ffts = zeros(ComplexF32, double_block_size, num_coherently_integrated_code_periods * num_blocks)
-    # At N_nc == 1 each PRN's noncoherent matrix is written once and consumed
-    # once for result extraction; we collapse the per-PRN vector into a
-    # per-thread accumulator (see `noncoherent_integration_accumulator` in
-    # AcquisitionScratch). The multistep path (N_nc > 1) still needs the
-    # per-PRN vector because it accumulates across steps.
+    # At N_nc == 1 each cell of the power surface is produced exactly once, so
+    # the result statistics (peak, noise row/column sums) are reduced on the fly
+    # per tile and NO noncoherent power matrix exists at all — see
+    # `_acquire_prn_streamed!`. The multistep path (N_nc > 1) keeps the
+    # per-PRN vector because it accumulates across signal segments.
     # Derive the secondary-code rotation search size. No-op for signals without a
     # secondary code (L = 1) or when the user opts out.
     secondary_code_length = get_secondary_code_length(system)
@@ -462,30 +499,23 @@ function plan_acquire(
     noncoherent_integration_matrices = sequential_prn_mode ?
         Matrix{Float32}[] :
         [zeros(Float32, num_doppler_bins, samples_per_code_eff) for _ in prns]
-    accumulator_rows = sequential_prn_mode ? num_doppler_bins : 0
-    accumulator_cols = sequential_prn_mode ? samples_per_code_eff : 0
     fftshift_perm = [mod(r - 1 + num_doppler_bins ÷ 2, num_doppler_bins) + 1 for r in 1:num_doppler_bins]
     result_buffers = Union{Nothing,Matrix{Float32}}[nothing for _ in prns]
 
-    # The sign-search path in `_accumulate_noncoherent_integration_step!` runs when
-    # num_data_bits > 1, bit_edge_search_steps > 1, or the secondary-code rotation
-    # search is active. Otherwise the simple/pilot path is taken, which never reads
-    # `sign_search_max_buf` or `sub_block_ffts`.
+    # The sign-search path runs when num_data_bits > 1, bit_edge_search_steps > 1,
+    # or the secondary-code rotation search is active. Otherwise the simple/pilot
+    # path is taken, which never reads `stage_buf` or `sub_block_ffts`.
     sign_search_path_active = num_data_bits > 1 || bit_edge_search_steps > 1 ||
                               rotation_search_active
-    # `sign_search_max_buf` is the running max across bit-edge-search alignments;
-    # it only exists when more than one alignment is searched. When
-    # `bit_edge_search_steps == 1` the dispatcher writes the kernel output
-    # directly into the noncoherent integration matrix (`.+=` accumulate) and
-    # this buffer stays at 0×0 — the dominant configuration for the rotation
-    # search path on L5I (≈68 MiB/thread saved at fs=12 MHz, N_coh=10).
-    max_buf_needed = bit_edge_search_steps > 1
-    sign_search_max_rows = max_buf_needed ? num_doppler_bins      : 0
-    sign_search_max_cols = max_buf_needed ? samples_per_code_eff  : 0
+    # Per-column staging for the sign-search kernels: ONE column of power per
+    # rotation hypothesis. Bit-edge alignments and data-bit polarities are
+    # max-reduced into it column-locally, so neither search needs a buffer
+    # proportional to `samples_per_code` anymore.
+    stage_rows = sign_search_path_active ? num_doppler_bins        : 0
+    stage_cols = sign_search_path_active ? num_secondary_rotations : 0
     # The data-bit kernel needs one sub-block FFT column per data bit; the
     # rotation kernel needs one per coherent period. Size to the max so the same
-    # scratch matrix serves both code paths. The row dim is `num_doppler_bins`
-    # — independent of whether `sign_search_max_buf` is allocated.
+    # scratch matrix serves both code paths.
     sub_block_rows = sign_search_path_active ? num_doppler_bins : 0
     sub_block_cols = if sign_search_path_active
         rotation_search_active ? max(num_data_bits, num_coherently_integrated_code_periods) :
@@ -494,58 +524,55 @@ function plan_acquire(
         0
     end
 
-    # `noncoherent_integration_buf` (the |x|² intermediate) is bypassed by the
-    # fused FFT+|x|²+(code-drift)+fftshift kernel on every simple-path route:
-    # sequential N_nc==1 (slice 5) and multistep N_nc>1 (Issue #62). Only the
-    # sign-search path still consumes the buf — it reuses the buf across
-    # bit-edge-search alignments to take the cell-wise max.
-    integration_buf_needed = sign_search_path_active
-    integration_buf_rows = integration_buf_needed ? num_doppler_bins      : 0
-    integration_buf_cols = integration_buf_needed ? samples_per_code_eff  : 0
+    # Streaming-reduction state exists only on the sequential (N_nc == 1) path;
+    # the multistep path reduces from the materialised per-PRN accumulators.
+    row_sums_len = sequential_prn_mode ? num_doppler_bins : 0
+    # Column sums are consumed by multistep extraction (`est_signal_noise_power`
+    # always fills them) and by the GlobalMean estimator on the streamed path.
+    # At N_nc == 1 with the default OppositeRow estimator nothing reads them,
+    # so the (samples_per_code_eff-long) buffer is dropped entirely.
+    col_sums_len = (!sequential_prn_mode || noise_estimator isa GlobalMeanNoiseEstimator) ?
+        samples_per_code_eff : 0
 
-    # Multistep simple path uses `code_drift_shifts` (length num_doppler_bins)
-    # to precompute the per-row column shift once per accumulation step before
-    # the per-PRN parallel loop. Sequential N_nc=1 doesn't drift; sign-search
-    # uses the unfused `_apply_code_drift!` on the buf directly.
-    multistep_simple_path_active = !sequential_prn_mode && !sign_search_path_active
-    code_drift_shifts_len = multistep_simple_path_active ? num_doppler_bins : 0
+    # The multistep path folds code-drift correction into the per-column
+    # destination scatter; shifts are pre-filled once per accumulation step.
+    # The sequential path never drifts (step 0 has zero drift by definition).
+    code_drift_shifts_len = sequential_prn_mode ? 0 : num_doppler_bins
 
     # Per-thread scratch pool. Sized to the most chunks `@batch per=core` ever
     # runs at once, `min(nthreads, num_cores)`, rather than `maxthreadid()`: a
     # chunk claims a free slot per PRN (see `_claim_scratch!`) instead of indexing
     # by `threadid()`, so the footprint is hard-capped at this many scratches no
-    # matter how `acquire!` is scheduled (Issue #60). For a wide signal each
-    # scratch is large (~296 MiB for GPS L1C-P at 16 MHz), so this is the dominant
-    # plan cost. `sig_buf` lives in slot 1, the ambient single-threaded scratch
-    # `acquire!` uses for downconversion before the parallel loop. All slots are
-    # built up front (the size is known here), so the plan's construction
-    # footprint is its steady-state footprint — no first-`acquire!` spike.
+    # matter how `acquire!` is scheduled (Issue #60). The pipeline is tiled, so
+    # each scratch's largest member is the (num_doppler_bins × block_size) tile —
+    # nothing in the pool scales with `samples_per_code` (the L1C-P/16 MHz
+    # scratch that used to weigh ~296 MiB is now ~1.5 MiB). All slots are built
+    # up front (the size is known here), so the plan's construction footprint is
+    # its steady-state footprint — no first-`acquire!` spike.
     nthreads = min(Threads.nthreads(), max(1, Int(num_cores())))
     thread_scratch = [
         AcquisitionScratch(
             zeros(ComplexF32, double_block_size),
             zeros(ComplexF32, double_block_size),
-            zeros(ComplexF32, segment_length),
+            zeros(ComplexF32, num_doppler_bins, block_size),
             zeros(ComplexF32, num_doppler_bins),
-            # row_buf / row_shift_buf hold ONE primary-code-period block; drift
-            # correction shifts within each rotation block independently when
-            # the expanded buffer is in use, so per-block length suffices.
-            zeros(Float32, samples_per_code),
-            zeros(Float32, samples_per_code),
-            zeros(ComplexF32, num_doppler_bins, samples_per_code),
-            zeros(Float32, sign_search_max_rows, sign_search_max_cols),
-            zeros(Float32, integration_buf_rows, integration_buf_cols),
-            zeros(Float32, accumulator_rows, accumulator_cols),
+            zeros(Float32, stage_rows, stage_cols),
+            zeros(Float32, row_sums_len),
+            zeros(Float32, sequential_prn_mode ? num_doppler_bins : 0),
             zeros(ComplexF32, sub_block_rows, sub_block_cols),
             zeros(Float32, rotation_search_active ? num_doppler_bins : 0),
             zeros(Float32, rotation_search_active ? num_doppler_bins : 0),
-            zeros(Float32, samples_per_code_eff),
+            zeros(Float32, col_sums_len),
             zeros(Int, code_drift_shifts_len),
         )
         for _ in 1:nthreads
     ]
     scratch_free = collect(1:nthreads)
     scratch_lock = Threads.SpinLock()
+
+    # Single downconversion staging buffer — filled once per accumulation step
+    # before the per-PRN parallel loop, so one instance serves every thread.
+    sig_buf = zeros(ComplexF32, segment_length)
 
     avail_prns_vec = collect(Int, prns)
 
@@ -614,6 +641,7 @@ function plan_acquire(
         double_block_fft_plan, double_block_bfft_plan, col_fft_plan, col_batch_fft_plan,
         doppler_freqs,
         signal_block_ffts,
+        sig_buf,
         noncoherent_integration_matrices, fftshift_perm,
         result_buffers,
         avail_prns_vec,

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -12,13 +12,13 @@ const BATCH_FFT_THRESHOLD = 320
 #
 # The FM-DBZP pipeline is tiled: the coherent correlation surface is produced one
 # `(num_doppler_bins, block_size)` column-block tile at a time
-# (`_build_coherent_tile!`) and reduced immediately, so NO scratch buffer scales
-# with `samples_per_code` on the hot path. The full
+# (`_build_coherent_tile!`) and reduced immediately. The full
 # `(num_doppler_bins, samples_per_code_eff)` power surface is materialised only
-# where it is genuinely needed: the per-PRN `noncoherent_integration_matrices`
+# where it is genuinely needed: one `noncoherent_accumulator` per scratch slot
 # at `num_noncoherent_accumulations > 1` (accumulation across signal segments
-# requires the whole surface) and the per-PRN `result_buffers` when the caller
-# opts in via `store_power_bins = true`.
+# requires the surface; the PRN-outer loop bounds the count by the concurrency,
+# not the PRN count) and the per-PRN `result_buffers` when the caller opts in
+# via `store_power_bins = true`.
 struct AcquisitionScratch
     double_block_buf::Vector{ComplexF32}            # length double_block_size
     corr_buf::Vector{ComplexF32}                    # length double_block_size
@@ -32,10 +32,18 @@ struct AcquisitionScratch
     # (num_doppler_bins, num_secondary_rotations). Holds ONE code-phase column's
     # power per rotation hypothesis, max-reduced across bit-edge alignments and
     # data-bit polarities, before it is consumed (streamed at N_nc == 1,
-    # scattered into the per-PRN accumulator at N_nc > 1). Replaces the
-    # full-surface `noncoherent_integration_buf`/`sign_search_max_buf` pair.
+    # scattered into the accumulator at N_nc > 1). Replaces the full-surface
+    # `noncoherent_integration_buf`/`sign_search_max_buf` pair.
     # 0×0 when the simple/pilot path is taken.
     stage_buf::Matrix{Float32}
+    # Multistep (N_nc > 1) power accumulator: (num_doppler_bins,
+    # samples_per_code_eff). The multistep PRN loop is PRN-outer — one claimed
+    # scratch slot carries one PRN through ALL accumulation steps and extracts
+    # its result before moving on — so `min(nthreads, num_cores, num_prns)`
+    # accumulators replace the former one-per-PRN matrices (a 32-PRN search on
+    # 8 threads holds 8 surfaces instead of 32). 0×0 at N_nc == 1, where the
+    # streamed reduction needs no surface at all.
+    noncoherent_accumulator::Matrix{Float32}
     # Streaming-reduction state at num_noncoherent_accumulations == 1: running
     # per-row (sorted-Doppler order) power sums feeding the OppositeRow noise
     # estimate. length num_doppler_bins; 0 on the multistep path, which reduces
@@ -97,13 +105,20 @@ struct AcquisitionPlan{S<:AbstractGNSSSignal,DS,P1,P2,P3,P4,R,E<:AbstractNoiseEs
     col_batch_fft_plan::P4      # in-place forward FFT along dim 1 of a (num_doppler_bins, block_size) tile; `nothing` when num_doppler_bins > BATCH_FFT_THRESHOLD
     # doppler_freqs: StepRangeLen of num_doppler_bins Hz values, sorted from -doppler_coverage_hz/2 to doppler_coverage_hz/2-doppler_bin_spacing_hz
     doppler_freqs::DS
-    signal_block_ffts::Matrix{ComplexF32} # (double_block_size, num_coh*num_blocks) — precomputed once per acquire!, shared across PRNs
+    # Signal-block FFT cache: (double_block_size, num_coh*num_blocks*N_nc).
+    # Holds FFT(signal double-block k) for EVERY accumulation segment,
+    # precomputed serially once per acquire! call (the same total FFT work the
+    # per-segment cache used to do) and then read-only shared across the PRN
+    # loop. Caching all segments — 16 bytes per signal sample, i.e. 2× the
+    # ComplexF32 signal itself — is what lets the multistep PRN loop run
+    # PRN-outer with `min(nthreads, num_cores, num_prns)` accumulators instead
+    # of one surface per PRN, with zero recompute.
+    signal_block_ffts::Matrix{ComplexF32}
     # Downconverted-segment staging (length segment_length). Filled once per
     # accumulation step BEFORE the per-PRN parallel loop, so a single instance
     # suffices — keeping it out of the per-thread scratch pool saves
     # (nthreads-1) × segment_length × 8 bytes.
     sig_buf::Vector{ComplexF32}
-    noncoherent_integration_matrices::Vector{Matrix{Float32}}  # per PRN, (num_doppler_bins, samples_per_code); index i corresponds to avail_prns[i]
     fftshift_perm::Vector{Int}               # length num_doppler_bins — pre-computed fftshift row permutation
     # Per PRN: holds a copy of power_bins when the caller of `acquire!` passes
     # store_power_bins=true. Initialised to `nothing` and allocated on the first
@@ -469,14 +484,16 @@ function plan_acquire(
 
     segment_length = num_coherently_integrated_code_periods * samples_per_code
     # Pre-allocated signal-block FFT cache: holds FFT(signal double-block k) for
-    # k ∈ 0..num_coh*num_blocks-1. Filled once per acquire! call before the PRN
-    # loop and reused across all PRNs.
-    signal_block_ffts = zeros(ComplexF32, double_block_size, num_coherently_integrated_code_periods * num_blocks)
+    # every accumulation segment (16 bytes per signal sample). Filled once per
+    # acquire! call before the PRN loop and read-only shared across all PRNs —
+    # see the field docstring for why all N_nc segments are cached.
+    signal_block_ffts = zeros(ComplexF32, double_block_size,
+        num_coherently_integrated_code_periods * num_blocks * num_noncoherent_accumulations)
     # At N_nc == 1 each cell of the power surface is produced exactly once, so
     # the result statistics (peak, noise row/column sums) are reduced on the fly
     # per tile and NO noncoherent power matrix exists at all — see
-    # `_acquire_prn_streamed!`. The multistep path (N_nc > 1) keeps the
-    # per-PRN vector because it accumulates across signal segments.
+    # `_acquire_prn_streamed!`. The multistep path (N_nc > 1) accumulates across
+    # signal segments into one per-claimed-scratch surface (PRN-outer loop).
     # Derive the secondary-code rotation search size. No-op for signals without a
     # secondary code (L = 1) or when the user opts out.
     secondary_code_length = get_secondary_code_length(system)
@@ -496,9 +513,6 @@ function plan_acquire(
         samples_per_code * num_secondary_rotations : samples_per_code
 
     sequential_prn_mode = num_noncoherent_accumulations == 1
-    noncoherent_integration_matrices = sequential_prn_mode ?
-        Matrix{Float32}[] :
-        [zeros(Float32, num_doppler_bins, samples_per_code_eff) for _ in prns]
     fftshift_perm = [mod(r - 1 + num_doppler_bins ÷ 2, num_doppler_bins) + 1 for r in 1:num_doppler_bins]
     result_buffers = Union{Nothing,Matrix{Float32}}[nothing for _ in prns]
 
@@ -525,8 +539,14 @@ function plan_acquire(
     end
 
     # Streaming-reduction state exists only on the sequential (N_nc == 1) path;
-    # the multistep path reduces from the materialised per-PRN accumulators.
+    # the multistep path reduces from the per-scratch accumulator surface.
     row_sums_len = sequential_prn_mode ? num_doppler_bins : 0
+    # Multistep accumulator: one power surface per scratch slot — the PRN-outer
+    # multistep loop carries one PRN through all accumulation steps per slot, so
+    # `min(nthreads, num_cores, num_prns)` surfaces bound the footprint instead
+    # of one per PRN. 0×0 at N_nc == 1 (streamed, no surface).
+    accumulator_rows = sequential_prn_mode ? 0 : num_doppler_bins
+    accumulator_cols = sequential_prn_mode ? 0 : samples_per_code_eff
     # Column sums are consumed by multistep extraction (`est_signal_noise_power`
     # always fills them) and by the GlobalMean estimator on the streamed path.
     # At N_nc == 1 with the default OppositeRow estimator nothing reads them,
@@ -540,16 +560,20 @@ function plan_acquire(
     code_drift_shifts_len = sequential_prn_mode ? 0 : num_doppler_bins
 
     # Per-thread scratch pool. Sized to the most chunks `@batch per=core` ever
-    # runs at once, `min(nthreads, num_cores)`, rather than `maxthreadid()`: a
+    # runs at once — `min(nthreads, num_cores, num_prns)` (the PRN loop never
+    # has more concurrent chunks than PRNs) — rather than `maxthreadid()`: a
     # chunk claims a free slot per PRN (see `_claim_scratch!`) instead of indexing
     # by `threadid()`, so the footprint is hard-capped at this many scratches no
     # matter how `acquire!` is scheduled (Issue #60). The pipeline is tiled, so
-    # each scratch's largest member is the (num_doppler_bins × block_size) tile —
-    # nothing in the pool scales with `samples_per_code` (the L1C-P/16 MHz
-    # scratch that used to weigh ~296 MiB is now ~1.5 MiB). All slots are built
-    # up front (the size is known here), so the plan's construction footprint is
-    # its steady-state footprint — no first-`acquire!` spike.
-    nthreads = min(Threads.nthreads(), max(1, Int(num_cores())))
+    # at N_nc == 1 each scratch's largest member is the (num_doppler_bins ×
+    # block_size) tile — nothing in the pool scales with `samples_per_code`
+    # (the L1C-P/16 MHz scratch that used to weigh ~296 MiB is now ~1.5 MiB).
+    # At N_nc > 1 each slot additionally carries ONE accumulation surface (see
+    # `noncoherent_accumulator`), bounding the multistep footprint by the
+    # concurrency instead of the PRN count. All slots are built up front (the
+    # size is known here), so the plan's construction footprint is its
+    # steady-state footprint — no first-`acquire!` spike.
+    nthreads = min(Threads.nthreads(), max(1, Int(num_cores())), max(1, length(prns)))
     thread_scratch = [
         AcquisitionScratch(
             zeros(ComplexF32, double_block_size),
@@ -557,6 +581,7 @@ function plan_acquire(
             zeros(ComplexF32, num_doppler_bins, block_size),
             zeros(ComplexF32, num_doppler_bins),
             zeros(Float32, stage_rows, stage_cols),
+            zeros(Float32, accumulator_rows, accumulator_cols),
             zeros(Float32, row_sums_len),
             zeros(Float32, sequential_prn_mode ? num_doppler_bins : 0),
             zeros(ComplexF32, sub_block_rows, sub_block_cols),
@@ -642,7 +667,7 @@ function plan_acquire(
         doppler_freqs,
         signal_block_ffts,
         sig_buf,
-        noncoherent_integration_matrices, fftshift_perm,
+        fftshift_perm,
         result_buffers,
         avail_prns_vec,
         thread_scratch,

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -403,8 +403,12 @@ end
             interm_freq = 0.0Hz, subsample_interpolation = true)
         r_store = acquire!(plan, ComplexF32.(signal), prn;
             interm_freq = 0.0Hz, subsample_interpolation = true, store_power_bins = true)
-        @test r_nostore.code_phase ≈ r_store.code_phase
-        @test r_nostore.carrier_doppler ≈ r_store.carrier_doppler
+        # The recompute uses the per-column FFT plan while the stored surface
+        # came from the batched tile FFT; FFTW's two algorithms differ in the
+        # last bits, so the interpolated estimates match to ~1e-7 relative,
+        # not exactly. Tolerances far below a bin still catch logic errors.
+        @test r_nostore.code_phase ≈ r_store.code_phase atol = 1e-3
+        @test abs(r_nostore.carrier_doppler - r_store.carrier_doppler) < 0.01Hz
     end
     @testset "rotation path (L5I NH10)" begin
         system = GPSL5I()
@@ -421,8 +425,9 @@ end
         r_store = acquire!(plan, ComplexF32.(signal), prn;
             interm_freq = 0.0Hz, subsample_interpolation = true, store_power_bins = true)
         @test is_detected(r_nostore)
-        @test r_nostore.code_phase ≈ r_store.code_phase
-        @test r_nostore.carrier_doppler ≈ r_store.carrier_doppler
+        # Same last-bit caveat as the simple path above.
+        @test r_nostore.code_phase ≈ r_store.code_phase atol = 1e-3
+        @test abs(r_nostore.carrier_doppler - r_store.carrier_doppler) < 0.01Hz
         @test r_nostore.secondary_code_phase == r_store.secondary_code_phase
     end
 end

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -134,29 +134,25 @@ end
     @test r2.code_phase ≈ gen2.code_phase atol = 2.0
 end
 
-@testset "_acquire_step_threaded! — threaded path runs correctly (multistep)" begin
-    # _acquire_step_threaded! is the per-step fan-out used by the multistep
-    # (N_nc>1) path. Driven directly from the test, with a plan sized so the
-    # per-PRN noncoherent matrices exist.
+@testset "multistep acquire! — PRN-outer parallel layout" begin
+    # The multistep (N_nc>1) path is PRN-outer: each parallel chunk carries one
+    # PRN through all accumulation steps against its claimed scratch slot's
+    # accumulator. Drive it through the public API with two PRNs and verify
+    # both results are produced, the planted PRN is found, and every scratch
+    # slot returns to the pool.
     system = GPSL1CA()
     sampling_freq = 2.048e6Hz
     plan = plan_acquire(system, sampling_freq, [1, 2];
         num_noncoherent_accumulations = 2, fft_flag = FFTW.ESTIMATE)
-    scratch = Acquisition._default_scratch(plan)
     (; signal, code_phase) = generate_test_signal(system, 1;
-        num_samples = plan.samples_per_code, sampling_freq, interm_freq = 0.0Hz, CN0 = 45)
-    plan.sig_buf .= ComplexF32.(signal)
-    for prn_idx in eachindex(plan.avail_prns)
-        fill!(plan.noncoherent_integration_matrices[prn_idx], 0f0)
-    end
-    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, plan.sig_buf,
-        plan.samples_per_code, plan.num_blocks, plan.block_size,
-        plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
-        plan.double_block_fft_plan)
-    Acquisition._acquire_step_threaded!(plan, collect(plan.avail_prns), 0)
-    # PRN 1 should have a peak; just verify noncoherent matrix was filled
-    @test maximum(plan.noncoherent_integration_matrices[1]) > 0
-    @test maximum(plan.noncoherent_integration_matrices[2]) > 0
+        num_samples = 2 * plan.samples_per_code, doppler = 800Hz, code_phase = 150.0,
+        sampling_freq, interm_freq = 0.0Hz, CN0 = 45, seed = 13)
+    results = acquire!(plan, ComplexF32.(signal), [1, 2]; interm_freq = 0.0Hz)
+    @test length(results) == 2
+    @test is_detected(results[1])
+    @test results[1].code_phase ≈ code_phase atol = 1.5
+    @test !is_detected(results[2])   # PRN 2 is absent
+    @test length(plan.scratch_free) == length(plan.thread_scratch)
 end
 
 @testset "acquire! N_nc=1 sequential vs N_nc=2 multistep parity" begin
@@ -450,6 +446,10 @@ end
     @test result.power_bins isa Matrix{Float32}
     @test size(result.power_bins) ==
         (length(plan.doppler_freqs), plan.samples_per_code_eff)
-    # The stored surface is a copy of the accumulation matrix.
-    @test result.power_bins == plan.noncoherent_integration_matrices[1]
+    # The stored surface is reproducible: a second identical run stores the
+    # same accumulated power.
+    result2 = acquire!(plan, ComplexF32.(signal), prn;
+        interm_freq = 0.0Hz, subsample_interpolation = true, store_power_bins = true)
+    @test result2.power_bins == result.power_bins
+    @test result2.power_bins === plan.result_buffers[1]   # cached buffer reused
 end

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -355,3 +355,101 @@ end
     # Sanity: signal-plus-noise is finite and non-zero
     @test all(isfinite, out.signal)
 end
+
+@testset "acquire! — GlobalMean noise estimator on the streamed N_nc=1 path" begin
+    # The streamed path computes GlobalMean noise from column sums collected on
+    # the fly (col_sums_buf is only allocated for this estimator at N_nc=1).
+    # Detection and peak location must agree with the default estimator.
+    system = GPSL1CA()
+    sampling_freq = 2.048e6Hz
+    prn = 4
+    (; signal) = generate_test_signal(system, prn;
+        num_samples = 2048, doppler = 750Hz, code_phase = 512.0,
+        sampling_freq, interm_freq = 0.0Hz, CN0 = 45, seed = 21)
+
+    plan_gm = plan_acquire(system, sampling_freq, [prn];
+        noise_estimator = GlobalMeanNoiseEstimator(), fft_flag = FFTW.ESTIMATE)
+    plan_or = plan_acquire(system, sampling_freq, [prn]; fft_flag = FFTW.ESTIMATE)
+    res_gm = acquire!(plan_gm, ComplexF32.(signal), prn; interm_freq = 0.0Hz)
+    res_or = acquire!(plan_or, ComplexF32.(signal), prn; interm_freq = 0.0Hz)
+
+    @test is_detected(res_gm)
+    @test res_gm.code_phase == res_or.code_phase           # same peak cell
+    @test res_gm.carrier_doppler == res_or.carrier_doppler
+    @test res_gm.noise_power != res_or.noise_power          # different estimator
+
+    # And the GlobalMean noise must equal the reference computed from the
+    # stored surface via est_signal_noise_power.
+    res_stored = acquire!(plan_gm, ComplexF32.(signal), prn;
+        interm_freq = 0.0Hz, store_power_bins = true)
+    col_sums = zeros(Float32, plan_gm.samples_per_code_eff)
+    sp, np, _, _ = Acquisition.est_signal_noise_power(res_stored.power_bins,
+        ustrip(Hz, sampling_freq), ustrip(Hz, get_code_frequency(system)),
+        col_sums, GlobalMeanNoiseEstimator())
+    @test res_stored.noise_power == Float32(np)
+end
+
+@testset "subsample_interpolation without stored bins — on-demand column recompute" begin
+    # With store_power_bins=false the streamed path recomputes the up-to-three
+    # peak-neighbour columns on demand; the interpolated result must be
+    # identical to the store_power_bins=true run (which reads the neighbours
+    # back from the stored surface). Exercised on the simple path AND the
+    # secondary-code rotation path (stage-based recompute).
+    @testset "simple path" begin
+        system = GPSL1CA()
+        sampling_freq = 2.048e6Hz
+        prn = 2
+        (; signal) = generate_test_signal(system, prn;
+            num_samples = 2048, doppler = 250Hz, code_phase = 300.7,
+            sampling_freq, interm_freq = 0.0Hz, CN0 = 45, seed = 5)
+        plan = plan_acquire(system, sampling_freq, [prn]; fft_flag = FFTW.ESTIMATE)
+        r_nostore = acquire!(plan, ComplexF32.(signal), prn;
+            interm_freq = 0.0Hz, subsample_interpolation = true)
+        r_store = acquire!(plan, ComplexF32.(signal), prn;
+            interm_freq = 0.0Hz, subsample_interpolation = true, store_power_bins = true)
+        @test r_nostore.code_phase ≈ r_store.code_phase
+        @test r_nostore.carrier_doppler ≈ r_store.carrier_doppler
+    end
+    @testset "rotation path (L5I NH10)" begin
+        system = GPSL5I()
+        sampling_freq = 10.24e6Hz
+        prn = 1
+        (; signal) = generate_test_signal(system, prn;
+            num_samples = 10 * 10240, doppler = 850Hz, code_phase = 5115.3,
+            sampling_freq, interm_freq = 0.0Hz, CN0 = 45, seed = 6)
+        plan = plan_acquire(system, sampling_freq, [prn];
+            num_coherently_integrated_code_periods = 10, fft_flag = FFTW.ESTIMATE)
+        @test plan.num_secondary_rotations == 10   # rotation search active
+        r_nostore = acquire!(plan, ComplexF32.(signal), prn;
+            interm_freq = 0.0Hz, subsample_interpolation = true)
+        r_store = acquire!(plan, ComplexF32.(signal), prn;
+            interm_freq = 0.0Hz, subsample_interpolation = true, store_power_bins = true)
+        @test is_detected(r_nostore)
+        @test r_nostore.code_phase ≈ r_store.code_phase
+        @test r_nostore.carrier_doppler ≈ r_store.carrier_doppler
+        @test r_nostore.secondary_code_phase == r_store.secondary_code_phase
+    end
+end
+
+@testset "acquire! multistep — subsample_interpolation and store_power_bins" begin
+    # Covers the N_nc>1 extraction: interpolation neighbours read from the
+    # per-PRN accumulation matrix, and the stored copy of that matrix.
+    system = GPSL1CA()
+    sampling_freq = 2.048e6Hz
+    prn = 1
+    true_cp = 700.4
+    (; signal) = generate_test_signal(system, prn;
+        num_samples = 4 * 2048, doppler = 500Hz, code_phase = true_cp,
+        sampling_freq, interm_freq = 0.0Hz, CN0 = 42, seed = 8)
+    plan = plan_acquire(system, sampling_freq, [prn];
+        num_noncoherent_accumulations = 4, fft_flag = FFTW.ESTIMATE)
+    result = acquire!(plan, ComplexF32.(signal), prn;
+        interm_freq = 0.0Hz, subsample_interpolation = true, store_power_bins = true)
+    @test is_detected(result)
+    @test result.code_phase ≈ true_cp atol = 1.0
+    @test result.power_bins isa Matrix{Float32}
+    @test size(result.power_bins) ==
+        (length(plan.doppler_freqs), plan.samples_per_code_eff)
+    # The stored surface is a copy of the accumulation matrix.
+    @test result.power_bins == plan.noncoherent_integration_matrices[1]
+end

--- a/test/acquire.jl
+++ b/test/acquire.jl
@@ -145,11 +145,11 @@ end
     scratch = Acquisition._default_scratch(plan)
     (; signal, code_phase) = generate_test_signal(system, 1;
         num_samples = plan.samples_per_code, sampling_freq, interm_freq = 0.0Hz, CN0 = 45)
-    scratch.sig_buf .= ComplexF32.(signal)
+    plan.sig_buf .= ComplexF32.(signal)
     for prn_idx in eachindex(plan.avail_prns)
         fill!(plan.noncoherent_integration_matrices[prn_idx], 0f0)
     end
-    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, scratch.sig_buf,
+    Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, plan.sig_buf,
         plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)

--- a/test/coherent_integration.jl
+++ b/test/coherent_integration.jl
@@ -9,6 +9,10 @@
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 5_000Hz, num_coherently_integrated_code_periods = 1)
     scratch = Acquisition._default_scratch(plan)
+    # The production pipeline is tiled and never materialises the full coherent
+    # integration matrix; for inspection the test allocates one locally and
+    # fills it via the reference wrapper (which loops the tiled builder).
+    cim = zeros(ComplexF32, length(plan.doppler_freqs), plan.samples_per_code)
     # min_doppler_coverage=5000 → span 10000 Hz → num_blocks=16, block_size=128
 
     # code_phase=991 chips → tau_samples = round((1023-991)*2048/1023) = 64 samples
@@ -27,7 +31,7 @@
         plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+    Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
         scratch.corr_buf, plan.double_block_bfft_plan)
 
@@ -39,7 +43,7 @@
     expected_peak_col_1 = expected_pc_1 + 1
     for code_period in 0:plan.num_coherently_integrated_code_periods-1
         row = code_period * plan.num_blocks + 1  # check row 1 per code period
-        row_vals = abs.(scratch.coherent_integration_matrix[row, :])
+        row_vals = abs.(cim[row, :])
         _, peak_col = findmax(row_vals)
         @test peak_col == expected_peak_col_1
     end
@@ -57,7 +61,7 @@
         plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+    Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
         scratch.corr_buf, plan.double_block_bfft_plan)
     block_row_2 = tau_samples_2 ÷ plan.block_size
@@ -67,7 +71,7 @@
     expected_peak_col_2  = scrambled_col_2 + 1
     for code_period_2 in 0:plan.num_coherently_integrated_code_periods-1
         row_2 = code_period_2 * plan.num_blocks + 1
-        row_vals_2 = abs.(scratch.coherent_integration_matrix[row_2, :])
+        row_vals_2 = abs.(cim[row_2, :])
         _, peak_col_2 = findmax(row_vals_2)
         @test peak_col_2 == expected_peak_col_2
     end

--- a/test/noncoherent_integration.jl
+++ b/test/noncoherent_integration.jl
@@ -114,16 +114,14 @@ end
     nim_via_dispatch = zeros(Float32, n_dop_a, plan_a.samples_per_code)
     Acquisition._accumulate_noncoherent_integration_step!(nim_via_dispatch, copy(cim_a), plan_a, 7)
 
+    # The plan's batched FFT plan is tile-shaped (the pipeline consumes one
+    # column-block tile at a time), so the full-matrix reference uses the
+    # per-column kernel — the batched/per-column parity is asserted separately
+    # in the fused-kernel testsets above.
     nim_direct = zeros(Float32, n_dop_a, plan_a.samples_per_code)
-    if n_dop_a <= Acquisition.BATCH_FFT_THRESHOLD
-        Acquisition._accumulate_fftshifted_power_pilot_batched!(
-            nim_direct, copy(cim_a), plan_a.col_batch_fft_plan,
-            plan_a.samples_per_code, n_dop_a)
-    else
-        Acquisition._accumulate_fftshifted_power_pilot!(
-            nim_direct, copy(cim_a), Acquisition._default_scratch(plan_a).col_buf,
-            plan_a.col_fft_plan, plan_a.samples_per_code, n_dop_a)
-    end
+    Acquisition._accumulate_fftshifted_power_pilot!(
+        nim_direct, copy(cim_a), Acquisition._default_scratch(plan_a).col_buf,
+        plan_a.col_fft_plan, plan_a.samples_per_code, n_dop_a)
     @test nim_via_dispatch ≈ nim_direct
 
     # (b) non-zero drift on the per-column path
@@ -208,6 +206,8 @@ end
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 10_000Hz, num_coherently_integrated_code_periods = 20)
     scratch = Acquisition._default_scratch(plan)
+    # Full CIM materialised locally via the reference wrapper (production is tiled).
+    cim = zeros(ComplexF32, plan.num_coherently_integrated_code_periods * plan.num_blocks, plan.samples_per_code)
     doppler_bin_spacing = step(plan.doppler_freqs)
     tau_samples = round(Int, (get_code_length(system) - code_phase) * plan.samples_per_code / get_code_length(system))
 
@@ -221,12 +221,12 @@ end
         plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+    Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
         scratch.corr_buf, plan.double_block_bfft_plan)
 
     noncoherent_integration_matrix = zeros(Float32, plan.num_coherently_integrated_code_periods * plan.num_blocks, plan.samples_per_code)
-    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_matrix, scratch.coherent_integration_matrix, scratch.col_buf,
+    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_matrix, cim, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
 
     peak_row, peak_col = Tuple(argmax(noncoherent_integration_matrix))
@@ -253,7 +253,7 @@ end
 
     # 3. Verify += accumulation: a second call should double the peak value.
     peak_value_first = noncoherent_integration_matrix[peak_row, peak_col]
-    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_matrix, scratch.coherent_integration_matrix, scratch.col_buf,
+    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_matrix, cim, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
     @test noncoherent_integration_matrix[peak_row, peak_col] ≈ 2 * peak_value_first
 end
@@ -268,6 +268,8 @@ end
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 10_000Hz, num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 1, num_noncoherent_accumulations = 1)
     scratch = Acquisition._default_scratch(plan)
+    # Full CIM materialised locally via the reference wrapper (production is tiled).
+    cim = zeros(ComplexF32, plan.num_coherently_integrated_code_periods * plan.num_blocks, plan.samples_per_code)
     num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks  # 640
 
     code_phase = 100.0
@@ -283,7 +285,7 @@ end
         plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+    Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
         scratch.corr_buf, plan.double_block_bfft_plan)
 
@@ -291,7 +293,7 @@ end
     noncoherent_integration_buf = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
     patterns = Acquisition.sign_patterns(nothing, 0, plan.num_data_bits, 1, plan.num_coherently_integrated_code_periods, false)
-    Acquisition._sign_search_step!(noncoherent_integration_buf, scratch.coherent_integration_matrix, scratch.col_buf,
+    Acquisition._sign_search_step!(noncoherent_integration_buf, cim, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code, num_doppler_bins, plan.num_data_bits, 0, sub_block_ffts, patterns)
     noncoherent_integration_matrix .+= noncoherent_integration_buf
 
@@ -323,6 +325,8 @@ end
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 10_000Hz, num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 1, num_noncoherent_accumulations = 1)
     scratch = Acquisition._default_scratch(plan)
+    # Full CIM materialised locally via the reference wrapper (production is tiled).
+    cim = zeros(ComplexF32, plan.num_coherently_integrated_code_periods * plan.num_blocks, plan.samples_per_code)
     num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks  # 640
 
     # Generate a clean signal, then negate the second half to simulate a bit
@@ -341,19 +345,19 @@ end
         plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
+    Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts, plan.prn_conj_ffts[prn],
         plan.samples_per_code, plan.num_blocks, plan.block_size, plan.num_coherently_integrated_code_periods,
         scratch.corr_buf, plan.double_block_bfft_plan)
 
     noncoherent_integration_data = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
     patterns = Acquisition.sign_patterns(nothing, 0, plan.num_data_bits, 1, plan.num_coherently_integrated_code_periods, false)
-    Acquisition._sign_search_step!(noncoherent_integration_data, scratch.coherent_integration_matrix, scratch.col_buf,
+    Acquisition._sign_search_step!(noncoherent_integration_data, cim, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code, num_doppler_bins, plan.num_data_bits, 0, sub_block_ffts, patterns)
 
     # Pilot path: no bit search → the two halves cancel → weaker peak
     noncoherent_integration_pilot = zeros(Float32, num_doppler_bins, plan.samples_per_code)
-    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_pilot, scratch.coherent_integration_matrix, scratch.col_buf,
+    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_pilot, cim, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
 
     # Data bit search should recover a much stronger peak than naive pilot
@@ -528,6 +532,8 @@ end
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 10_000Hz, num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 1, num_noncoherent_accumulations = 1)
     scratch = Acquisition._default_scratch(plan)
+    # Full CIM materialised locally via the reference wrapper (production is tiled).
+    cim = zeros(ComplexF32, plan.num_coherently_integrated_code_periods * plan.num_blocks, plan.samples_per_code)
     num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks
 
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
@@ -536,12 +542,12 @@ end
         plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts,
+    Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.corr_buf,
         plan.double_block_bfft_plan)
     noncoherent_integration_no_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
-    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_no_transition, scratch.coherent_integration_matrix, scratch.col_buf,
+    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_no_transition, cim, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
     peak_no_transition = maximum(noncoherent_integration_no_transition)
 
@@ -549,13 +555,13 @@ end
         plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts,
+    Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.corr_buf,
         plan.double_block_bfft_plan)
     noncoherent_integration_with_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     patterns = Acquisition.sign_patterns(nothing, 0, plan.num_data_bits, 1, plan.num_coherently_integrated_code_periods, false)
-    Acquisition._sign_search_step!(noncoherent_integration_with_transition, scratch.coherent_integration_matrix, scratch.col_buf, plan.col_fft_plan, plan.samples_per_code, num_doppler_bins,
+    Acquisition._sign_search_step!(noncoherent_integration_with_transition, cim, scratch.col_buf, plan.col_fft_plan, plan.samples_per_code, num_doppler_bins,
         plan.num_data_bits, 0, sub_block_ffts, patterns)
     peak_with_transition = maximum(noncoherent_integration_with_transition)
 
@@ -577,6 +583,8 @@ end
     plan = plan_acquire(system, sampling_freq, [prn];
         min_doppler_coverage = 10_000Hz, num_coherently_integrated_code_periods = 60, bit_edge_search_steps = 1, num_noncoherent_accumulations = 1)
     scratch = Acquisition._default_scratch(plan)
+    # Full CIM materialised locally via the reference wrapper (production is tiled).
+    cim = zeros(ComplexF32, plan.num_coherently_integrated_code_periods * plan.num_blocks, plan.samples_per_code)
     num_doppler_bins = plan.num_coherently_integrated_code_periods * plan.num_blocks
 
     sub_block_ffts = zeros(ComplexF32, num_doppler_bins, plan.num_data_bits)
@@ -585,12 +593,12 @@ end
         plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts,
+    Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.corr_buf,
         plan.double_block_bfft_plan)
     noncoherent_integration_no_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
-    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_no_transition, scratch.coherent_integration_matrix, scratch.col_buf,
+    Acquisition._accumulate_noncoherent_integration_pilot!(noncoherent_integration_no_transition, cim, scratch.col_buf,
         plan.col_fft_plan, plan.samples_per_code)
     peak_no_transition = maximum(noncoherent_integration_no_transition)
 
@@ -598,13 +606,13 @@ end
         plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
         plan.double_block_fft_plan)
-    Acquisition._build_coherent_integration_matrix!(scratch.coherent_integration_matrix, plan.signal_block_ffts,
+    Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts,
         plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks, plan.block_size,
         plan.num_coherently_integrated_code_periods, scratch.corr_buf,
         plan.double_block_bfft_plan)
     noncoherent_integration_with_transition = zeros(Float32, num_doppler_bins, plan.samples_per_code)
     patterns = Acquisition.sign_patterns(nothing, 0, plan.num_data_bits, 1, plan.num_coherently_integrated_code_periods, false)
-    Acquisition._sign_search_step!(noncoherent_integration_with_transition, scratch.coherent_integration_matrix, scratch.col_buf, plan.col_fft_plan, plan.samples_per_code, num_doppler_bins,
+    Acquisition._sign_search_step!(noncoherent_integration_with_transition, cim, scratch.col_buf, plan.col_fft_plan, plan.samples_per_code, num_doppler_bins,
         plan.num_data_bits, 0, sub_block_ffts, patterns)
     peak_with_transition = maximum(noncoherent_integration_with_transition)
 

--- a/test/noncoherent_integration.jl
+++ b/test/noncoherent_integration.jl
@@ -654,18 +654,20 @@ end
                 doppler = 1300Hz, code_phase = 210.7,
                 sampling_freq = plan.sampling_freq, interm_freq = 0.0Hz, CN0 = 45, seed = 11)
             plan.sig_buf .= ComplexF32.(signal)
-            Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, plan.sig_buf,
+            # One segment's slice of the plan's all-segment signal-FFT cache.
+            seg_ffts = Acquisition._signal_block_ffts_for_step(plan, 1)
+            Acquisition._precompute_signal_block_ffts!(seg_ffts, plan.sig_buf,
                 plan.samples_per_code, plan.num_blocks, plan.block_size,
                 plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
                 plan.double_block_fft_plan)
 
             # Production: tiled driver.
             nim_tiled = zeros(Float32, ndop, plan.samples_per_code_eff)
-            Acquisition._accumulate_prn_step_tiled!(nim_tiled, plan, scratch, prn, step_idx)
+            Acquisition._accumulate_prn_step_tiled!(nim_tiled, seg_ffts, plan, scratch, prn, step_idx)
 
             # Reference: full CIM + materialised dispatcher.
             cim = zeros(ComplexF32, ndop, plan.samples_per_code)
-            Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts,
+            Acquisition._build_coherent_integration_matrix!(cim, seg_ffts,
                 plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks,
                 plan.block_size, plan.num_coherently_integrated_code_periods,
                 scratch.corr_buf, plan.double_block_bfft_plan)

--- a/test/noncoherent_integration.jl
+++ b/test/noncoherent_integration.jl
@@ -618,3 +618,68 @@ end
 
     @test peak_with_transition ≈ peak_no_transition rtol = 0.1
 end
+
+@testset "Tiled production pipeline matches materialised reference dispatcher (N_nc>1)" begin
+    # The production multistep driver `_accumulate_prn_step_tiled!` builds one
+    # column-block tile at a time and folds code drift into the destination
+    # scatter; `_accumulate_noncoherent_integration_step!` is the retained
+    # reference that materialises the full coherent matrix and runs the
+    # historical kernel → `_apply_code_drift!` → max/accumulate pipeline. Both
+    # must produce the same per-PRN accumulation matrix on every path.
+    prn = 1
+    cases = [
+        # (label, plan, accumulation_step_index)
+        # Simple path with non-zero drift (plan_b geometry from the
+        # _fill_code_drift_shifts! testset: drift rounds non-zero at step 7).
+        ("pilot+drift", plan_acquire(GPSL1CA(), 2.048e6Hz, [prn];
+            min_doppler_coverage = 12_000Hz,
+            num_coherently_integrated_code_periods = 20,
+            num_noncoherent_accumulations = 8, fft_flag = FFTW.ESTIMATE), 7),
+        # Secondary-code rotation search with drift (L5I NH10).
+        ("rotation+drift", plan_acquire(GPSL5I(), 10.24e6Hz, [prn];
+            num_coherently_integrated_code_periods = 10,
+            num_noncoherent_accumulations = 4, fft_flag = FFTW.ESTIMATE), 3),
+        # Data-bit + bit-edge search (max across alignments), no drift at step 0.
+        ("bitedge", plan_acquire(GPSL1CA(), 2.048e6Hz, [prn];
+            min_doppler_coverage = 10_000Hz,
+            num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 4,
+            num_noncoherent_accumulations = 2, fft_flag = FFTW.ESTIMATE), 0),
+    ]
+    for (label, plan, step_idx) in cases
+        @testset "$label" begin
+            scratch = Acquisition._default_scratch(plan)
+            ndop = length(plan.doppler_freqs)
+            (; signal) = generate_test_signal(plan.system, prn;
+                num_samples = plan.num_coherently_integrated_code_periods * plan.samples_per_code,
+                doppler = 1300Hz, code_phase = 210.7,
+                sampling_freq = plan.sampling_freq, interm_freq = 0.0Hz, CN0 = 45, seed = 11)
+            plan.sig_buf .= ComplexF32.(signal)
+            Acquisition._precompute_signal_block_ffts!(plan.signal_block_ffts, plan.sig_buf,
+                plan.samples_per_code, plan.num_blocks, plan.block_size,
+                plan.num_coherently_integrated_code_periods, scratch.double_block_buf,
+                plan.double_block_fft_plan)
+
+            # Production: tiled driver.
+            nim_tiled = zeros(Float32, ndop, plan.samples_per_code_eff)
+            Acquisition._accumulate_prn_step_tiled!(nim_tiled, plan, scratch, prn, step_idx)
+
+            # Reference: full CIM + materialised dispatcher.
+            cim = zeros(ComplexF32, ndop, plan.samples_per_code)
+            Acquisition._build_coherent_integration_matrix!(cim, plan.signal_block_ffts,
+                plan.prn_conj_ffts[prn], plan.samples_per_code, plan.num_blocks,
+                plan.block_size, plan.num_coherently_integrated_code_periods,
+                scratch.corr_buf, plan.double_block_bfft_plan)
+            nim_ref = zeros(Float32, ndop, plan.samples_per_code_eff)
+            Acquisition._accumulate_noncoherent_integration_step!(nim_ref, cim, plan,
+                scratch, prn, step_idx)
+
+            @test nim_tiled ≈ nim_ref
+            # Sanity: drift really fires where intended so the fold is exercised.
+            if step_idx > 0
+                shifts = zeros(Int, ndop)
+                @test Acquisition._fill_code_drift_shifts!(shifts, plan, step_idx) ==
+                    (label != "bitedge")
+            end
+        end
+    end
+end

--- a/test/plan.jl
+++ b/test/plan.jl
@@ -245,21 +245,26 @@ end
     plan = plan_acquire(GPSL1CA(), 2.048e6Hz, [1];
         num_coherently_integrated_code_periods = 1)
     duplicated_fields = (
-        :coherent_integration_matrix,
-        :sign_search_max_buf,
-        :noncoherent_integration_buf,
+        :coherent_tile,
+        :stage_buf,
         :sub_block_ffts,
         :col_buf,
-        :row_buf,
-        :row_shift_buf,
+        :row_sums_buf,
+        :col_power_buf,
         :double_block_buf,
         :corr_buf,
-        :sig_buf,
         :col_sums_buf,
+        :code_drift_shifts,
     )
     for f in duplicated_fields
         @test !hasfield(typeof(plan), f)
     end
+
+    # `sig_buf` deliberately lives ON the plan as a single instance: it is
+    # filled before the per-PRN parallel loop, so a per-thread copy would be
+    # pure waste ((nthreads-1) × segment_length × 8 bytes).
+    @test hasfield(typeof(plan), :sig_buf)
+    @test !hasfield(Acquisition.AcquisitionScratch, :sig_buf)
 
     # _default_scratch names the "thread 1 is the ambient scratch" convention.
     scratch = Acquisition._default_scratch(plan)
@@ -268,6 +273,53 @@ end
     for f in duplicated_fields
         @test hasfield(typeof(scratch), f)
     end
+end
+
+@testset "per-thread scratch never scales with samples_per_code (tiled pipeline)" begin
+    # THE memory guarantee of the tiled pipeline: no per-thread buffer is
+    # proportional to samples_per_code (or samples_per_code_eff). The largest
+    # scratch member is the (num_doppler_bins × block_size) coherent tile —
+    # num_blocks× smaller than the coherent matrix it replaced. With N threads
+    # the old layout multiplied full surfaces by N; this lock keeps that from
+    # coming back.
+    cases = [
+        # simple/pilot, N_nc = 1 (dominant wide-search config)
+        plan_acquire(GPSL1CA(), 5e6Hz, [1]),
+        # multistep simple
+        plan_acquire(GPSL1CA(), 5e6Hz, [1]; num_noncoherent_accumulations = 4),
+        # data-bit + bit-edge search
+        plan_acquire(GPSL1CA(), 2.048e6Hz, [1];
+            min_doppler_coverage = 10_000Hz,
+            num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 4),
+        # secondary-code rotation search (L5I NH10)
+        plan_acquire(GPSL5I(), 10.24e6Hz, [1];
+            num_coherently_integrated_code_periods = 10),
+    ]
+    for plan in cases
+        ndop = length(plan.doppler_freqs)
+        for scratch in plan.thread_scratch
+            @test size(scratch.coherent_tile) == (ndop, plan.block_size)
+            # Nothing else may exceed the tile's column count except the
+            # 1-D col_sums (multistep extraction needs per-column sums).
+            @test size(scratch.stage_buf, 2) <= plan.num_secondary_rotations
+            @test size(scratch.sub_block_ffts, 2) <=
+                max(plan.num_data_bits, plan.num_coherently_integrated_code_periods)
+            @test length(scratch.row_sums_buf) <= ndop
+            @test length(scratch.col_power_buf) <= ndop
+        end
+    end
+
+    # col_sums is the single spc_eff-length vector left, and only where it is
+    # actually consumed: multistep extraction or the GlobalMean estimator.
+    seq_plan = plan_acquire(GPSL1CA(), 5e6Hz, [1])
+    @test isempty(Acquisition._default_scratch(seq_plan).col_sums_buf)
+    seq_gm_plan = plan_acquire(GPSL1CA(), 5e6Hz, [1];
+        noise_estimator = GlobalMeanNoiseEstimator())
+    @test length(Acquisition._default_scratch(seq_gm_plan).col_sums_buf) ==
+        seq_gm_plan.samples_per_code_eff
+    multi_plan = plan_acquire(GPSL1CA(), 5e6Hz, [1]; num_noncoherent_accumulations = 2)
+    @test length(Acquisition._default_scratch(multi_plan).col_sums_buf) ==
+        multi_plan.samples_per_code_eff
 end
 
 @testset "result_buffers are lazy — nothing unless store_power_bins=true" begin
@@ -300,10 +352,10 @@ end
 end
 
 @testset "sign-search scratch is 0x0 when the simple path is provably taken" begin
-    # The router in _accumulate_noncoherent_integration_step! takes the simple/pilot
-    # path when num_data_bits == 1 && bit_edge_search_steps == 1. In that regime
-    # sign_search_max_buf and sub_block_ffts are never read, so the
-    # plan should allocate them as 0x0 sentinels per thread.
+    # The routers take the simple/pilot path when num_data_bits == 1 &&
+    # bit_edge_search_steps == 1 && no rotation search. In that regime
+    # stage_buf and sub_block_ffts are never read, so the plan should
+    # allocate them as 0x0 sentinels per thread.
     system = GPSL1CA()
     sampling_freq = 2.048e6Hz
 
@@ -312,77 +364,39 @@ end
     simple_scratch = Acquisition._default_scratch(simple_plan)
     @test simple_plan.num_data_bits == 1
     @test simple_plan.bit_edge_search_steps == 1
-    @test size(simple_scratch.sign_search_max_buf) == (0, 0)
+    @test size(simple_scratch.stage_buf) == (0, 0)
     @test size(simple_scratch.sub_block_ffts) == (0, 0)
     # And every pool slot matches — not just slot 1.
     for t_scratch in simple_plan.thread_scratch
-        @test size(t_scratch.sign_search_max_buf) == (0, 0)
+        @test size(t_scratch.stage_buf) == (0, 0)
         @test size(t_scratch.sub_block_ffts) == (0, 0)
     end
 
-    # Sign-search path: bit_edge_search_steps > 1 makes the kernel actually read
-    # these buffers, so they must be full-sized.
+    # Sign-search path: bit_edge_search_steps > 1 makes the kernels actually
+    # read these buffers, so they must exist — but the stage is per-COLUMN
+    # (num_doppler_bins × num_rotations), never per-surface.
     search_plan = plan_acquire(system, sampling_freq, [1];
         min_doppler_coverage = 10_000Hz,
         num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 4)
     search_scratch = Acquisition._default_scratch(search_plan)
-    expected = (length(search_plan.doppler_freqs), search_plan.samples_per_code)
-    @test size(search_scratch.sign_search_max_buf) == expected
+    @test size(search_scratch.stage_buf) ==
+        (length(search_plan.doppler_freqs), search_plan.num_secondary_rotations)
     @test size(search_scratch.sub_block_ffts) ==
         (length(search_plan.doppler_freqs), search_plan.num_data_bits)
+
+    # Rotation search: one stage column per secondary-code rotation.
+    rot_plan = plan_acquire(GPSL5I(), 10.24e6Hz, [1];
+        num_coherently_integrated_code_periods = 10)
+    @test size(Acquisition._default_scratch(rot_plan).stage_buf) ==
+        (length(rot_plan.doppler_freqs), 10)
 end
 
-@testset "noncoherent_integration_buf is 0x0 whenever the simple path runs" begin
-    # The fused FFT+|x|²+(code-drift)+fftshift kernel writes straight into the
-    # destination, so the simple/pilot path never touches `noncoherent_integration_buf`.
-    # That's true at N_nc==1 (slice 5) AND at N_nc>1 (Issue #62). Sign-search is
-    # the only remaining consumer of the buf.
-    system = GPSL1CA()
-    sampling_freq = 2.048e6Hz
-
-    fused_plan = plan_acquire(system, sampling_freq, [1];
-        num_coherently_integrated_code_periods = 1, bit_edge_search_steps = 1,
-        num_noncoherent_accumulations = 1)
-    fused_scratch = Acquisition._default_scratch(fused_plan)
-    @test size(fused_scratch.noncoherent_integration_buf) == (0, 0)
-    for t_scratch in fused_plan.thread_scratch
-        @test size(t_scratch.noncoherent_integration_buf) == (0, 0)
-    end
-
-    # Multistep (N_nc>1) simple path: the fused kernel handles code drift, so
-    # the buf is dropped here too. This is the Issue #62 regression-lock.
-    multi_simple_plan = plan_acquire(system, sampling_freq, [1];
-        num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 2)
-    multi_simple_scratch = Acquisition._default_scratch(multi_simple_plan)
-    @test multi_simple_plan.num_data_bits == 1
-    @test multi_simple_plan.bit_edge_search_steps == 1
-    @test multi_simple_plan.num_noncoherent_accumulations == 2
-    @test size(multi_simple_scratch.noncoherent_integration_buf) == (0, 0)
-    for t_scratch in multi_simple_plan.thread_scratch
-        @test size(t_scratch.noncoherent_integration_buf) == (0, 0)
-    end
-
-    # Sign-search at N_nc=1 still needs the buf.
-    sign_search_plan = plan_acquire(system, sampling_freq, [1];
-        min_doppler_coverage = 10_000Hz,
-        num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 4)
-    @test size(Acquisition._default_scratch(sign_search_plan).noncoherent_integration_buf) ==
-        (length(sign_search_plan.doppler_freqs), sign_search_plan.samples_per_code)
-
-    # Multistep sign-search needs the buf too.
-    multi_sign_plan = plan_acquire(system, sampling_freq, [1];
-        min_doppler_coverage = 10_000Hz,
-        num_coherently_integrated_code_periods = 40, bit_edge_search_steps = 4,
-        num_noncoherent_accumulations = 2)
-    @test size(Acquisition._default_scratch(multi_sign_plan).noncoherent_integration_buf) ==
-        (length(multi_sign_plan.doppler_freqs), multi_sign_plan.samples_per_code)
-end
-
-@testset "sequential N_nc=1 layout: empty per-PRN matrices, full per-thread accumulator" begin
-    # When num_noncoherent_accumulations == 1 the per-PRN noncoherent matrices
-    # collapse into a single per-thread accumulator reused across PRNs. Layout
-    # should be: empty Vector{Matrix{Float32}} on the plan, full-sized
-    # accumulator per thread.
+@testset "sequential N_nc=1 layout: no power surface exists at all" begin
+    # When num_noncoherent_accumulations == 1 every power cell is produced
+    # exactly once, so the result statistics are streamed per tile and neither
+    # the plan nor the scratch holds any noncoherent power matrix: the per-PRN
+    # vector is empty AND the per-thread accumulator of the pre-tiled layout is
+    # gone entirely (the field no longer exists).
     system = GPSL1CA()
     sampling_freq = 2.048e6Hz
     prns = collect(1:4)
@@ -391,13 +405,14 @@ end
         num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 1)
     seq_scratch = Acquisition._default_scratch(seq_plan)
     @test length(seq_plan.noncoherent_integration_matrices) == 0
-    expected = (length(seq_plan.doppler_freqs), seq_plan.samples_per_code)
-    @test size(seq_scratch.noncoherent_integration_accumulator) == expected
-    for t_scratch in seq_plan.thread_scratch
-        @test size(t_scratch.noncoherent_integration_accumulator) == expected
-    end
+    @test !hasfield(Acquisition.AcquisitionScratch, :noncoherent_integration_accumulator)
+    @test !hasfield(Acquisition.AcquisitionScratch, :noncoherent_integration_buf)
+    @test !hasfield(Acquisition.AcquisitionScratch, :sign_search_max_buf)
+    # Streaming stats live in a length-num_doppler_bins row-sum vector.
+    @test length(seq_scratch.row_sums_buf) == length(seq_plan.doppler_freqs)
 
-    # N_nc>1 path keeps the per-PRN matrices and uses no accumulator.
+    # N_nc>1 path keeps the per-PRN matrices (accumulation across segments
+    # genuinely needs the surface) and no streaming row sums.
     multi_plan = plan_acquire(system, sampling_freq, prns;
         num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 2)
     multi_scratch = Acquisition._default_scratch(multi_plan)
@@ -405,7 +420,7 @@ end
     for nim in multi_plan.noncoherent_integration_matrices
         @test size(nim) == (length(multi_plan.doppler_freqs), multi_plan.samples_per_code)
     end
-    @test size(multi_scratch.noncoherent_integration_accumulator) == (0, 0)
+    @test isempty(multi_scratch.row_sums_buf)
 end
 
 @testset "scratch pool: hard-capped, all slots built up front" begin
@@ -427,11 +442,11 @@ end
     @test length(plan.scratch_free) == cap
 
     # All slots are built up front at full geometry — none are empty placeholders.
-    expected = (length(plan.doppler_freqs), plan.samples_per_code)
-    materialised(p) = count(s -> size(s.coherent_integration_matrix, 2) > 0, p.thread_scratch)
+    expected = (length(plan.doppler_freqs), plan.block_size)
+    materialised(p) = count(s -> size(s.coherent_tile, 2) > 0, p.thread_scratch)
     @test materialised(plan) == cap
     for s in plan.thread_scratch
-        @test size(s.coherent_integration_matrix) == expected
+        @test size(s.coherent_tile) == expected
     end
 
     # Acquiring produces correct results and returns every slot to the pool.

--- a/test/plan.jl
+++ b/test/plan.jl
@@ -300,12 +300,16 @@ end
         for scratch in plan.thread_scratch
             @test size(scratch.coherent_tile) == (ndop, plan.block_size)
             # Nothing else may exceed the tile's column count except the
-            # 1-D col_sums (multistep extraction needs per-column sums).
+            # 1-D col_sums and — at N_nc>1 only — the per-slot accumulator
+            # (bounded by min(threads, cores, num_prns) slots, never per PRN).
             @test size(scratch.stage_buf, 2) <= plan.num_secondary_rotations
             @test size(scratch.sub_block_ffts, 2) <=
                 max(plan.num_data_bits, plan.num_coherently_integrated_code_periods)
             @test length(scratch.row_sums_buf) <= ndop
             @test length(scratch.col_power_buf) <= ndop
+            if plan.num_noncoherent_accumulations == 1
+                @test size(scratch.noncoherent_accumulator) == (0, 0)
+            end
         end
     end
 
@@ -391,12 +395,11 @@ end
         (length(rot_plan.doppler_freqs), 10)
 end
 
-@testset "sequential N_nc=1 layout: no power surface exists at all" begin
-    # When num_noncoherent_accumulations == 1 every power cell is produced
-    # exactly once, so the result statistics are streamed per tile and neither
-    # the plan nor the scratch holds any noncoherent power matrix: the per-PRN
-    # vector is empty AND the per-thread accumulator of the pre-tiled layout is
-    # gone entirely (the field no longer exists).
+@testset "N_nc=1 streams with no surface; N_nc>1 holds one surface per slot" begin
+    # At num_noncoherent_accumulations == 1 every power cell is produced
+    # exactly once, so the result statistics are streamed per tile and NO
+    # noncoherent power matrix exists anywhere — neither per PRN (that plan
+    # field is gone) nor per thread.
     system = GPSL1CA()
     sampling_freq = 2.048e6Hz
     prns = collect(1:4)
@@ -404,23 +407,30 @@ end
     seq_plan = plan_acquire(system, sampling_freq, prns;
         num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 1)
     seq_scratch = Acquisition._default_scratch(seq_plan)
-    @test length(seq_plan.noncoherent_integration_matrices) == 0
-    @test !hasfield(Acquisition.AcquisitionScratch, :noncoherent_integration_accumulator)
+    @test !hasfield(typeof(seq_plan), :noncoherent_integration_matrices)
     @test !hasfield(Acquisition.AcquisitionScratch, :noncoherent_integration_buf)
     @test !hasfield(Acquisition.AcquisitionScratch, :sign_search_max_buf)
+    @test size(seq_scratch.noncoherent_accumulator) == (0, 0)
     # Streaming stats live in a length-num_doppler_bins row-sum vector.
     @test length(seq_scratch.row_sums_buf) == length(seq_plan.doppler_freqs)
 
-    # N_nc>1 path keeps the per-PRN matrices (accumulation across segments
-    # genuinely needs the surface) and no streaming row sums.
+    # N_nc>1: accumulation across segments genuinely needs a surface, but the
+    # PRN-outer loop bounds it at ONE per scratch slot — min(threads, cores,
+    # num_prns) surfaces total, never one per PRN — and no streaming row sums.
     multi_plan = plan_acquire(system, sampling_freq, prns;
         num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 2)
     multi_scratch = Acquisition._default_scratch(multi_plan)
-    @test length(multi_plan.noncoherent_integration_matrices) == length(prns)
-    for nim in multi_plan.noncoherent_integration_matrices
-        @test size(nim) == (length(multi_plan.doppler_freqs), multi_plan.samples_per_code)
+    @test length(multi_plan.thread_scratch) <= length(prns)
+    for t_scratch in multi_plan.thread_scratch
+        @test size(t_scratch.noncoherent_accumulator) ==
+            (length(multi_plan.doppler_freqs), multi_plan.samples_per_code_eff)
     end
     @test isempty(multi_scratch.row_sums_buf)
+    # The all-segment signal-FFT cache is the multistep trade: 16 bytes per
+    # signal sample (2x the ComplexF32 signal), read-only shared across PRNs.
+    @test size(multi_plan.signal_block_ffts, 2) ==
+        multi_plan.num_noncoherent_accumulations *
+        multi_plan.num_coherently_integrated_code_periods * multi_plan.num_blocks
 end
 
 @testset "scratch pool: hard-capped, all slots built up front" begin
@@ -435,7 +445,7 @@ end
 
     plan = plan_acquire(system, sampling_freq, prns;
         num_coherently_integrated_code_periods = 1, num_noncoherent_accumulations = 1)
-    cap = min(Threads.nthreads(), max(1, Int(Acquisition.num_cores())))
+    cap = min(Threads.nthreads(), max(1, Int(Acquisition.num_cores())), length(prns))
 
     # Pool is sized to the cap; all slots are free initially.
     @test length(plan.thread_scratch) == cap

--- a/test/secondary_code_search.jl
+++ b/test/secondary_code_search.jl
@@ -121,7 +121,13 @@ end
         @test sum(nim)       ≈ 5.2553412608f10 rtol = 1e-4
         @test nim[1, 100]    ≈ 8.2944015625f4  rtol = 1e-4
         @test nim[end, end]  ≈ 2.318815625f4   rtol = 1e-4
-        @test argmax(nim)    == CartesianIndex(17, 1)
+        # The NH10 signs make the opt-out's naive coherent sum sign-modulated,
+        # so its Doppler spectrum is symmetric about 0 Hz: rows 17 and 25
+        # (∓400 Hz) carry an EXACT mirror-pair peak (equal in Float32). Which
+        # one argmax returns is decided by FFT last-bit noise and differs
+        # across FFTW builds/platforms — accept either, and pin the tie itself.
+        @test argmax(nim) in (CartesianIndex(17, 1), CartesianIndex(25, 1))
+        @test nim[17, 1] ≈ nim[25, 1] rtol = 1e-3
     end
 
     @testset "L5I gain recovery — use_secondary_code=true recovers ~10× peak over the opt-out" begin


### PR DESCRIPTION
## Summary

The FM-DBZP pipeline used to materialise two full `(num_doppler_bins × samples_per_code_eff)` matrices **per thread** — the ComplexF32 coherent-integration matrix and the Float32 power accumulator (plus two more full-size buffers on the sign-search paths). With multiple threads the plan footprint multiplied accordingly: ~1.2 GiB for the L5I rotation search and ~2.6 GiB for L1C-P/16 MHz at 8 threads.

Every consumer after the coherent build is strictly **column-oriented**, so the full surface never needs to exist. This PR tiles the pipeline — build one `(num_doppler_bins × block_size)` column-block tile, reduce it immediately, move on — and streams the reduction:

- **At `num_noncoherent_accumulations == 1`** (the default), the result statistics (global peak, per-row power sums for the OppositeRow noise estimate, per-column sums for GlobalMean) are reduced on the fly. **No power surface exists at all.** The full Doppler × code-phase matrix is materialised only when the user asks for it (`store_power_bins = true`), directly into the cached per-PRN result buffer.
- **At `N_nc > 1`**, the PRN loop runs **PRN-outer**: each parallel chunk carries one PRN through all accumulation steps against its scratch slot's accumulator, so `min(threads, cores, #PRNs)` accumulation surfaces replace the former one-per-PRN matrices (32-PRN L5I rotation dwell at N_nc=4: 2 220 → 578 MiB at 8 threads, 2 210 → 87 MiB single-threaded). The signal-block FFT cache spans all N_nc segments (16 B per signal sample, precomputed serially exactly as before — zero recompute, and the per-step thread barriers disappear; multistep per-call allocations drop 7.7×). The per-thread CIM and the full-size sign-search buffers are gone; code drift is folded into the per-column destination scatter.
- Sign-search / secondary-code-rotation kernels are restructured into per-column primitives with a `(num_doppler_bins × L)` staging column; the SIMD inner loops are unchanged. Bit-edge alignments and data-bit polarities max-reduce column-locally.
- `sig_buf` moves out of the per-thread pool onto the plan (it is filled before the parallel loop; only one instance is ever used).
- Subsample interpolation without `store_power_bins` recomputes the up-to-three peak-neighbour columns on demand (~`1/block_size` of one PRN pass, once per PRN).

Per-thread scratch no longer contains **any** buffer that scales with `samples_per_code`; the largest member is the tile, `num_blocks`× smaller than the old coherent matrix. Adding threads now adds tile-sized scratch only.

## Memory (plan_acquire, `@allocated`)

| Case | master, 8 threads | this PR, 8 threads | master, 1 thread | this PR, 1 thread |
|---|---|---|---|---|
| L1CA 5 MHz, 32 PRNs | 14.1 MiB | **3.8 MiB** | 5.3 MiB | **3.4 MiB** |
| L1CA 5 MHz, N_nc=8 | 9.7 MiB | **2.6 MiB** | 3.6 MiB | **2.2 MiB** |
| L5I 12 MHz, N_coh=10 (rotation) | 1 237 MiB | **12.6 MiB** | 169 MiB | **5.9 MiB** |
| L1C-P 16 MHz | 2 579 MiB | **27.2 MiB** | 506 MiB | **18.5 MiB** |
| L1CA 2 MHz, N_coh=40, bit-edge=4 | 207 MiB | **7.1 MiB** | 27 MiB | **2.6 MiB** |

## Speed (min of 15 runs, `acquire!` on planted PRN 1)

| Case | master 8t | PR 8t | master 1t | PR 1t |
|---|---|---|---|---|
| L1CA 5 MHz, 32 PRNs | 4 ms | 4 ms | 24 ms | **14 ms** |
| L1CA 5 MHz, N_nc=8 | 5 ms | 5 ms | 14 ms | 13 ms |
| L5I 12 MHz, N_coh=10 | 195 ms | **107 ms** | 522 ms | **329 ms** |
| L1C-P 16 MHz | 478 ms | **211 ms** | 1 081 ms | **673 ms** |
| L1CA N_coh=40, bit-edge=4 | 56 ms | **46 ms** | 37 ms | **30 ms** |

The tile stays L2-resident, so the column FFTs and the reduction read hot data instead of streaming multi-hundred-MiB surfaces through DRAM — that's where the large-case speedups come from. Per-`acquire!` heap allocation is unchanged (0 bytes single-threaded at N_nc=1).

## Correctness

- Power surfaces (`store_power_bins`) are **bit-identical** to the previous kernels on all paths (simple, data-bit, rotation; verified against the retained full-matrix reference wrappers).
- Peak location, CN0, detection, and secondary-code phase are identical. The OppositeRow noise estimate agrees to Float32 rounding (the old `_row_mean` summed with `@simd` reassociation; the streaming sum is strictly sequential — relative difference ~1e-5).
- The full test suite passes single- and multi-threaded.
- Kernel-level tests keep their parity checks: the old full-matrix kernels remain as thin reference wrappers that delegate to the per-column primitives.

## Notes for review

- `test/plan.jl`'s scratch-layout regression locks are rewritten to lock the *new* invariant: no per-thread buffer proportional to `samples_per_code`, no power surface at N_nc=1.
- The multistep pilot drift kernels are untouched, including their raw-bin/sorted-row indexing convention (see the parity-test comment in `test/noncoherent_integration.jl`) — flagging while I was in there: that convention looks like a preserved historical quirk (drift shift for raw bin `r` is computed from `doppler_freqs[r]`, i.e. the sorted row of the same index, not `doppler_freqs[perm[r]]`). Deliberately not changed here — tracked in #74.
- `BatchFFTCrossover` (opt-in) now benchmarks tile-shaped batches; `BATCH_FFT_THRESHOLD = 320` was kept and can be re-tuned on the new shape if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
